### PR TITLE
Refactor/unify split tables for rag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ The application follows a 4-step pipeline for natural language MLB queries:
 3. **BigQuery Data Retrieval**
    - Executes generated SQL against MLB statistics tables in GCP project `tksm-dash-test-25`
    - Main tables: `fact_batting_stats_with_risp`, `fact_pitching_stats`
-   - Specialized tables for splits: `tbl_batter_clutch_*`, `tbl_batter_inning_stats`, etc.
+   - Specialized tables for splits: `tbl_batter_clutch_*`, `mart_batter_inning_stats`, etc.
 
 4. **LLM Response Generation** (`ai_service._generate_final_response_with_llm`)
    - Converts structured data back to natural Japanese responses

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The application follows a sophisticated 4-step pipeline:
 3. **📊 BigQuery Data Retrieval**
    - Executes generated SQL against MLB statistics tables in GCP project `your-project-id`
    - Main tables: `fact_batting_stats_with_risp`, `fact_pitching_stats`
-   - Specialized tables for splits: `tbl_batter_clutch_*`, `tbl_batter_inning_stats`, etc.
+   - Specialized tables for splits: `tbl_batter_clutch_*`, `mart_batter_inning_stats`, etc.
 
 4. **💬 LLM Response Generation** (`ai_service._generate_final_response_with_llm`)
    - Converts structured data back to natural Japanese responses

--- a/README_JP.md
+++ b/README_JP.md
@@ -131,7 +131,7 @@
 3. **📊 BigQueryデータ取得**
    - GCPプロジェクト `project-id` のMLB統計テーブルに対して生成されたSQLを実行
    - メインテーブル：`fact_batting_stats_with_risp`、`fact_pitching_stats`
-   - スプリット専用テーブル：`tbl_batter_clutch_*`、`tbl_batter_inning_stats`など
+   - スプリット専用テーブル：`tbl_batter_clutch_*`、`mart_batter_inning_stats`など
 
 4. **💬 LLMレスポンス生成** (`ai_service._generate_final_response_with_llm`)
    - 構造化データを自然な日本語レスポンスに変換

--- a/backend/app/config/query_maps.py
+++ b/backend/app/config/query_maps.py
@@ -20,22 +20,28 @@ QUERY_TYPE_CONFIG = {
     },
     "batting_splits": {
         "risp": {
-            "table_id": "tbl_batter_clutch_risp",
+            "table_id": "mart_batter_clutch",
             "year_col": "game_year",
             "player_col": "batter_name",
-            "available_metrics": ["ab_at_risp", "avg_at_risp", "obp_at_risp", "slg_at_risp", "homeruns_at_risp"]
+            "filter_col": "situation_type",
+            "filter_val": "risp",
+            "available_metrics": ["ab", "avg", "obp", "slg", "homeruns"]
         },
         "bases_loaded": {
-            "table_id": "tbl_batter_clutch_bases_loaded",
+            "table_id": "mart_batter_clutch",
             "year_col": "game_year",
             "player_col": "batter_name",
-            "available_metrics": ["ab_at_bases_loaded", "avg_at_bases_loaded", "obp_at_bases_loaded", "slg_at_bases_loaded", "grandslam"]
+            "filter_col": "situation_type",
+            "filter_val": "bases_loaded",
+            "available_metrics": ["ab", "avg", "obp", "slg", "homeruns"]
         },
         "runner_on_1b": {
-            "table_id": "tbl_batter_clutch_runner_on_1b",
+            "table_id": "mart_batter_clutch",
             "year_col": "game_year",
             "player_col": "batter_name",
-            "available_metrics": ["ab_at_runner_on_1b", "avg_at_runner_on_1b", "obp_at_runner_on_1b", "slg_at_runner_on_1b", "homeruns_at_runner_on_1b"]
+            "filter_col": "situation_type",
+            "filter_val": "runner_on_1b",
+            "available_metrics": ["ab", "avg", "obp", "slg", "homeruns"]
         },
         "inning": {
             "table_id": "tbl_batter_inning_stats",
@@ -148,14 +154,14 @@ DECIMAL_FORMAT_COLUMNS = [
     'avg', 'obp', 'slg', 'ops', 'batting_average', 'on_base_percentage', 
     'slugging_percentage', 'on_base_plus_slugging',
     
-    # RISP stats
-    'avg_at_risp', 'obp_at_risp', 'slg_at_risp', 'ops_at_risp',
+    # # RISP stats
+    # 'avg', 'obp', 'slg', 'ops',
     
-    # Bases loaded stats
-    'avg_at_bases_loaded', 'obp_at_bases_loaded', 'slg_at_bases_loaded', 'ops_at_bases_loaded',
+    # # Bases loaded stats
+    # 'avg', 'obp', 'slg', 'ops',
     
-    # Runner on 1B stats
-    'avg_at_runner_on_1b', 'obp_at_runner_on_1b', 'slg_at_runner_on_1b', 'ops_at_runner_on_1b',
+    # # Runner on 1B stats
+    # 'avg', 'obp', 'slg', 'ops',
     
     # Inning stats
     'avg_by_inning', 'obp_by_inning', 'slg_by_inning', 'ops_by_inning',
@@ -195,9 +201,9 @@ METRIC_MAP = {
             "risp": "career_homeruns_at_risp",
             "bases_loaded": "career_grandslam_at_bases_loaded"
         },
-        "batting_splits_risp": "homeruns_at_risp",
-        "batting_splits_bases_loaded": "grandslam",
-        "batting_splits_runner_on_1b": "homeruns_at_runner_on_1b",
+        "batting_splits_risp": "homeruns",
+        "batting_splits_bases_loaded": "homeruns",
+        "batting_splits_runner_on_1b": "homeruns",
         "batting_splits_inning": "homeruns_by_inning",
         "batting_splits_pitcher_throws": "homeruns_by_p_throws",
         "batting_splits_pitch_type": "homeruns_by_pitch_type",
@@ -215,9 +221,9 @@ METRIC_MAP = {
             "risp": "career_avg_at_risp",
             "bases_loaded": "career_avg_at_bases_loaded"
         },
-        "batting_splits_risp": "avg_at_risp",
-        "batting_splits_bases_loaded": "avg_at_bases_loaded",
-        "batting_splits_runner_on_1b": "avg_at_runner_on_1b",
+        "batting_splits_risp": "avg",
+        "batting_splits_bases_loaded": "avg",
+        "batting_splits_runner_on_1b": "avg",
         "batting_splits_inning": "avg_by_inning",
         "batting_splits_pitcher_throws": "avg_by_p_throws",
         "batting_splits_pitch_type": "avg_by_pitch_type",
@@ -234,9 +240,9 @@ METRIC_MAP = {
             "risp": "career_obp_at_risp",
             "bases_loaded": "career_obp_at_bases_loaded"
         },
-        "batting_splits_risp": "obp_at_risp",
-        "batting_splits_bases_loaded": "obp_at_bases_loaded",
-        "batting_splits_runner_on_1b": "obp_at_runner_on_1b",
+        "batting_splits_risp": "obp",
+        "batting_splits_bases_loaded": "obp",
+        "batting_splits_runner_on_1b": "obp",
         "batting_splits_inning": "obp_by_inning",
         "batting_splits_pitcher_throws": "obp_by_p_throws",
         "batting_splits_pitch_type": "obp_by_pitch_type",
@@ -254,9 +260,9 @@ METRIC_MAP = {
             "risp": "career_slg_at_risp",
             "bases_loaded": "career_slg_at_bases_loaded"
         },
-        "batting_splits_risp": "slg_at_risp",
-        "batting_splits_bases_loaded": "slg_at_bases_loaded",
-        "batting_splits_runner_on_1b": "slg_at_runner_on_1b",
+        "batting_splits_risp": "slg",
+        "batting_splits_bases_loaded": "slg",
+        "batting_splits_runner_on_1b": "slg",
         "batting_splits_inning": "slg_by_inning",
         "batting_splits_pitcher_throws": "slg_by_p_throws",
         "batting_splits_pitch_type": "slg_by_pitch_type",
@@ -274,9 +280,9 @@ METRIC_MAP = {
             "risp": "career_ops_at_risp",
             "bases_loaded": "career_ops_at_bases_loaded"
         },
-        "batting_splits_risp": "ops_at_risp",
-        "batting_splits_bases_loaded": "ops_at_bases_loaded",
-        "batting_splits_runner_on_1b": "ops_at_runner_on_1b",
+        "batting_splits_risp": "ops",
+        "batting_splits_bases_loaded": "ops",
+        "batting_splits_runner_on_1b": "ops",
         "batting_splits_inning": "ops_by_inning",
         "batting_splits_pitcher_throws": "ops_by_p_throws",
         "batting_splits_pitch_type": "ops_by_pitch_type",
@@ -294,9 +300,9 @@ METRIC_MAP = {
             "risp": "career_ab_at_risp",
             "bases_loaded": "career_ab_at_bases_loaded"
         },
-        "batting_splits_risp": "ab_at_risp",
-        "batting_splits_bases_loaded": "ab_at_bases_loaded",
-        "batting_splits_runner_on_1b": "ab_at_runner_on_1b",
+        "batting_splits_risp": "ab",
+        "batting_splits_bases_loaded": "ab",
+        "batting_splits_runner_on_1b": "ab",
         "batting_splits_inning": "ab_by_inning",
         "batting_splits_pitcher_throws": "ab_by_p_throws",
         "batting_splits_pitch_type": "ab_by_pitch_type",
@@ -334,9 +340,9 @@ METRIC_MAP = {
             "risp": "career_so_at_risp",
             "bases_loaded": "career_so_at_bases_loaded"
         },
-        "batting_splits_risp": "so_at_risp",
-        "batting_splits_bases_loaded": "so_at_bases_loaded",
-        "batting_splits_runner_on_1b": "so_at_runner_on_1b",
+        "batting_splits_risp": "so",
+        "batting_splits_bases_loaded": "so",
+        "batting_splits_runner_on_1b": "so",
         "batting_splits_inning": "so_by_inning",
         "batting_splits_pitcher_throws": "so_by_p_throws",
         "batting_splits_pitch_type": "so_by_pitch_type",

--- a/backend/app/config/query_maps.py
+++ b/backend/app/config/query_maps.py
@@ -44,43 +44,43 @@ QUERY_TYPE_CONFIG = {
             "available_metrics": ["ab", "avg", "obp", "slg", "homeruns"]
         },
         "inning": {
-            "table_id": "tbl_batter_inning_stats",
+            "table_id": "mart_batter_inning_stats",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_inning", "avg_by_inning", "obp_by_inning", "slg_by_inning", "homeruns_by_inning", "ops_by_inning"]
         },
         "pitcher_throws": {
-            "table_id": "tbl_batter_pitcher_throws_stats",
+            "table_id": "mart_batter_pitcher_throws",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_p_throws", "avg_by_p_throws", "obp_by_p_throws", "slg_by_p_throws", "homeruns_by_p_throws", "ops_by_p_throws"]
         },
         "pitch_type": {
-            "table_id": "tbl_batter_pitch_type_stats",
+            "table_id": "mart_batter_pitch_type",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_pitch_type", "avg_by_pitch_type", "obp_by_pitch_type", "slg_by_pitch_type", "homeruns_by_pitch_type", "ops_by_pitch_type"]
         },
         "pitch_count": {
-            "table_id": "tbl_batter_pitch_count_stats",
+            "table_id": "mart_batter_pitch_count",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_pitch_count", "avg_by_pitch_count", "obp_by_pitch_count", "slg_by_pitch_count", "homeruns_by_pitch_count", "ops_by_pitch_count"]
         },
         "pitch_speed": {
-            "table_id": "tbl_batter_pitch_speed_stats",
+            "table_id": "mart_batter_pitch_speed",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_release_speed", "avg_by_release_speed", "obp_by_release_speed", "slg_by_release_speed", "homeruns_by_release_speed", "ops_by_release_speed"]
         },
         "game_score_situation": {
-            "table_id": "tbl_batter_game_score_situations_stats",
+            "table_id": "mart_batter_game_score_situations",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_game_score_situation", "avg_by_game_score_situation", "obp_by_game_score_situation", "slg_by_game_score_situation", "homeruns_by_game_score_situation", "ops_by_game_score_situation"]
         },
         "zone": {
-            "table_id": "tbl_batter_zone_stats",
+            "table_id": "mart_batter_zone",
             "year_col": "game_year",
             "player_col": "batter_name",
             "available_metrics": ["ab_by_zone", "avg_by_zone", "obp_by_zone", "slg_by_zone", "homeruns_by_zone", "ops_by_zone"]

--- a/backend/app/services/analytics/base_engine.py
+++ b/backend/app/services/analytics/base_engine.py
@@ -545,6 +545,10 @@ class BaseEngine:
         if params.get("season"):
             where_conditions.append(f"{year_column} = @season")
             query_parameters["season"] = params["season"]
+        
+        if config.get("filter_col") and config.get("filter_val"):
+            where_conditions.append(f"{config['filter_col']} = @filter_val")
+            query_parameters["filter_val"] = config["filter_val"]
 
         if params.get("inning") is not None and split_type == "inning":
             where_conditions.append(f"inning = @inning")

--- a/backend/app/services/mlb_data_engine.py
+++ b/backend/app/services/mlb_data_engine.py
@@ -648,6 +648,10 @@ class MLBDataEngine:
         if params.get("season"):
             where_conditions.append(f"{year_column} = @season")
             query_parameters["season"] = params["season"]
+        
+        if config.get("filter_col") and config.get("filter_val"):
+            where_conditions.append(f"{config['filter_col']} = @filter_val")
+            query_parameters["filter_val"] = config["filter_val"]
 
         if params.get("inning") is not None and split_type == "inning":
             where_conditions.append(f"inning = @inning")

--- a/backend/app/services/query_builder.py
+++ b/backend/app/services/query_builder.py
@@ -164,7 +164,7 @@ class QueryBuilder:
         
         # WHERE句の構築
         where_clause, query_parameters = self._build_where_clause(
-            params, player_name_col, year_column, split_type
+            params, player_name_col, year_column, split_type, config
         )
         
         # GROUP BY句の構築
@@ -439,7 +439,8 @@ class QueryBuilder:
         params: Dict[str, Any],
         player_name_col: str,
         year_column: str,
-        split_type: Optional[str]
+        split_type: Optional[str],
+        config: Dict
     ) -> Tuple[str, Dict[str, Any]]:
         """WHERE句を構築（パラメータ化）"""
         where_conditions = []
@@ -452,6 +453,10 @@ class QueryBuilder:
         if params.get("season"):
             where_conditions.append(f"{year_column} = @season")
             query_parameters["season"] = params["season"]
+        
+        if config.get("filter_col") and config.get("filter_val"):
+            where_conditions.append(f"{config['filter_col']} = @filter_val")
+            query_parameters["filter_val"] = config["filter_val"]
         
         if params.get("inning") is not None and split_type == "inning":
             where_conditions.append("inning = @inning")

--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -194,28 +194,30 @@ def get_batter_season_splits_stats(
     指定された選手名とシーズンに基づいて、選手の打撃スプリット成績を取得します。
     """
     if split_type == 'risp':
-        available_metrics = ["hits_at_risp", "homeruns_at_risp", "doubles_at_risp", "triples_at_risp", "singles_at_risp", "ab_at_risp", 
-                             "avg_at_risp", "obp_at_risp", "slg_at_risp", "ops_at_risp", "strikeout_rate_at_risp"]
-        table_id = "tbl_batter_clutch_risp"
+        available_metrics = ["hits", "homeruns", "doubles", "triples", "singles", "ab", 
+                             "avg", "obp", "slg", "ops", "strikeout_rate"]
+        table_id = "mart_batter_clutch"
     elif split_type == 'bases_loaded':
-        available_metrics = ["hits_at_bases_loaded", "grandslam", "doubles_at_bases_loaded", "triples_at_bases_loaded", "singles_at_bases_loaded", "ab_at_bases_loaded", 
-                             "avg_at_bases_loaded", "obp_at_bases_loaded", "slg_at_bases_loaded", "ops_at_bases_loaded", "strikeout_rate_at_bases_loaded"]
-        table_id = "tbl_batter_clutch_bases_loaded"
+        available_metrics = ["hits", "homeruns", "doubles", "triples", "singles", "ab", 
+                             "avg", "obp", "slg", "ops", "strikeout_rate"]
+        table_id = "mart_batter_clutch"
     # Add more split type if needed
     
     selected_metrics = ", ".join([metric for metric in metrics if metric in available_metrics]) if metrics else ""
 
     # Build WHERE clause based on season parameter
     if season is not None:
-        where_clause = "batter_id = @player_id AND game_year = @season"
+        where_clause = "batter_id = @player_id AND game_year = @season AND situation_type = @situation_type"
         query_parameters = [
             bigquery.ScalarQueryParameter("player_id", "INT64", player_id),
-            bigquery.ScalarQueryParameter("season", "INT64", season)
+            bigquery.ScalarQueryParameter("season", "INT64", season),
+            bigquery.ScalarQueryParameter("situation_type", "STRING", split_type)
         ]
     else:
-        where_clause = "batter_id = @player_id"
+        where_clause = "batter_id = @player_id AND situation_type = @situation_type"
         query_parameters = [
-            bigquery.ScalarQueryParameter("player_id", "INT64", player_id)
+            bigquery.ScalarQueryParameter("player_id", "INT64", player_id),
+            bigquery.ScalarQueryParameter("situation_type", "STRING", split_type)
         ]
 
     query = f"""

--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -798,7 +798,7 @@ def get_batter_performance_at_risp(
 #     query = f"""
 #         SELECT
 #             *
-#         FROM `{PROJECT_ID}.{DATASET_ID}.tbl_batter_inning_stats`
+#         FROM `{PROJECT_ID}.{DATASET_ID}.mart_batter_inning_stats`
 #         WHERE batter_id = @batter_id
 #         {season_where_clause}
 #     """

--- a/backend/tests/test_build_dynamic_sql.py
+++ b/backend/tests/test_build_dynamic_sql.py
@@ -281,7 +281,7 @@ class TestBattingSplitsSQL:
         sql, sql_params = _build_dynamic_sql(params)
 
         assert sql is not None
-        assert "tbl_batter_inning_stats" in sql
+        assert "mart_batter_inning_stats" in sql
         assert "@inning" in sql
         assert sql_params["inning"] == 7
 
@@ -298,7 +298,7 @@ class TestBattingSplitsSQL:
         sql, sql_params = _build_dynamic_sql(params)
 
         assert sql is not None
-        assert "tbl_batter_pitcher_throws_stats" in sql
+        assert "mart_batter_pitcher_throws" in sql
         assert "@pitcher_throws" in sql
         assert sql_params["pitcher_throws"] == "LHP"
 
@@ -315,7 +315,7 @@ class TestBattingSplitsSQL:
         sql, sql_params = _build_dynamic_sql(params)
 
         assert sql is not None
-        assert "tbl_batter_pitch_type_stats" in sql
+        assert "mart_batter_pitch_type" in sql
         assert "pitch_name = 'Fastball'" in sql or "pitch_name IN" in sql
 
     def test_pitch_type_multiple_batting_splits(self):

--- a/backend/tests/test_build_dynamic_sql.py
+++ b/backend/tests/test_build_dynamic_sql.py
@@ -243,11 +243,13 @@ class TestBattingSplitsSQL:
         sql, sql_params = _build_dynamic_sql(params)
 
         assert sql is not None
-        assert "tbl_batter_clutch_risp" in sql
-        assert "avg_at_risp" in sql
-        assert "homeruns_at_risp" in sql
+        assert "mart_batter_clutch" in sql
+        assert "avg" in sql
+        assert "homeruns" in sql
         assert "@player_name" in sql
         assert sql_params["player_name"] == "Mookie Betts"
+        assert "@filter_val" in sql
+        assert sql_params["filter_val"] == "risp"
 
     def test_bases_loaded_batting_splits(self):
         """満塁打撃スプリットのSQL生成を検証"""
@@ -261,8 +263,10 @@ class TestBattingSplitsSQL:
         sql, sql_params = _build_dynamic_sql(params)
 
         assert sql is not None
-        assert "tbl_batter_clutch_bases_loaded" in sql
-        assert "avg_at_bases_loaded" in sql
+        assert "mart_batter_clutch" in sql
+        assert "avg" in sql
+        assert "@filter_val" in sql
+        assert sql_params["filter_val"] == "bases_loaded"
 
     def test_inning_batting_splits(self):
         """イニング別打撃スプリットのSQL生成を検証"""


### PR DESCRIPTION
## What
- Consolidated 3 clutch tables into mart_batter_clutch with situation_type column
- Renamed split tables with mart_ prefix

## Why
- Reduces Structured RAG schema complexity for LLM query generation
- Consistent naming convention across all mart tables