### PR TITLE
fix: added Nginx security headers

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,39 @@
 server {
     listen 8080;
     server_name localhost;
+    
+    # ======== Security Headers =========
+    # To block MIME type sniffing
+    # ブラウザがレスポンスの Content-Type を無視して中身を「推測」する動作（MIME スニッフィング）を防ぎます。
+    # 例えば、テキストファイルが JavaScript として実行されるような攻撃を防止します。
+    add_header X-Content-Type-Options "nosniff" always;
+
+    # To prevent clickjacking
+    # このページを <iframe> で埋め込める対象を、同一オリジンのみに制限します。
+    # 悪意あるサイトがあなたのページを iframe 内に表示して、ユーザーのクリックを騙し取る「クリックジャッキング攻撃」を防ぎます。
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    # To enforce HTTPS (HSTS)
+    # ブラウザに対して「このサイトは今後必ず HTTPS でアクセスしてください」と強制します。
+    # これにより、中間者攻撃（Man-in-the-Middle Attack）で通信を盗聴されるリスクを低減できます。
+    # max-age=31536000 は「1年間はHTTPSでアクセスすること」を意味します。
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # To prevent XSS (Cross-Site Scripting) attacks
+    # 許可するコンテンツのソースを制限します。
+    # default-src 'self': 基本は自分自身のドメインからのみ読み込む。
+    # script-src 'self': JavaScriptは自分自身のドメインからのみ実行可能。
+    # style-src 'self' 'unsafe-inline': CSSは自分自身のドメインから、またはインラインスタイルとして許可。
+    # img-src 'self' data:: 画像は自分自身のドメインから、またはData URI（Base64エンコードされた画像）として許可。
+    # connect-src 'self' https://*.run.app: APIリクエストは自分自身のドメイン、またはCloud Runのエンドポイントに対してのみ許可。
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.run.app;" always;
+
+    # gzip圧縮
+    # テキスト系アセット（CSS, JS, JSON 等）を gzip 圧縮してレスポンスサイズを削減します。
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
+    gzip_min_length 1000;
+
     root /usr/share/nginx/html;
     index index.html;
 
@@ -13,5 +46,10 @@ server {
     location /static/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # server レベルのヘッダーが上書きされるため、ここにも記述が必要
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.run.app;" always;
     }
 }


### PR DESCRIPTION
## What
4 nginx security headers are added.

## Why
- to block MIME sniffing
- prevent clickjacking
- to enforce HTTPS to prevent the risk of MM attack
- to prevent XSS (cross-site scripting) attacks