### PR TITLE
feat: added visualization for agent chain of thoughts in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ backend/app/api/schemas_experimental
 mlb_parsing_practice.py
 
 linux_practice_test/*
+
+CLAUDE.md

--- a/backend/app/prompts/parse_query_v1.txt
+++ b/backend/app/prompts/parse_query_v1.txt
@@ -1,85 +1,77 @@
-prompt = f"""
-    あなたはMLBのデータアナリストです。ユーザーからの"打撃成績のランキング"、"投手成績のランキング"、または"選手成績"に関する以下の質問を解析し、
-    データベースで検索するためのパラメータをJSON形式で抽出してください。
+あなたはMLBのデータアナリストです。ユーザーからの"打撃成績のランキング"、または"選手成績"に関する以下の質問を解析し、
+データベースで検索するためのパラメータをJSON形式で抽出してください。
 
-    # 指示
-    - 選手名は英語表記（フルネーム）に正規化してください。例：「大谷さん」 -> "Shohei Ohtani"
-    - `season`は、ユーザーの質問から年を抽出してください。`season`が指定されていない場合、または「キャリア」や「通算」などの表現があれば、`season`はnullにしてください。
-    - `query_type`は "season_batting"、"season_pitching"、 "batting_splits"、または "career_batting" のいずれかを選択してください。
-    - `metrics`には、ユーザーが知りたい指標をリスト形式で格納してください。
-    - **重要**: metricsには以下の定義済みキー名のみを使用してください。それ以外の名前は絶対に使わないでください。
-    
-    【打撃指標（season_batting / batting_splits / career_batting）】
-    homerun, batting_average, on_base_percentage, slugging_percentage, on_base_plus_slugging, at_bats, hits, runs_batted_in, stolen_bases, strikeouts, games, war
-    
-    【投手指標（season_pitching）】
-    era（防御率）, whip（WHIP）, strikeouts（奪三振）, fip（FIP）, wins（勝利数）, innings_pitched（投球回）, games_started（先発数）, hits_allowed（被安打）, runs（失点）, earned_runs（自責点）, base_on_balls（四球）, batting_average_against（被打率）
-    
-    - `split_type`は、「得点圏（RISP）」「満塁」「ランナー1類」「イニング別」「投手が左投げか右投げか」「球種別」「ゲームスコア状況別」などの特定の状況を示します。該当しない場合はnullにしてください。
-    - `split_type`で、game_score_situation (ゲームスコア状況別) を選択した場合、`game_score`に具体的なスコア状況（例：1点リード、2点ビハインドなど）を示す必要があります。
-        例えば、「1点差ゲーム、1点リード、1点ビハインド」は、'one_run_game'、'one_run_lead'、'one_run_trail'のように表現します。4点以上の差は'four_plus_run_lead'や'four_plus_run_trail'としてください。該当しない場合はnullにしてください。
-    - `split_type`で、inning (イニング別) を選択した場合、`inning`に具体的なイニング数をリスト形式で示してください。レギュラーイニング数は1~9イニングまで。例：1イニング目なら [1]、7イニング目以降なら [7, 8, 9] とします。
-    - `strikes`は、特定のストライク数を指定します。該当しない場合はnullにしてください。`balls`は、特定のボール数を指定します。該当しない場合はnullにしてください。
-    - 例えば、「フルカウント」は、 `strikes`を2、`balls`を3としてください。「初球」は、`strikes`を0、`balls`を0とします。該当しない場合はnullにしてください。
-    - `pitcher_throws`は、投手の投げ方（右投げまたは左投げ）を示します。右投げはRHP、左投げはLHPとし、該当しない場合はnullにしてください。
-    - ユーザーが「主要スタッツ」や「主な成績」のような曖昧な表現を使った場合、metricsには ["main_stats"] というキーワードを一つだけ格納してください。
-    - `order_by`には、ランキングの基準となる指標を一つだけ設定してください。order_byにもmetricsと同じ定義済みキー名を使用してください。
-    - `output_format`では、デフォルトは "sentence" です。もしユーザーの質問に『表で』『一覧で』『まとめて』といったような言葉が含まれていたら、output_formatをtableに設定してください。そうでなければsentenceにしてください。
+# 指示
+- 選手名は英語表記（フルネーム）に正規化してください。例：「大谷さん」 -> "Shohei Ohtani"
+- **最重要**: `season`（シーズン年）の抽出ルール:
+    1. 質問に「2024年」「2023年」など具体的な年が含まれている場合、**必ず**その年を`season`フィールドに整数値で設定してください。例: "2024年" → "season": 2024
+    2. 質問に年の記載がなく、「の」「今年の」などの表現がある場合、会話コンテキストから年を推測してください。{season_hint}
+    3. 「キャリア」「通算」「全期間」などの表現がある場合のみ、`season`をnullにしてください。
+- `query_type`の判定ルール:
+    1. `season`が設定されており、特定の状況（RISP、満塁など）が指定されていない場合、`query_type`は"season_batting"にしてください。
+    2. `season`が設定されており、特定の状況が指定されている場合、`query_type`は"batting_splits"にしてください。
+    3. `season`がnull（キャリア通算）の場合、`query_type`は"career_batting"にしてください。
+- `query_type`は "season_batting"、 "batting_splits"、または "career_batting" のいずれかを選択してください。
+- `metrics`には、ユーザーが知りたい指標をリスト形式で格納してください。例えば、ホームラン数を知りたい場合は ["homerun"] とします。打率の場合は ["batting_average"] とし、単語と単語の間にアンダースコアを使用してください。
+- `split_type`は、「得点圏（RISP）」「満塁」「ランナー1類」「イニング別」「投手が左投げか右投げか」「球種別」「ゲームスコア状況別」などの特定の状況を示します。該当しない場合はnullにしてください。
+- `split_type`で、game_score_situation (ゲームスコア状況別) を選択した場合、`game_score`に具体的なスコア状況（例：1点リード、2点ビハインドなど）を示す必要があります。
+    例えば、「1点差ゲーム、1点リード、1点ビハインド」は、'one_run_game'、'one_run_lead'、'one_run_trail'のように表現します。4点以上の差は'four_plus_run_lead'や'four_plus_run_trail'としてください。該当しない場合はnullにしてください。
+- `split_type`で、inning (イニング別) を選択した場合、`inning`に具体的なイニング数をリスト形式で示してください。レギュラーイニング数は1~9イニングまで。例：1イニング目なら [1]、7イニング目以降なら [7, 8, 9] とします。
+- `strikes`は、特定のストライク数を指定します。該当しない場合はnullにしてください。`balls`は、特定のボール数を指定します。該当しない場合はnullにしてください。
+- 例えば、「フルカウント」は、 `strikes`を2、`balls`を3としてください。「初球」は、`strikes`を0、`balls`を0とします。該当しない場合はnullにしてください。
+- `pitcher_throws`は、投手の投げ方（右投げまたは左投げ）を示します。右投げはRHP、左投げはLHPとし、該当しない場合はnullにしてください。
+- ユーザーが「主要スタッツ」や「主な成績」のような曖昧な表現を使った場合、metricsには ["main_stats"] というキーワードを一つだけ格納してください。
+- `order_by`には、ランキングの基準となる指標を一つだけ設定してください。
+- `output_format`では、デフォルトは "sentence" です。もしユーザーの質問に『表で』『一覧で』『まとめて』といったような言葉が含まれていたら、output_formatをtableに設定してください。そうでなければsentenceにしてください。
 
-    # JSONスキーマ
-    {{
-        "query_type": "season_batting" | "season_pitching" | "batting_splits" | "career_batting" | null,
-        "metrics": ["string"],
-        "split_type": "risp" | "bases_loaded" | "runner_on_1b" | "inning" | "pitcher_throws" | "pitch_type" | "game_score_situation" | "monthly" | null,
-        "inning": ["integer"] | null,
-        "strikes": "integer | null",
-        "balls": "integer | null",
-        "game_score": "string | null",
-        "pitcher_throws": "string | null",
-        "pitch_type": ["string"] | null,
-        "name": "string | null",
-        "season": "integer | null",
-        "order_by": "string",
-        "limit": "integer | null",
-        "output_format": "sentence" | "table"
-    }}
+# JSONスキーマ
+{{
+    "query_type": "season_batting" | "batting_splits" | "career_batting" | null,
+    "metrics": ["string"],
+    "split_type": "risp" | "bases_loaded" | "runner_on_1b" | "inning" | "pitcher_throws" | "pitch_type" | "game_score_situation" | "monthly" | null,
+    "inning": ["integer"] | null,
+    "strikes": "integer | null",
+    "balls": "integer | null",
+    "game_score": "string | null",
+    "pitcher_throws": "string | null",
+    "pitch_type": ["string"] | null,
+    "name": "string | null",
+    "season": "integer | null",
+    "order_by": "string",
+    "limit": "integer | null",
+    "output_format": "sentence" | "table"
+}}
 
-    # 質問の例
-    質問: 「2023年のホームラン王は誰？」
-    JSON: {{ "query_type": "season_batting", "season": 2023, "metrics": ["homerun"],  "order_by": "homerun", "limit": 1 }}
+# 質問の例
+質問: 「2023年のホームラン王は誰？」
+JSON: {{ "query_type": "season_batting", "season": 2023, "metrics": ["homerun"],  "order_by": "homerun", "limit": 1 }}
 
-    質問: 「大谷さんの2024年のRISP時の主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "risp", "order_by": null, "limit": 1 }}
+質問: 「大谷さんの2024年のRISP時の主要スタッツは？」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "risp", "order_by": null, "limit": 1 }}
 
-    質問: 「大谷さんのの2024年の1イニング目のホームラン数とOPSを教えて」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["homerun", "on_base_plus_slugging"], "split_type": "inning", "inning": 1, "order_by": null, "limit": 1 }}
+質問: 「大谷さんのの2024年の1イニング目のホームラン数とOPSを教えて」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["homerun", "on_base_plus_slugging"], "split_type": "inning", "inning": 1, "order_by": null, "limit": 1 }}
 
-    質問: 「大谷さんの2024年の左投手に対する主要スタッツを一覧で教えて？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "pitcher_throws", "pitcher_throws": "LHP", "order_by": null, "limit": 1, "output_format": "table" }}
+質問: 「大谷さんの2024年の左投手に対する主要スタッツを一覧で教えて？」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "pitcher_throws", "pitcher_throws": "LHP", "order_by": null, "limit": 1, "output_format": "table" }}
 
-    質問: 「大谷さんの2024年のスライダーに対する主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "pitch_type", "pitch_type": "Slider", "order_by": null }}
+質問: 「大谷さんの2024年のスライダーに対する主要スタッツは？」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "pitch_type", "pitch_type": "Slider", "order_by": null }}
 
-    質問: 「大谷さんのキャリア主要打撃成績を一覧で教えて」
-    JSON: {{ "query_type": "career_batting", "name": "Shohei Ohtani", "metrics": ["main_stats"], "order_by": null, "limit": 1, "output_format": "table" }}
+質問: 「大谷さんのキャリア主要打撃成績を一覧で教えて」
+JSON: {{ "query_type": "career_batting", "name": "Shohei Ohtani", "metrics": ["main_stats"], "order_by": null, "limit": 1, "output_format": "table" }}
 
-    質問: 「2025年の防御率トップ5を表で見せて」
-    JSON: {{ "query_type": "season_pitching", "metrics": ["era"], "season": 2025, "order_by": "era", "limit": 5, "output_format": "table" }}
+質問: 「大谷さんの2024年の、1点ビハインドでの主要スタッツは？」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "game_score_situation", "game_score": "one_run_trail", "order_by": null, "limit": 1 }}
 
-    質問: 「ポールスキーンズの2025年の防御率とWHIPは？」
-    JSON: {{ "query_type": "season_pitching", "name": "Paul Skenes", "season": 2025, "metrics": ["era", "whip"], "order_by": null, "limit": 1 }}
+質問: 「大谷さんの2024年の打率を月毎の推移をチャートで教えて」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["batting_average"], "split_type": "monthly", "order_by": null }}
 
-    質問: 「大谷さんの2024年の、1点ビハインドでの主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "game_score_situation", "game_score": "one_run_trail", "order_by": null, "limit": 1 }}
+# 複合質問の例
+質問: 「大谷さんの2024年の7イニング目以降、フルカウントでの、RISP時の主要スタッツは？」
+JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "risp", "inning": [7, 8, 9], "strikes": 2, "balls": 3, "order_by": null, "limit": 1 }}
 
-    質問: 「大谷さんの2024年の打率を月毎の推移をチャートで教えて」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["batting_average"], "split_type": "monthly", "order_by": null }}
-
-    # 複合質問の例
-    質問: 「大谷さんの2024年の7イニング目以降、フルカウントでの、RISP時の主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "risp", "inning": [7, 8, 9], "strikes": 2, "balls": 3, "order_by": null, "limit": 1 }}
-
-    # 本番
-    質問: 「{query}」
-    JSON:
-    """
+# 本番
+# 注意: 質問に「〇〇年」という表現があれば、必ずその年を整数値でseasonに設定してください。例: "2024年" → "season": 2024
+質問: 「{query}」
+JSON:

--- a/backend/app/services/analytics/batter_services.py
+++ b/backend/app/services/analytics/batter_services.py
@@ -66,6 +66,24 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY_V2")
 SERVICE_ACCOUNT_KEY_PATH = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 
+def _load_prompt_template(template_name: str) -> str:
+    """
+    プロンプトテンプレートファイルを読み込みます。
+    """
+    prompt_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'prompts')
+    prompt_path = os.path.join(prompt_dir, f"{template_name}.txt")
+
+    try:
+        with open(prompt_path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        logger.error(f"Prompt template not found: {prompt_path}")
+        raise
+    except Exception as e:
+        logger.error(f"Error loading prompt template: {e}")
+        raise
+
+
 def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[str, Any]]:
     """
     [ステップ1] LLMを使い、質問からパラメータを抽出します。この関数はLLMの役割を果たします。ユーザーの質問を解析し、「意図」を汲み取り、
@@ -75,80 +93,14 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
         logger.error("GEMINI_API_KEY_V2 is not set.")
         return None
 
-    prompt = f"""
-    あなたはMLBのデータアナリストです。ユーザーからの"打撃成績のランキング"、または"選手成績"に関する以下の質問を解析し、
-    データベースで検索するためのパラメータをJSON形式で抽出してください。
+    # プロンプトテンプレートを読み込み
+    prompt_template = _load_prompt_template("parse_query_v1")
 
-    # 指示
-    - 選手名は英語表記（フルネーム）に正規化してください。例：「大谷さん」 -> "Shohei Ohtani"
-    - **重要**: `season`と`query_type`の判定ルール:
-        1. 質問に「2024年」「2023年」など具体的な年が含まれている場合、必ず`season`にその年を設定し、`query_type`は"season_batting"にしてください。
-        2. 「キャリア」「通算」「全期間」などの表現がある場合のみ、`season`をnullにし、`query_type`を"career_batting"にしてください。
-        3. 年の記載がなく、特定の状況（RISP、満塁など）が指定されている場合は、`query_type`を"batting_splits"にしてください。
-    - `query_type`は "season_batting"、 "batting_splits"、または "career_batting" のいずれかを選択してください。
-    - `metrics`には、ユーザーが知りたい指標をリスト形式で格納してください。例えば、ホームラン数を知りたい場合は ["homerun"] とします。打率の場合は ["batting_average"] とし、単語と単語の間にアンダースコアを使用してください。
-    - `split_type`は、「得点圏（RISP）」「満塁」「ランナー1類」「イニング別」「投手が左投げか右投げか」「球種別」「ゲームスコア状況別」などの特定の状況を示します。該当しない場合はnullにしてください。
-    - `split_type`で、game_score_situation (ゲームスコア状況別) を選択した場合、`game_score`に具体的なスコア状況（例：1点リード、2点ビハインドなど）を示す必要があります。
-        例えば、「1点差ゲーム、1点リード、1点ビハインド」は、'one_run_game'、'one_run_lead'、'one_run_trail'のように表現します。4点以上の差は'four_plus_run_lead'や'four_plus_run_trail'としてください。該当しない場合はnullにしてください。
-    - `split_type`で、inning (イニング別) を選択した場合、`inning`に具体的なイニング数をリスト形式で示してください。レギュラーイニング数は1~9イニングまで。例：1イニング目なら [1]、7イニング目以降なら [7, 8, 9] とします。
-    - `strikes`は、特定のストライク数を指定します。該当しない場合はnullにしてください。`balls`は、特定のボール数を指定します。該当しない場合はnullにしてください。
-    - 例えば、「フルカウント」は、 `strikes`を2、`balls`を3としてください。「初球」は、`strikes`を0、`balls`を0とします。該当しない場合はnullにしてください。
-    - `pitcher_throws`は、投手の投げ方（右投げまたは左投げ）を示します。右投げはRHP、左投げはLHPとし、該当しない場合はnullにしてください。
-    - ユーザーが「主要スタッツ」や「主な成績」のような曖昧な表現を使った場合、metricsには ["main_stats"] というキーワードを一つだけ格納してください。
-    - `order_by`には、ランキングの基準となる指標を一つだけ設定してください。
-    - `output_format`では、デフォルトは "sentence" です。もしユーザーの質問に『表で』『一覧で』『まとめて』といったような言葉が含まれていたら、output_formatをtableに設定してください。そうでなければsentenceにしてください。
+    # seasonパラメータがある場合、ヒントとして追加
+    season_hint = f"\n    - **コンテキスト情報**: 会話履歴から、対象シーズンは {season} 年と推測されます。質問に年の記載がない場合でも、このシーズンを使用してください。" if season else ""
 
-    # JSONスキーマ
-    {{
-        "query_type": "season_batting" | "batting_splits" | "career_batting" | null,
-        "metrics": ["string"],
-        "split_type": "risp" | "bases_loaded" | "runner_on_1b" | "inning" | "pitcher_throws" | "pitch_type" | "game_score_situation" | "monthly" | null,
-        "inning": ["integer"] | null,
-        "strikes": "integer | null",
-        "balls": "integer | null",
-        "game_score": "string | null",
-        "pitcher_throws": "string | null",
-        "pitch_type": ["string"] | null,
-        "name": "string | null",
-        "season": "integer | null",
-        "order_by": "string",
-        "limit": "integer | null",
-        "output_format": "sentence" | "table"
-    }}
-
-    # 質問の例
-    質問: 「2023年のホームラン王は誰？」
-    JSON: {{ "query_type": "season_batting", "season": 2023, "metrics": ["homerun"],  "order_by": "homerun", "limit": 1 }}
-
-    質問: 「大谷さんの2024年のRISP時の主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "risp", "order_by": null, "limit": 1 }}
-
-    質問: 「大谷さんのの2024年の1イニング目のホームラン数とOPSを教えて」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["homerun", "on_base_plus_slugging"], "split_type": "inning", "inning": 1, "order_by": null, "limit": 1 }}
-
-    質問: 「大谷さんの2024年の左投手に対する主要スタッツを一覧で教えて？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "pitcher_throws", "pitcher_throws": "LHP", "order_by": null, "limit": 1, "output_format": "table" }}
-
-    質問: 「大谷さんの2024年のスライダーに対する主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "pitch_type", "pitch_type": "Slider", "order_by": null }}
-
-    質問: 「大谷さんのキャリア主要打撃成績を一覧で教えて」
-    JSON: {{ "query_type": "career_batting", "name": "Shohei Ohtani", "metrics": ["main_stats"], "order_by": null, "limit": 1, "output_format": "table" }}
-
-    質問: 「大谷さんの2024年の、1点ビハインドでの主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "game_score_situation", "game_score": "one_run_trail", "order_by": null, "limit": 1 }}
-
-    質問: 「大谷さんの2024年の打率を月毎の推移をチャートで教えて」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["batting_average"], "split_type": "monthly", "order_by": null }}
-
-    # 複合質問の例
-    質問: 「大谷さんの2024年の7イニング目以降、フルカウントでの、RISP時の主要スタッツは？」
-    JSON: {{ "query_type": "batting_splits", "name": "Shohei Ohtani", "season": 2024,  "metrics": ["main_stats"], "split_type": "risp", "inning": [7, 8, 9], "strikes": 2, "balls": 3, "order_by": null, "limit": 1 }}
-
-    # 本番
-    質問: 「{query}」
-    JSON:
-    """
+    # プレースホルダーを置換
+    prompt = prompt_template.format(season_hint=season_hint, query=query)
 
     GEMINI_API_URL=f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={GEMINI_API_KEY}"
     headers = {"Content-Type": "application/json"}
@@ -163,12 +115,16 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
         result = response.json()
         if result.get("candidates"):
             json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            params = json.loads(json_string)
+            logger.info(f"LLM raw response: {json_string}")
 
+            params = json.loads(json_string)
             logger.info(f"Parsed parameters: {params}")
 
-            if season and 'season' not in params:
+            # seasonパラメータが渡されており、かつLLMがseasonを設定していない場合、強制的に設定
+            if season and (not params.get('season') or params.get('season') is None):
+                logger.info(f"Overriding season from context: {season}")
                 params['season'] = season
+
             return params
         return None
     except (requests.exceptions.RequestException, json.JSONDecodeError) as e:

--- a/frontend/src/components/AgentReasoningTracker.jsx
+++ b/frontend/src/components/AgentReasoningTracker.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronUp, Brain, Wrench, CheckCircle, Circle, Clock } from 'lucide-react';
+
+const AgentReasoningTracker = ({
+    steps = [],
+    isStreaming = false,
+    isCollapsible = false
+}) => {
+    const [isExpanded, setIsExpanded] = useState(true);
+
+    if (!steps || steps.length === 0) return null;
+
+    const getStepIcon = (stepType, status) => {
+        const iconProps = { className: "w-4 h-4 flex-shrink-0" };
+
+        if (stepType === 'node_start' || stepType === 'node_end') {
+            return status === 'completed'
+                ? <CheckCircle {...iconProps} className="w-4 h-4 flex-shrink-0 text-green-500" />
+                : <Circle {...iconProps} className="w-4 h-4 flex-shrink-0 text-blue-400 animate-pulse" />;
+        }
+
+        if (stepType === 'tool_call' || stepType === 'tool_result') {
+            return <Wrench {...iconProps} className="w-4 h-4 flex-shrink-0 text-purple-400" />;
+        }
+
+        return <Brain {...iconProps} className="w-4 h-4 flex-shrink-0 text-gray-400" />;
+    };
+
+    const getStepColor = (node, status) => {
+        if (status === 'completed') return 'text-green-600 dark:text-green-400';
+        if (node === 'oracle') return 'text-blue-600 dark:text-blue-400';
+        if (node === 'executor') return 'text-purple-600 dark:text-purple-400';
+        if (node === 'synthesizer') return 'text-orange-600 dark:text-orange-400';
+        return 'text-gray-600 dark:text-gray-400';
+    };
+
+    const formatTimestamp = (timestamp) => {
+        if (!timestamp) return '';
+        try {
+            const date = new Date(timestamp);
+            return date.toLocaleTimeString('ja-JP', {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                fractionalSecondDigits: 1
+            });
+        } catch (e) {
+            return '';
+        }
+    };
+
+    return (
+        <div className="mt-4 mb-4 p-4 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800/50 dark:to-gray-800/30 rounded-xl border border-gray-200 dark:border-gray-600 shadow-sm">
+            {/* ヘッダー */}
+            <div
+                className={`flex items-center justify-between mb-3 ${isCollapsible ? 'cursor-pointer' : ''}`}
+                onClick={() => isCollapsible && setIsExpanded(!isExpanded)}
+            >
+                <div className="flex items-center gap-2">
+                    <Brain className="w-5 h-5 text-purple-600 dark:text-purple-400 animate-pulse" />
+                    <span className="text-sm font-bold uppercase tracking-wider text-purple-700 dark:text-purple-300">
+                        AI推論プロセス
+                    </span>
+                    {isStreaming && (
+                        <span className="ml-2 px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-full animate-pulse">
+                            実行中
+                        </span>
+                    )}
+                </div>
+
+                {isCollapsible && (
+                    <button
+                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+                        aria-label={isExpanded ? "折りたたむ" : "展開する"}
+                    >
+                        {isExpanded ? (
+                            <ChevronUp className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+                        ) : (
+                            <ChevronDown className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+                        )}
+                    </button>
+                )}
+            </div>
+
+            {/* ステップリスト */}
+            {isExpanded && (
+                <div className="space-y-2 relative">
+                    {/* 縦線（タイムライン） */}
+                    <div className="absolute left-[11px] top-2 bottom-2 w-0.5 bg-gradient-to-b from-blue-300 via-purple-300 to-orange-300 dark:from-blue-700 dark:via-purple-700 dark:to-orange-700 opacity-30" />
+
+                    {steps.map((step, idx) => (
+                        <div
+                            key={idx}
+                            className="relative flex items-start gap-3 pl-1 group transition-all duration-200 hover:translate-x-1"
+                        >
+                            {/* アイコン */}
+                            <div className="relative z-10 bg-white dark:bg-gray-800 rounded-full p-0.5">
+                                {getStepIcon(step.step_type, step.status)}
+                            </div>
+
+                            {/* ステップ詳細 */}
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    {/* ノード名バッジ */}
+                                    {step.node && (
+                                        <span className={`px-2 py-0.5 text-xs font-semibold rounded-md ${getStepColor(step.node, step.status)} bg-white/50 dark:bg-gray-700/50`}>
+                                            {step.node.toUpperCase()}
+                                        </span>
+                                    )}
+
+                                    {/* メッセージ */}
+                                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                                        {step.message}
+                                    </span>
+
+                                    {/* タイムスタンプ */}
+                                    {step.timestamp && (
+                                        <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+                                            <Clock className="w-3 h-3" />
+                                            {formatTimestamp(step.timestamp)}
+                                        </span>
+                                    )}
+                                </div>
+
+                                {/* 詳細情報 */}
+                                {step.detail && (
+                                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 italic">
+                                        {step.detail}
+                                    </p>
+                                )}
+
+                                {/* ツールの出力サマリー */}
+                                {step.output_summary && (
+                                    <p className="mt-1 text-xs text-green-600 dark:text-green-400 font-medium">
+                                        → {step.output_summary}
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* 折りたたまれている場合のサマリー */}
+            {!isExpanded && (
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {steps.length}ステップ完了
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AgentReasoningTracker;


### PR DESCRIPTION
## Summary

Implements real-time visualization of LangGraph agent reasoning steps to improve transparency during query processing. Users can now see what the AI agent is doing at each step (e.g., "Parsing intent...", "Querying BigQuery...", "Generating response...") via an accordion-style collapsible UI component.

## Changes

### Backend (`ai_agent_service.py`)
- Enhanced SSE events (`state_update`, `tool_start`, `tool_end`) with timestamps and detailed context
- Fixed Python 3.12 compatibility (`datetime.utcnow()` → `datetime.now(timezone.utc)`)

### Frontend
- **New component**: `AgentReasoningTracker.jsx` - displays reasoning steps with timeline, icons, and timestamps
- **Updated**: `App.jsx` - integrated component and added error handling for stream failures
- Dark theme compatible, fully collapsible after streaming completes

## Testing

Test with queries like "大谷翔平の2025年の打率は？" and verify:
- Steps appear in real-time (Oracle → Executor → Synthesizer)
- Timestamps and tool summaries display correctly
- Accordion collapses after streaming completes
- Dark mode renders properly

## Related Issues

Closes #32  
Depends on: #28 ✅  
Enhances: #29