### PR TITLE
revamp frontend design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ CLAUDE.md
 .claude/
 
 queries/
+
+design/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,9 @@
     <meta name="theme-color" content="#2563eb" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Diamond Lens</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import QuickQuestions from './components/QuickQuestions.jsx';
-import CustomQueryBuilder from './components/CustomQueryBuilder.jsx';
 import StatisticalAnalysis from './components/StatisticalAnalysis.jsx';
 import PlayerSegmentation from './components/PlayerSegmentation.jsx';
-import PitcherFatigue from './components/PitcherFatigue.jsx';
-import PitcherWhiffPredictor from './components/PitcherWhiffPredictor.jsx';
 import StuffPlus from './components/StuffPlus.jsx';
 import AdvancedStats from './components/AdvancedStats.jsx';
 import LiveScoreboard from './components/LiveScoreboard.jsx';
@@ -13,7 +10,6 @@ import Standings from './components/Standings.jsx';
 import Leaderboard from './components/Leaderboard.jsx';
 import HotSlumpDashboard from './components/HotSlumpDashboard.jsx';
 import PlayerProfile from './components/PlayerProfile.jsx';
-import VoiceInput from './components/VoiceInput.jsx';
 import { useAuth } from './hooks/useAuth';
 import { useSession } from './hooks/useSession.js';
 import { useBackendAPI } from './hooks/useBackendAPI.js';
@@ -25,25 +21,32 @@ import { useCustomQuery } from './hooks/useCustomQuery.js';
 import { useStreamChat } from './hooks/useStreamChat.js';
 import LoginScreen from './components/layout/LoginScreen.jsx';
 import AppSidebar from './components/layout/AppSidebar.jsx';
-import ChatTopBar from './components/layout/ChatTopBar.jsx';
-import ChatInputArea from './components/layout/ChatInputArea.jsx';
-import ChatMessageList from './components/layout/ChatMessageList.jsx';
+import Topbar from './components/layout/ChatTopBar.jsx';
+import Ticker from './components/layout/Ticker.jsx';
+import ChatScreen from './components/layout/ChatScreen.jsx';
+import { DLMark } from './components/layout/Icon.jsx';
 
-// Force dark mode on app load
-const initializeDarkMode = () => {
-  document.documentElement.classList.add('dark');
-};
+// ============================================================
+// Placeholder — 未実装画面のフォールバック
+// ============================================================
+const Placeholder = ({ label }) => (
+  <div style={{
+    flex: 1, display: "flex", alignItems: "center", justifyContent: "center",
+    flexDirection: "column", gap: 14, color: "var(--ink-3)",
+  }}>
+    <DLMark size={48}/>
+    <div className="h-display" style={{ fontSize: 22, color: "var(--ink-1)" }}>{label}</div>
+    <div className="t-mono" style={{ fontSize: 11, color: "var(--ink-4)", letterSpacing: "0.1em" }}>
+      MODULE · 準備中
+    </div>
+  </div>
+);
 
-
-
-
+// ============================================================
+// Main app
+// ============================================================
 const MLBChatApp = () => {
-  // Initialize dark mode on component mount
-  useEffect(() => {
-    initializeDarkMode();
-  }, []);
-
-  // ===== STATE管理 =====
+  // ===== STATE =====
   const {
     messages, setMessages,
     inputMessage, setInputMessage,
@@ -51,214 +54,190 @@ const MLBChatApp = () => {
     messagesEndRef,
     resetMessages,
     formatTime,
-    handleVoiceTranscript,
   } = useMessages();
 
-  // Firebase認証（Googleログイン）
   const { user, loading: authLoading, error: authError, loginWithGoogle, logout, getIdToken } = useAuth();
   const [isCheckingAuth, setIsCheckingAuth] = useState(false);
 
-  // UIモード管理のstate
-  const [uiMode, setUiMode] = useState('chat'); // 'chat', 'quick', 'custom', 'statistics', 'segmentation', 'fatigue', 'pitcher-whiff'
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // mode: "chat" | "quick" | "stats" | "segment" | "stuff" | "advanced"
+  //       "hot"  | "leader"| "live"  | "monitor" | "standings" | "profile"
+  const [mode, setMode] = useState(() => localStorage.getItem("dl-mode") || "chat");
+  const [collapsed, setCollapsed] = useState(false);
 
+  useEffect(() => { localStorage.setItem("dl-mode", mode); }, [mode]);
 
-  // エージェントモード（推論ループ）のON/OFF
   const [isAgentMode, setIsAgentMode] = useState(false);
 
-  // ★ 会話履歴用のセッションID管理 ★
   const { sessionId, setSessionId, clearSession } = useSession();
 
-  // ===== API フック =====
-  // getBackendURL / getAuthHeaders / callBackendAPI / searchPlayers
+  // ===== API hooks =====
   const { getBackendURL, getAuthHeaders, callBackendAPI, searchPlayers } = useBackendAPI({
-    getIdToken,
-    sessionId,
-    setSessionId,
-    isAgentMode,
+    getIdToken, sessionId, setSessionId, isAgentMode,
   });
 
   const { callFixedQueryAPI } = useFixedQueryAPI({ getBackendURL, getAuthHeaders });
 
-  // ===== クイック質問 =====
   const { quickResult, setQuickResult, handleQuickQuestion } = useQuickQuery({ callFixedQueryAPI, setIsLoading });
 
-  // ===== カスタムクエリ =====
-  const { customResult, setCustomResult, handleCustomQuery } = useCustomQuery({ callFixedQueryAPI, getBackendURL, getAuthHeaders, setIsLoading });
+  const { setCustomResult } = useCustomQuery({
+    callFixedQueryAPI, getBackendURL, getAuthHeaders, setIsLoading,
+  });
 
-  // ===== フィードバック =====
   const {
-    feedbackState,
-    activeFeedbackForm,
-    setActiveFeedbackForm,
-    feedbackFormData,
-    setFeedbackFormData,
-    handleFeedback,
+    feedbackState, activeFeedbackForm, setActiveFeedbackForm,
+    feedbackFormData, setFeedbackFormData, handleFeedback,
   } = useFeedback({ getBackendURL, getAuthHeaders, sessionId });
 
-  // ===== チャット送信・履歴クリア =====
-  const { handleClearHistory, handleSendMessage, handleSendMessageStream, handleKeyDown } = useStreamChat({
+  const { handleClearHistory, handleSendMessageStream, handleKeyDown } = useStreamChat({
     inputMessage, isLoading, sessionId,
     setMessages, setInputMessage, setIsLoading, setSessionId, resetMessages, clearSession,
     getBackendURL, getAuthHeaders, callBackendAPI,
   });
 
-  // Googleログイン処理
+  // Clear sub-results when switching modes
+  const handleSetMode = (newMode) => {
+    setMode(newMode);
+    setQuickResult(null);
+    setCustomResult(null);
+  };
+
   const handleGoogleLogin = async () => {
     setIsCheckingAuth(true);
     try {
       await loginWithGoogle();
-    } catch (err) {
-      // エラーは useAuth 内で処理済み
     } finally {
       setIsCheckingAuth(false);
     }
   };
 
+  // ===== Screen routing =====
+  const renderScreen = () => {
+    switch (mode) {
+      case "chat":
+        return (
+          <ChatScreen
+            messages={messages}
+            feedbackState={feedbackState}
+            activeFeedbackForm={activeFeedbackForm}
+            feedbackFormData={feedbackFormData}
+            setFeedbackFormData={setFeedbackFormData}
+            setActiveFeedbackForm={setActiveFeedbackForm}
+            handleFeedback={handleFeedback}
+            messagesEndRef={messagesEndRef}
+            formatTime={formatTime}
+            user={user}
+            inputMessage={inputMessage}
+            setInputMessage={setInputMessage}
+            handleKeyDown={handleKeyDown}
+            isLoading={isLoading}
+            handleSendMessageStream={handleSendMessageStream}
+            isAgentMode={isAgentMode}
+            setIsAgentMode={setIsAgentMode}
+            sessionId={sessionId}
+            handleClearHistory={handleClearHistory}
+          />
+        );
+      case "quick":
+        return (
+          <div style={{ padding: "24px 32px", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <QuickQuestions
+              onQuestionClick={handleQuickQuestion}
+              isLoading={isLoading}
+              quickResult={quickResult}
+              onClearResult={() => setQuickResult(null)}
+            />
+          </div>
+        );
+      case "stats":
+        return <div style={{ padding: "24px 32px", height: "100%" }}><StatisticalAnalysis/></div>;
+      case "segment":
+        return <div style={{ padding: "24px 32px", height: "100%" }}><PlayerSegmentation/></div>;
+      case "stuff":
+        return <div style={{ padding: "24px 32px", height: "100%" }}><StuffPlus/></div>;
+      case "advanced":
+        return <div style={{ padding: "24px 32px", height: "100%" }}><AdvancedStats/></div>;
+      case "hot":
+        return <div style={{ height: "100%", overflowY: "auto" }}><HotSlumpDashboard/></div>;
+      case "leader":
+        return <div style={{ padding: "24px 32px", height: "100%" }}><Leaderboard/></div>;
+      case "live":
+        return <div style={{ padding: "24px 32px", height: "100%", width: "100%" }}><LiveScoreboard/></div>;
+      case "monitor":
+        return <div style={{ padding: "24px 32px", height: "100%", width: "100%" }}><LiveMonitorBoard/></div>;
+      case "standings":
+        return <div style={{ padding: "24px 32px", height: "100%", width: "100%" }}><Standings/></div>;
+      case "profile":
+        return (
+          <div style={{ padding: "24px 32px", height: "100%", width: "100%" }}>
+            <PlayerProfile
+              onSearchPlayers={searchPlayers}
+              getAuthHeaders={getAuthHeaders}
+              getBackendURL={getBackendURL}
+            />
+          </div>
+        );
+      default:
+        return <Placeholder label={mode.toUpperCase()}/>;
+    }
+  };
 
-  // ===== メインUIレンダリング =====
+  // ===== Render =====
   return (
-    <div className="flex flex-col h-screen w-full bg-white dark:bg-gray-900 transition-colors duration-200" data-theme-test>
+    <div style={{ height: "100%", display: "flex", background: "var(--bg-0)", color: "var(--ink-1)" }}>
       {authLoading ? (
-        <div className="flex items-center justify-center h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-black">
-          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+        <div style={{
+          flex: 1, display: "flex", alignItems: "center", justifyContent: "center",
+          background: "var(--bg-0)",
+        }}>
+          <div style={{
+            width: 32, height: 32,
+            border: "2px solid var(--bg-3)",
+            borderTop: "2px solid var(--amber)",
+            borderRadius: "50%",
+            animation: "spin 0.8s linear infinite",
+          }}/>
+          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
         </div>
       ) : !user ? (
-        <LoginScreen
-          authError={authError}
-          isCheckingAuth={isCheckingAuth}
-          handleGoogleLogin={handleGoogleLogin}
-        />
+        <div style={{ flex: 1 }}>
+          <LoginScreen
+            authError={authError}
+            isCheckingAuth={isCheckingAuth}
+            handleGoogleLogin={handleGoogleLogin}
+          />
+        </div>
       ) : (
-        <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
-          {/* モバイルオーバーレイ */}
-          {sidebarOpen && (
-            <div className="fixed inset-0 z-20 bg-black/60 md:hidden" onClick={() => setSidebarOpen(false)} />
-          )}
+        <>
           <AppSidebar
-            sidebarOpen={sidebarOpen}
-            setSidebarOpen={setSidebarOpen}
-            uiMode={uiMode}
-            setUiMode={setUiMode}
-            setQuickResult={setQuickResult}
-            setCustomResult={setCustomResult}
+            mode={mode}
+            setMode={handleSetMode}
+            collapsed={collapsed}
+            setCollapsed={setCollapsed}
+            user={user}
             logout={logout}
           />
-          <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-            <ChatTopBar
-              sidebarOpen={sidebarOpen}
-              setSidebarOpen={setSidebarOpen}
-              uiMode={uiMode}
+
+          <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+            <Ticker/>
+            <Topbar
+              mode={mode}
+              collapsed={collapsed}
+              onToggleSidebar={() => setCollapsed(c => !c)}
               sessionId={sessionId}
-              handleClearHistory={handleClearHistory}
+              onClearHistory={handleClearHistory}
             />
-            <div className="flex-1 overflow-y-auto">
-              {uiMode === 'chat' ? (
-                <ChatMessageList
-                  messages={messages}
-                  feedbackState={feedbackState}
-                  activeFeedbackForm={activeFeedbackForm}
-                  feedbackFormData={feedbackFormData}
-                  setFeedbackFormData={setFeedbackFormData}
-                  setActiveFeedbackForm={setActiveFeedbackForm}
-                  handleFeedback={handleFeedback}
-                  messagesEndRef={messagesEndRef}
-                  formatTime={formatTime}
-                />
-              ) : uiMode === 'quick' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full flex items-center justify-center">
-                  <QuickQuestions
-                    onQuestionClick={handleQuickQuestion}
-                    isLoading={isLoading}
-                    quickResult={quickResult}
-                    onClearResult={() => setQuickResult(null)}
-                  />
-                </div>
-              ) : uiMode === 'statistics' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <StatisticalAnalysis />
-                </div>
-              ) : uiMode === 'segmentation' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <PlayerSegmentation />
-                </div>
-              ) : uiMode === 'stuff-plus' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <StuffPlus />
-                </div>
-              ) : uiMode === 'advanced-stats' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <AdvancedStats />
-                </div>
-              ) : uiMode === 'fatigue' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <PitcherFatigue />
-                </div>
-              ) : uiMode === 'pitcher-whiff' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <PitcherWhiffPredictor />
-                </div>
-              ) : uiMode === 'hot-slump' ? (
-                <div className="h-full overflow-y-auto">
-                  <HotSlumpDashboard />
-                </div>
-              ) : uiMode === 'leaderboard' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <Leaderboard />
-                </div>
-              ) : uiMode === 'live' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full w-full">
-                  <LiveScoreboard />
-                </div>
-              ) : uiMode === 'monitor' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full w-full">
-                  <LiveMonitorBoard />
-                </div>
-              ) : uiMode === 'standings' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full w-full">
-                  <Standings />
-                </div>
-              ) : uiMode === 'player-profile' ? (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full w-full">
-                  <PlayerProfile
-                    onSearchPlayers={searchPlayers}
-                    getAuthHeaders={getAuthHeaders}
-                    getBackendURL={getBackendURL}
-                  />
-                </div>
-              ) : (
-                <div className="px-4 sm:px-6 py-6 sm:py-8 h-full">
-                  <CustomQueryBuilder
-                    isLoading={isLoading}
-                    onExecuteQuery={handleCustomQuery}
-                    customResult={customResult}
-                    onClearResult={() => setCustomResult(null)}
-                    onSearchPlayers={searchPlayers}
-                  />
-                </div>
-              )}
+
+            {/* Screen content */}
+            <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflowY: mode === "chat" ? "hidden" : "auto" }}>
+              {renderScreen()}
             </div>
-            {uiMode === 'chat' && (
-              <ChatInputArea
-                inputMessage={inputMessage}
-                setInputMessage={setInputMessage}
-                handleKeyDown={handleKeyDown}
-                isLoading={isLoading}
-                handleSendMessageStream={handleSendMessageStream}
-                isAgentMode={isAgentMode}
-                setIsAgentMode={setIsAgentMode}
-              />
-            )}
           </div>
-        </div>
+        </>
       )}
     </div>
   );
 };
 
-// メインアプリケーション（ダークモード固定）
-const App = () => {
-  return <MLBChatApp />;
-};
+const App = () => <MLBChatApp/>;
 
 export default App;

--- a/frontend/src/components/AdvancedStats.jsx
+++ b/frontend/src/components/AdvancedStats.jsx
@@ -3,7 +3,6 @@ import {
   RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
 } from 'recharts';
-import { BarChart3, User, GitCompare, TrendingUp, Search } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 
 import AdvancedStatsPitching from './AdvancedStatsPitching';
@@ -17,32 +16,63 @@ import {
   getBackendUrl,
 } from './advancedStatsConstants';
 
+// Design-system color constants for recharts (CSS vars not supported in SVG attrs)
+const C_AMBER  = "oklch(0.80 0.165 80)";
+const C_POS    = "oklch(0.78 0.165 148)";
+const C_NEG    = "oklch(0.70 0.180 28)";
+const C_PURP   = "oklch(0.72 0.150 310)";
+const C_INFO   = "oklch(0.75 0.120 240)";
+const C_RULE   = "oklch(0.28 0.008 60)";
+const C_INK3   = "oklch(0.52 0.010 75)";
+const C_INK4   = "oklch(0.40 0.010 70)";
+const CHART_COLORS = [C_AMBER, C_INFO, C_POS, C_PURP, C_NEG];
+
+// Shared input style
+const inputStyle = {
+  background: "var(--bg-2)", color: "var(--ink-0)",
+  border: "1px solid var(--rule)", padding: "5px 10px",
+  fontSize: 12.5, fontFamily: "var(--ff-text)", width: "100%",
+};
+
 // ============================================================
-// PlayerSearchDropdown — コンポーネント外に定義（フォーカス維持のため）
+// PlayerSearchDropdown
 // ============================================================
 const PlayerSearchDropdown = ({ query, setQuery, onSelect, placeholder, players }) => {
   const [isOpen, setIsOpen] = useState(false);
   const results = !query || query.length < 1
     ? []
     : players.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()));
+
   return (
-    <div className="relative">
-      <div className="flex items-center">
-        <Search className="absolute left-2.5 w-3.5 h-3.5 text-gray-500" />
-        <input
-          type="text" value={query}
-          onChange={(e) => { setQuery(e.target.value); setIsOpen(true); }}
-          placeholder={placeholder || 'Search player...'}
-          className="bg-gray-700 text-white border border-gray-600 rounded-lg pl-8 pr-3 py-1.5 text-sm w-56"
-        />
-      </div>
+    <div style={{ position: "relative" }}>
+      <input
+        type="text" value={query}
+        onChange={(e) => { setQuery(e.target.value); setIsOpen(true); }}
+        placeholder={placeholder || 'Search player...'}
+        style={{ ...inputStyle, width: 220 }}
+      />
       {isOpen && results.length > 0 && (
-        <div className="absolute z-50 mt-1 w-72 bg-gray-800 border border-gray-600 rounded-lg shadow-xl max-h-48 overflow-y-auto">
+        <div style={{
+          position: "absolute", zIndex: 50, marginTop: 2, width: 280,
+          background: "var(--bg-1)", border: "1px solid var(--rule)",
+          maxHeight: 192, overflowY: "auto",
+          boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
+        }}>
           {results.map((p) => (
-            <button key={p.id} onClick={() => { onSelect(p.id); setQuery(p.name); setIsOpen(false); }}
-              className="w-full text-left px-3 py-2 hover:bg-gray-700 transition-colors flex items-center justify-between">
-              <span className="text-white text-sm font-medium">{p.name}</span>
-              <span className="text-gray-500 text-xs">{p.team}</span>
+            <button key={p.id}
+              onClick={() => { onSelect(p.id); setQuery(p.name); setIsOpen(false); }}
+              style={{
+                width: "100%", textAlign: "left",
+                padding: "8px 12px", display: "flex",
+                justifyContent: "space-between", alignItems: "center",
+                fontSize: 12.5, color: "var(--ink-0)",
+                borderBottom: "1px solid var(--rule-dim)",
+              }}
+              onMouseEnter={e => e.currentTarget.style.background = "var(--bg-2)"}
+              onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+            >
+              <span style={{ fontWeight: 500 }}>{p.name}</span>
+              <span style={{ fontSize: 11, color: "var(--ink-3)" }}>{p.team}</span>
             </button>
           ))}
         </div>
@@ -91,7 +121,6 @@ const AdvancedStats = () => {
   const [trendsLoading, setTrendsLoading]                 = useState(false);
   const [trendsSelectedMetrics, setTrendsSelectedMetrics] = useState([]);
 
-  // category切替時にtrendsをリセット
   useEffect(() => {
     setTrendsSearch('');
     setTrendsSearchResults([]);
@@ -110,16 +139,21 @@ const AdvancedStats = () => {
   const getPlayer = (id) => players.find((p) => p.id === id);
 
   // ============================================================
-  // Shared sub-components
+  // Shared Tooltip
   // ============================================================
   const ChartTooltip = ({ active, payload }) => {
     if (!active || !payload || !payload.length) return null;
     const d = payload[0].payload;
     return (
-      <div className="bg-gray-800 border border-gray-600 rounded-lg p-3 shadow-lg">
-        <p className="text-white font-medium text-sm">{d.name || d.metricName || d.season || d.player_name}</p>
+      <div style={{
+        background: "var(--bg-1)", border: "1px solid var(--rule)",
+        padding: "8px 12px", fontSize: 11.5,
+      }}>
+        <p style={{ color: "var(--ink-0)", fontWeight: 600, marginBottom: 4 }}>
+          {d.name || d.metricName || d.season || d.player_name}
+        </p>
         {payload.map((p, i) => (
-          <p key={i} className="text-gray-300 text-xs">
+          <p key={i} style={{ color: "var(--ink-2)" }}>
             {p.name}: {typeof p.value === 'number' ? (p.value < 10 ? p.value.toFixed(2) : Math.round(p.value)) : p.value}
           </p>
         ))}
@@ -127,8 +161,13 @@ const AdvancedStats = () => {
     );
   };
 
+  // Card wrapper style
+  const card = {
+    border: "1px solid var(--rule)", background: "var(--bg-1)", padding: 16, marginBottom: 12,
+  };
+
   // ============================================================
-  // PROFILE VIEW (dummy for now)
+  // PROFILE VIEW
   // ============================================================
   const ProfileView = () => {
     const player   = getPlayer(profilePlayerId);
@@ -139,73 +178,91 @@ const AdvancedStats = () => {
     const weaknesses = profileData ? [...profileData].sort((a, b) => b.rank - a.rank).slice(0, 2) : [];
 
     return (
-      <div className="space-y-4">
-        <div className="flex flex-wrap gap-3 items-end">
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "flex-end" }}>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">{category === 'pitching' ? '投手名' : '打者名'}</label>
+            <div className="h-label" style={{ fontSize: 9, marginBottom: 6 }}>
+              {category === 'pitching' ? '投手名' : '打者名'}
+            </div>
             <PlayerSearchDropdown query={profileSearch} setQuery={setProfileSearch}
-              onSelect={setProfilePlayerId} placeholder={category === 'pitching' ? 'e.g. Ohtani' : 'e.g. Judge'}
+              onSelect={setProfilePlayerId}
+              placeholder={category === 'pitching' ? 'e.g. Ohtani' : 'e.g. Judge'}
               players={players} />
           </div>
         </div>
+
         {!profileData && (
-          <div className="text-center py-16 text-gray-500">
-            <User className="w-12 h-12 mx-auto mb-3 opacity-30" />
-            <p className="text-sm">選手を検索してプロファイルを表示</p>
+          <div style={{ textAlign: "center", padding: "48px 0", color: "var(--ink-4)" }}>
+            <div className="h-label" style={{ fontSize: 10 }}>選手を検索してプロファイルを表示</div>
           </div>
         )}
+
         {profileData && player && (
           <>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-5">
-                <h3 className="text-xl font-bold text-white">{player.name}</h3>
-                <p className="text-gray-400 text-sm">{player.team}</p>
-                <div className="mt-4 space-y-2">
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+              <div style={card}>
+                <div style={{ fontSize: 16, fontFamily: "var(--ff-head)", fontWeight: 700, color: "var(--ink-0)", letterSpacing: "0.04em" }}>
+                  {player.name}
+                </div>
+                <div style={{ fontSize: 11, color: "var(--ink-3)", marginBottom: 12 }}>{player.team}</div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                   {profileData.map((d) => (
-                    <div key={d.metricId} className="flex items-center gap-2">
-                      <span className="text-gray-400 text-xs w-6">{d.metricId}</span>
-                      <span className="text-gray-300 text-xs flex-1 truncate">{d.metricNameJp}</span>
-                      <span className={`text-sm font-bold w-12 text-right ${getScoreColor(d.score)}`}>{d.score}</span>
-                      <span className="text-gray-500 text-xs w-8">#{d.rank}</span>
-                      <div className="w-24 bg-gray-700 rounded-full h-1.5 relative">
-                        <div className="h-1.5 rounded-full absolute top-0 left-0"
-                          style={{ width: `${Math.min((d.score / 100) * 100, 100)}%`, backgroundColor: getBarFill(d.score) }} />
-                        <div className="absolute top-[-2px] h-[calc(100%+4px)] w-[2px] bg-gray-400"
-                          style={{ left: `${d.leagueAvg}%` }} title="League Avg" />
+                    <div key={d.metricId} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span className="t-mono" style={{ fontSize: 10, color: "var(--amber)", width: 28 }}>{d.metricId}</span>
+                      <span style={{ fontSize: 11.5, color: "var(--ink-2)", flex: 1 }}>{d.metricNameJp}</span>
+                      <span className="t-digit" style={{ fontSize: 12, width: 40, textAlign: "right", color: d.score >= 70 ? "var(--pos)" : d.score >= 40 ? "var(--ink-1)" : "var(--neg)" }}>
+                        {d.score}
+                      </span>
+                      <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", width: 32 }}>#{d.rank}</span>
+                      <div style={{ width: 80, height: 4, background: "var(--bg-3)", position: "relative" }}>
+                        <div style={{
+                          height: "100%", background: d.score >= 70 ? "var(--pos)" : d.score >= 40 ? "var(--amber)" : "var(--neg)",
+                          width: `${Math.min((d.score / 100) * 100, 100)}%`,
+                        }}/>
+                        <div style={{
+                          position: "absolute", top: -2, height: "calc(100% + 4px)", width: 1,
+                          background: "var(--ink-3)", left: `${d.leagueAvg}%`,
+                        }}/>
                       </div>
                     </div>
                   ))}
                 </div>
               </div>
-              <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-                <h4 className="text-sm font-medium text-gray-300 mb-2">Skill Radar</h4>
-                <ResponsiveContainer width="100%" height={300}>
+
+              <div style={card}>
+                <div className="h-label" style={{ fontSize: 9, marginBottom: 10 }}>SKILL RADAR</div>
+                <ResponsiveContainer width="100%" height={280}>
                   <RadarChart data={radarData}>
-                    <PolarGrid stroke="#374151" />
-                    <PolarAngleAxis dataKey="metric" stroke="#9ca3af" tick={{ fontSize: 11 }} />
-                    <PolarRadiusAxis angle={90} domain={[0, 100]} stroke="#374151" tick={{ fontSize: 10, fill: '#6b7280' }} />
-                    <Radar name={player.name} dataKey="score" stroke={RADAR_COLORS[0]} fill={RADAR_COLORS[0]} fillOpacity={0.25} strokeWidth={2} />
-                    <Radar name="League Avg" dataKey="leagueAvg" stroke={RADAR_COLORS[2]} fill="none" strokeDasharray="4 4" strokeWidth={1} />
-                    <Legend wrapperStyle={{ fontSize: 11, color: '#9ca3af' }} />
+                    <PolarGrid stroke={C_RULE}/>
+                    <PolarAngleAxis dataKey="metric" stroke={C_INK3} tick={{ fontSize: 10, fill: C_INK3 }}/>
+                    <PolarRadiusAxis angle={90} domain={[0, 100]} stroke={C_RULE} tick={{ fontSize: 9, fill: C_INK4 }}/>
+                    <Radar name={player.name} dataKey="score" stroke={C_AMBER} fill={C_AMBER} fillOpacity={0.2} strokeWidth={2}/>
+                    <Radar name="League Avg" dataKey="leagueAvg" stroke={C_INK3} fill="none" strokeDasharray="4 4" strokeWidth={1}/>
+                    <Legend wrapperStyle={{ fontSize: 11, color: C_INK3 }}/>
                   </RadarChart>
                 </ResponsiveContainer>
               </div>
             </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div className="bg-green-500/5 border border-green-500/20 rounded-xl p-4">
-                <h4 className="text-green-400 font-semibold text-sm mb-2">Top Strengths</h4>
+
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+              <div style={{ ...card, borderColor: "var(--pos-dim)" }}>
+                <div className="h-label" style={{ fontSize: 9, color: "var(--pos)", marginBottom: 8 }}>TOP STRENGTHS</div>
                 {strengths.map((s) => (
-                  <p key={s.metricId} className="text-gray-300 text-sm">
-                    {s.metricId} {s.metricNameJp} — <span className="text-green-400 font-medium">#{s.rank}</span> ({s.score})
-                  </p>
+                  <div key={s.metricId} style={{ fontSize: 12, color: "var(--ink-1)", marginBottom: 4 }}>
+                    <span className="t-mono" style={{ color: "var(--amber)" }}>{s.metricId}</span>
+                    {' '}{s.metricNameJp} — <span style={{ color: "var(--pos)", fontWeight: 600 }}>#{s.rank}</span>
+                    <span style={{ color: "var(--ink-3)" }}> ({s.score})</span>
+                  </div>
                 ))}
               </div>
-              <div className="bg-orange-500/5 border border-orange-500/20 rounded-xl p-4">
-                <h4 className="text-orange-400 font-semibold text-sm mb-2">Areas to Watch</h4>
+              <div style={{ ...card, borderColor: "var(--neg-dim)" }}>
+                <div className="h-label" style={{ fontSize: 9, color: "var(--neg)", marginBottom: 8 }}>AREAS TO WATCH</div>
                 {weaknesses.map((w) => (
-                  <p key={w.metricId} className="text-gray-300 text-sm">
-                    {w.metricId} {w.metricNameJp} — <span className="text-orange-400 font-medium">#{w.rank}</span> ({w.score})
-                  </p>
+                  <div key={w.metricId} style={{ fontSize: 12, color: "var(--ink-1)", marginBottom: 4 }}>
+                    <span className="t-mono" style={{ color: "var(--amber)" }}>{w.metricId}</span>
+                    {' '}{w.metricNameJp} — <span style={{ color: "var(--neg)", fontWeight: 600 }}>#{w.rank}</span>
+                    <span style={{ color: "var(--ink-3)" }}> ({w.score})</span>
+                  </div>
                 ))}
               </div>
             </div>
@@ -216,7 +273,7 @@ const AdvancedStats = () => {
   };
 
   // ============================================================
-  // COMPARE VIEW (dummy for now)
+  // COMPARE VIEW
   // ============================================================
   const CompareView = () => {
     const playerA = getPlayer(comparePlayerA);
@@ -226,84 +283,93 @@ const AdvancedStats = () => {
       : [];
 
     return (
-      <div className="space-y-4">
-        <div className="flex flex-wrap gap-4 items-end">
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 16, alignItems: "flex-end" }}>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">Player A</label>
-            <PlayerSearchDropdown query={compareSearchA} setQuery={setCompareSearchA} onSelect={setComparePlayerA} placeholder="Player A" players={players} />
+            <div className="h-label" style={{ fontSize: 9, marginBottom: 6 }}>PLAYER A</div>
+            <PlayerSearchDropdown query={compareSearchA} setQuery={setCompareSearchA} onSelect={setComparePlayerA} placeholder="Player A" players={players}/>
           </div>
-          <span className="text-gray-500 font-bold pb-1">vs</span>
+          <span className="t-mono" style={{ fontSize: 12, color: "var(--ink-4)", paddingBottom: 4 }}>vs</span>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">Player B</label>
-            <PlayerSearchDropdown query={compareSearchB} setQuery={setCompareSearchB} onSelect={setComparePlayerB} placeholder="Player B" players={players} />
+            <div className="h-label" style={{ fontSize: 9, marginBottom: 6 }}>PLAYER B</div>
+            <PlayerSearchDropdown query={compareSearchB} setQuery={setCompareSearchB} onSelect={setComparePlayerB} placeholder="Player B" players={players}/>
           </div>
         </div>
+
         {(!compareDataA || !compareDataB) && (
-          <div className="text-center py-16 text-gray-500">
-            <GitCompare className="w-12 h-12 mx-auto mb-3 opacity-30" />
-            <p className="text-sm">2選手を選択して比較</p>
+          <div style={{ textAlign: "center", padding: "48px 0", color: "var(--ink-4)" }}>
+            <div className="h-label" style={{ fontSize: 10 }}>2選手を選択して比較</div>
           </div>
         )}
+
         {compareDataA && compareDataB && playerA && playerB && (
           <>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-              <h4 className="text-sm font-medium text-gray-300 mb-2">Radar Comparison</h4>
-              <ResponsiveContainer width="100%" height={350}>
+            <div style={card}>
+              <div className="h-label" style={{ fontSize: 9, marginBottom: 10 }}>RADAR COMPARISON</div>
+              <ResponsiveContainer width="100%" height={320}>
                 <RadarChart data={radarData}>
-                  <PolarGrid stroke="#374151" />
-                  <PolarAngleAxis dataKey="metric" stroke="#9ca3af" tick={{ fontSize: 11 }} />
-                  <PolarRadiusAxis angle={90} domain={[0, 100]} stroke="#374151" tick={{ fontSize: 10, fill: '#6b7280' }} />
-                  <Radar name={playerA.name} dataKey="playerA" stroke={RADAR_COLORS[0]} fill={RADAR_COLORS[0]} fillOpacity={0.2} strokeWidth={2} />
-                  <Radar name={playerB.name} dataKey="playerB" stroke={RADAR_COLORS[1]} fill={RADAR_COLORS[1]} fillOpacity={0.2} strokeWidth={2} />
-                  <Legend wrapperStyle={{ fontSize: 11, color: '#9ca3af' }} />
+                  <PolarGrid stroke={C_RULE}/>
+                  <PolarAngleAxis dataKey="metric" stroke={C_INK3} tick={{ fontSize: 10, fill: C_INK3 }}/>
+                  <PolarRadiusAxis angle={90} domain={[0, 100]} stroke={C_RULE} tick={{ fontSize: 9, fill: C_INK4 }}/>
+                  <Radar name={playerA.name} dataKey="playerA" stroke={C_AMBER} fill={C_AMBER} fillOpacity={0.18} strokeWidth={2}/>
+                  <Radar name={playerB.name} dataKey="playerB" stroke={C_INFO}  fill={C_INFO}  fillOpacity={0.18} strokeWidth={2}/>
+                  <Legend wrapperStyle={{ fontSize: 11, color: C_INK3 }}/>
                 </RadarChart>
               </ResponsiveContainer>
             </div>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-              <h4 className="text-sm font-medium text-gray-300 mb-3">Metric Comparison</h4>
-              <div className="space-y-2">
+
+            <div style={card}>
+              <div className="h-label" style={{ fontSize: 9, marginBottom: 10 }}>METRIC COMPARISON</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                 {compareDataA.map((a, i) => {
                   const b    = compareDataB[i];
                   const diff = a.score - b.score;
                   return (
-                    <div key={a.metricId} className="flex items-center gap-2">
-                      <span className={`text-xs font-bold w-12 text-right ${diff > 0 ? 'text-blue-400' : 'text-gray-400'}`}>{a.score}</span>
-                      <div className="flex-1 flex items-center gap-1">
-                        <div className="flex-1 flex justify-end">
-                          <div className="h-3 rounded-l-full" style={{ width: `${a.score}%`, backgroundColor: RADAR_COLORS[0], opacity: 0.7 }} />
+                    <div key={a.metricId} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span className="t-digit" style={{ fontSize: 11, width: 40, textAlign: "right", color: diff > 0 ? C_AMBER : "var(--ink-4)" }}>{a.score}</span>
+                      <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 4 }}>
+                        <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
+                          <div style={{ height: 10, width: `${a.score}%`, background: C_AMBER, opacity: 0.7 }}/>
                         </div>
-                        <span className="text-gray-400 text-xs font-medium w-8 text-center">{a.metricId}</span>
-                        <div className="flex-1">
-                          <div className="h-3 rounded-r-full" style={{ width: `${b.score}%`, backgroundColor: RADAR_COLORS[1], opacity: 0.7 }} />
+                        <span className="t-mono" style={{ fontSize: 9.5, color: "var(--amber)", width: 36, textAlign: "center" }}>{a.metricId}</span>
+                        <div style={{ flex: 1 }}>
+                          <div style={{ height: 10, width: `${b.score}%`, background: C_INFO, opacity: 0.7 }}/>
                         </div>
                       </div>
-                      <span className={`text-xs font-bold w-12 ${diff < 0 ? 'text-red-400' : 'text-gray-400'}`}>{b.score}</span>
+                      <span className="t-digit" style={{ fontSize: 11, width: 40, color: diff < 0 ? C_INFO : "var(--ink-4)" }}>{b.score}</span>
                     </div>
                   );
                 })}
               </div>
-              <div className="flex justify-between mt-3 text-xs text-gray-500">
-                <span className="text-blue-400">{playerA.name}</span>
-                <span className="text-red-400">{playerB.name}</span>
+              <div style={{ display: "flex", justifyContent: "space-between", marginTop: 8 }}>
+                <span style={{ fontSize: 11, color: C_AMBER, fontWeight: 600 }}>{playerA.name}</span>
+                <span style={{ fontSize: 11, color: C_INFO,  fontWeight: 600 }}>{playerB.name}</span>
               </div>
             </div>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-              <h4 className="text-sm font-medium text-gray-300 mb-2">Summary</h4>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+
+            <div style={card}>
+              <div className="h-label" style={{ fontSize: 9, marginBottom: 10 }}>SUMMARY</div>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
                 <div>
-                  <p className="text-blue-400 text-xs font-semibold mb-1">{playerA.name} が優位</p>
+                  <div style={{ fontSize: 11, color: C_AMBER, fontWeight: 600, marginBottom: 6 }}>{playerA.name} が優位</div>
                   {compareDataA.map((a, i) => ({ ...a, diff: a.score - compareDataB[i].score }))
                     .filter((x) => x.diff > 0).sort((a, b) => b.diff - a.diff).slice(0, 3)
                     .map((x) => (
-                      <p key={x.metricId} className="text-gray-400 text-xs">{x.metricId} {x.metricNameJp} (+{x.diff.toFixed(1)})</p>
+                      <div key={x.metricId} style={{ fontSize: 11.5, color: "var(--ink-2)", marginBottom: 3 }}>
+                        <span className="t-mono" style={{ color: "var(--amber)" }}>{x.metricId}</span> {x.metricNameJp}
+                        <span style={{ color: "var(--pos)" }}> (+{x.diff.toFixed(1)})</span>
+                      </div>
                     ))}
                 </div>
                 <div>
-                  <p className="text-red-400 text-xs font-semibold mb-1">{playerB.name} が優位</p>
+                  <div style={{ fontSize: 11, color: C_INFO, fontWeight: 600, marginBottom: 6 }}>{playerB.name} が優位</div>
                   {compareDataA.map((a, i) => ({ ...a, diff: compareDataB[i].score - a.score }))
                     .filter((x) => x.diff > 0).sort((a, b) => b.diff - a.diff).slice(0, 3)
                     .map((x) => (
-                      <p key={x.metricId} className="text-gray-400 text-xs">{x.metricId} {x.metricNameJp} (+{x.diff.toFixed(1)})</p>
+                      <div key={x.metricId} style={{ fontSize: 11.5, color: "var(--ink-2)", marginBottom: 3 }}>
+                        <span className="t-mono" style={{ color: "var(--amber)" }}>{x.metricId}</span> {x.metricNameJp}
+                        <span style={{ color: "var(--pos)" }}> (+{x.diff.toFixed(1)})</span>
+                      </div>
                     ))}
                 </div>
               </div>
@@ -366,29 +432,40 @@ const AdvancedStats = () => {
     };
 
     return (
-      <div className="space-y-4">
-        <div className="flex flex-wrap gap-3 items-end">
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "flex-end" }}>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">{category === 'pitching' ? '投手名' : '打者名'}</label>
-            <div className="relative">
-              <div className="flex items-center">
-                <Search className="absolute left-2.5 w-3.5 h-3.5 text-gray-500" />
-                <input
-                  type="text" value={trendsSearch}
-                  onChange={(e) => handleSearchChange(e.target.value)}
-                  placeholder="Search player..."
-                  className="bg-gray-700 text-white border border-gray-600 rounded-lg pl-8 pr-3 py-1.5 text-sm w-56"
-                />
-              </div>
+            <div className="h-label" style={{ fontSize: 9, marginBottom: 6 }}>
+              {category === 'pitching' ? '投手名' : '打者名'}
+            </div>
+            <div style={{ position: "relative" }}>
+              <input
+                type="text" value={trendsSearch}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                placeholder="Search player..."
+                style={{ ...inputStyle, width: 220 }}
+              />
               {trendsSearchResults.length > 0 && (
-                <div className="absolute z-50 mt-1 w-72 bg-gray-800 border border-gray-600 rounded-lg shadow-xl max-h-48 overflow-y-auto">
+                <div style={{
+                  position: "absolute", zIndex: 50, marginTop: 2, width: 280,
+                  background: "var(--bg-1)", border: "1px solid var(--rule)",
+                  maxHeight: 192, overflowY: "auto",
+                }}>
                   {trendsSearchResults.map((p) => {
                     const id = p.pitcher_id ?? p.batter_id;
                     return (
                       <button key={id} onClick={() => handleSelectPlayer(id, p.player_name)}
-                        className="w-full text-left px-3 py-2 hover:bg-gray-700 transition-colors flex items-center justify-between">
-                        <span className="text-white text-sm font-medium">{p.player_name}</span>
-                        <span className="text-gray-500 text-xs">{p.team}</span>
+                        style={{
+                          width: "100%", textAlign: "left", padding: "8px 12px",
+                          display: "flex", justifyContent: "space-between",
+                          fontSize: 12.5, color: "var(--ink-0)",
+                          borderBottom: "1px solid var(--rule-dim)",
+                        }}
+                        onMouseEnter={e => e.currentTarget.style.background = "var(--bg-2)"}
+                        onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+                      >
+                        <span style={{ fontWeight: 500 }}>{p.player_name}</span>
+                        <span style={{ fontSize: 11, color: "var(--ink-3)" }}>{p.team}</span>
                       </button>
                     );
                   })}
@@ -397,62 +474,73 @@ const AdvancedStats = () => {
             </div>
           </div>
         </div>
-        <div className="flex flex-wrap gap-1.5">
-          {metrics.map((m, i) => (
-            <button key={m.id} onClick={() => toggleMetric(m.id)}
-              className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors border ${
-                trendsSelectedMetrics.includes(m.id) ? 'border-blue-500/50 text-white' : 'border-gray-600 text-gray-500 hover:text-gray-300'
-              }`}
-              style={trendsSelectedMetrics.includes(m.id) ? { backgroundColor: LINE_COLORS[i % LINE_COLORS.length] + '20' } : {}}>
-              {m.id}: {m.name}
-            </button>
-          ))}
+
+        {/* Metric toggles */}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {metrics.map((m, i) => {
+            const active = trendsSelectedMetrics.includes(m.id);
+            return (
+              <button key={m.id} onClick={() => toggleMetric(m.id)} style={{
+                padding: "3px 8px", fontSize: 10.5,
+                border: `1px solid ${active ? CHART_COLORS[i % CHART_COLORS.length] : "var(--rule)"}`,
+                color: active ? "var(--ink-0)" : "var(--ink-3)",
+                background: active ? `${CHART_COLORS[i % CHART_COLORS.length]}20` : "transparent",
+                fontFamily: "var(--ff-mono)",
+                transition: "all .1s",
+              }}>
+                {m.id}: {m.name}
+              </button>
+            );
+          })}
         </div>
+
         {trendsLoading && (
-          <div className="text-center py-16 text-gray-500">
-            <p className="text-sm">Loading...</p>
+          <div style={{ textAlign: "center", padding: "48px 0" }}>
+            <span className="think-dot"/><span className="think-dot" style={{ animationDelay: ".2s" }}/><span className="think-dot" style={{ animationDelay: ".4s" }}/>
           </div>
         )}
         {!trendsLoading && !trendsData && (
-          <div className="text-center py-16 text-gray-500">
-            <TrendingUp className="w-12 h-12 mx-auto mb-3 opacity-30" />
-            <p className="text-sm">選手を検索してトレンドを表示</p>
+          <div style={{ textAlign: "center", padding: "48px 0", color: "var(--ink-4)" }}>
+            <div className="h-label" style={{ fontSize: 10 }}>選手を検索してトレンドを表示</div>
           </div>
         )}
         {!trendsLoading && trendsData && trendsPlayerName && trendsSelectedMetrics.length > 0 && (
           <>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-              <h4 className="text-sm font-medium text-gray-300 mb-2">{trendsPlayerName} — Season Trends</h4>
-              <ResponsiveContainer width="100%" height={350}>
+            <div style={card}>
+              <div className="h-label" style={{ fontSize: 9, marginBottom: 10 }}>
+                {trendsPlayerName} — SEASON TRENDS
+              </div>
+              <ResponsiveContainer width="100%" height={320}>
                 <LineChart data={trendsData} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                  <XAxis dataKey="season" stroke="#9ca3af" tick={{ fontSize: 12 }} />
-                  <YAxis stroke="#9ca3af" tick={{ fontSize: 12 }} domain={['auto', 'auto']} />
-                  <Tooltip content={<ChartTooltip />} />
-                  <Legend wrapperStyle={{ fontSize: 11, color: '#9ca3af' }} />
+                  <CartesianGrid strokeDasharray="3 3" stroke={C_RULE}/>
+                  <XAxis dataKey="season" stroke={C_INK3} tick={{ fontSize: 11, fill: C_INK3 }}/>
+                  <YAxis stroke={C_INK3} tick={{ fontSize: 11, fill: C_INK3 }} domain={['auto', 'auto']}/>
+                  <Tooltip content={<ChartTooltip/>}/>
+                  <Legend wrapperStyle={{ fontSize: 11, color: C_INK3 }}/>
                   {trendsSelectedMetrics.map((metricId, i) => {
                     const m = metrics.find((x) => x.id === metricId);
                     return (
                       <Line key={metricId} type="monotone" dataKey={metricId}
                         name={`${metricId}: ${m?.nameJp || m?.name}`}
-                        stroke={LINE_COLORS[i % LINE_COLORS.length]} strokeWidth={2}
-                        dot={{ r: 4 }} activeDot={{ r: 6 }} connectNulls />
+                        stroke={CHART_COLORS[i % CHART_COLORS.length]} strokeWidth={2}
+                        dot={{ r: 4 }} activeDot={{ r: 6 }} connectNulls/>
                     );
                   })}
                 </LineChart>
               </ResponsiveContainer>
             </div>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-              <h4 className="text-sm font-medium text-gray-300 mb-3">Year-over-Year</h4>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
+
+            <div style={card}>
+              <div className="h-label" style={{ fontSize: 9, marginBottom: 10 }}>YEAR-OVER-YEAR</div>
+              <div style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
                   <thead>
-                    <tr className="border-b border-gray-700">
-                      <th className="text-left text-gray-400 py-2 px-3">Metric</th>
+                    <tr className="rule-b">
+                      <th style={{ textAlign: "left", padding: "6px 10px", color: "var(--ink-3)", fontWeight: 600, letterSpacing: "0.1em", fontSize: 9.5 }}>METRIC</th>
                       {trendsData.map((row) => (
-                        <th key={row.season} className="text-right text-gray-400 py-2 px-3">{row.season}</th>
+                        <th key={row.season} style={{ textAlign: "right", padding: "6px 10px", color: "var(--ink-3)", fontWeight: 600, fontSize: 9.5 }}>{row.season}</th>
                       ))}
-                      <th className="text-right text-gray-400 py-2 px-3">YoY</th>
+                      <th style={{ textAlign: "right", padding: "6px 10px", color: "var(--ink-3)", fontWeight: 600, fontSize: 9.5 }}>YoY</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -464,14 +552,17 @@ const AdvancedStats = () => {
                       const prev   = trendsData[trendsData.length - 2]?.[metricId];
                       const yoy    = latest != null && prev != null ? latest - prev : null;
                       return (
-                        <tr key={metricId} className="border-b border-gray-700/50">
-                          <td className="py-2 px-3 text-gray-300">{metricId} {m?.nameJp}</td>
+                        <tr key={metricId} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                          <td style={{ padding: "7px 10px", color: "var(--ink-1)" }}>
+                            <span className="t-mono" style={{ color: "var(--amber)", marginRight: 6 }}>{metricId}</span>
+                            {m?.nameJp}
+                          </td>
                           {trendsData.map((row) => (
-                            <td key={row.season} className="py-2 px-3 text-right text-gray-300">
+                            <td key={row.season} style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-1)", fontFamily: "var(--ff-mono)" }}>
                               {fmt(row[metricId])}
                             </td>
                           ))}
-                          <td className={`py-2 px-3 text-right font-medium ${yoy > 0 ? 'text-green-400' : yoy < 0 ? 'text-red-400' : 'text-gray-400'}`}>
+                          <td style={{ padding: "7px 10px", textAlign: "right", fontFamily: "var(--ff-mono)", fontWeight: 600, color: yoy > 0 ? "var(--pos)" : yoy < 0 ? "var(--neg)" : "var(--ink-4)" }}>
                             {yoy != null ? `${yoy > 0 ? '+' : ''}${yoy.toFixed(dec)}` : '—'}
                           </td>
                         </tr>
@@ -491,60 +582,63 @@ const AdvancedStats = () => {
   // Main Render
   // ============================================================
   const SUB_TABS = [
-    { key: 'rankings', label: 'Rankings',  icon: BarChart3   },
-    { key: 'profile',  label: 'Profile',   icon: User        },
-    { key: 'compare',  label: 'Compare',   icon: GitCompare  },
-    { key: 'trends',   label: 'Trends',    icon: TrendingUp  },
+    { key: 'rankings', label: 'RANKINGS' },
+    { key: 'profile',  label: 'PROFILE'  },
+    { key: 'compare',  label: 'COMPARE'  },
+    { key: 'trends',   label: 'TRENDS'   },
   ];
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <div className="p-2 bg-purple-600/20 rounded-lg">
-          <BarChart3 className="w-6 h-6 text-purple-400" />
-        </div>
-        <div>
-          <h2 className="text-xl font-bold text-white">Advanced Stats Rankings</h2>
-          <p className="text-sm text-gray-400">Statcastベースの高度投手・打者技術プロファイル</p>
-        </div>
-      </div>
-
-      {/* Controls Row */}
-      <div className="flex flex-wrap gap-3 items-center">
-        <div className="flex gap-1 bg-gray-800 rounded-lg p-1 border border-gray-700 w-fit">
-          {SUB_TABS.map((tab) => {
-            const Icon = tab.icon;
-            return (
-              <button key={tab.key} onClick={() => setView(tab.key)}
-                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors flex items-center gap-1.5 ${
-                  view === tab.key ? 'bg-gray-600 text-white' : 'text-gray-400 hover:text-gray-200'
-                }`}>
-                <Icon className="w-3.5 h-3.5" /> {tab.label}
-              </button>
-            );
-          })}
+    <div style={{ display: "flex", flexDirection: "column", gap: 0, height: "100%" }}>
+      {/* Filter bar */}
+      <div className="rule-b" style={{ padding: "10px 0 10px", display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10, flexShrink: 0 }}>
+        {/* Sub-tabs */}
+        <div style={{ display: "flex" }}>
+          {SUB_TABS.map((tab) => (
+            <button key={tab.key} onClick={() => setView(tab.key)} style={{
+              padding: "5px 12px", fontSize: 10.5,
+              fontFamily: "var(--ff-mono)", letterSpacing: "0.08em", fontWeight: 600,
+              border: "1px solid var(--rule)",
+              marginRight: -1,
+              color: view === tab.key ? "var(--bg-0)" : "var(--ink-2)",
+              background: view === tab.key ? "var(--amber)" : "transparent",
+              transition: "all .1s",
+            }}>{tab.label}</button>
+          ))}
         </div>
 
-        <div className="flex rounded-lg overflow-hidden border border-gray-600">
-          <button onClick={() => setCategory('pitching')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              category === 'pitching'
-                ? 'bg-blue-600 text-white shadow-[0_0_12px_rgba(59,130,246,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}>Pitching</button>
-          <button onClick={() => setCategory('batting')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              category === 'batting'
-                ? 'bg-purple-600 text-white shadow-[0_0_12px_rgba(147,51,234,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}>Batting</button>
+        <div style={{ width: 1, height: 20, background: "var(--rule)" }}/>
+
+        {/* Category */}
+        <div style={{ display: "flex" }}>
+          <button onClick={() => setCategory('pitching')} style={{
+            padding: "5px 12px", fontSize: 10.5,
+            fontFamily: "var(--ff-mono)", letterSpacing: "0.06em", fontWeight: 600,
+            border: "1px solid var(--rule)", marginRight: -1,
+            color: category === 'pitching' ? "var(--bg-0)" : "var(--ink-2)",
+            background: category === 'pitching' ? "var(--amber)" : "transparent",
+            transition: "all .1s",
+          }}>PITCHING</button>
+          <button onClick={() => setCategory('batting')} style={{
+            padding: "5px 12px", fontSize: 10.5,
+            fontFamily: "var(--ff-mono)", letterSpacing: "0.06em", fontWeight: 600,
+            border: "1px solid var(--rule)",
+            color: category === 'batting' ? "var(--bg-0)" : "var(--ink-2)",
+            background: category === 'batting' ? "var(--amber)" : "transparent",
+            transition: "all .1s",
+          }}>BATTING</button>
         </div>
 
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-gray-400">Season</label>
-          <select value={season} onChange={(e) => setSeason(Number(e.target.value))}
-            className="bg-gray-700 text-white border border-gray-600 rounded-lg px-3 py-1.5 text-sm">
+        <div style={{ width: 1, height: 20, background: "var(--rule)" }}/>
+
+        {/* Season */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span className="h-label" style={{ fontSize: 9 }}>SEASON</span>
+          <select value={season} onChange={(e) => setSeason(Number(e.target.value))} style={{
+            background: "var(--bg-2)", color: "var(--ink-0)",
+            border: "1px solid var(--rule)", padding: "4px 8px",
+            fontSize: 12, fontFamily: "var(--ff-mono)",
+          }}>
             {[2026, 2025, 2024, 2023, 2022, 2021].map((y) => (
               <option key={y} value={y}>{y}</option>
             ))}
@@ -553,15 +647,17 @@ const AdvancedStats = () => {
       </div>
 
       {/* Content */}
-      {view === 'rankings' && category === 'pitching' && (
-        <AdvancedStatsPitching season={season} getAuthHeaders={getAuthHeaders} BACKEND_URL={BACKEND_URL} />
-      )}
-      {view === 'rankings' && category === 'batting' && (
-        <AdvancedStatsBatting season={season} getAuthHeaders={getAuthHeaders} BACKEND_URL={BACKEND_URL} />
-      )}
-      {view === 'profile'  && ProfileView()}
-      {view === 'compare'  && CompareView()}
-      {view === 'trends'   && TrendsView()}
+      <div style={{ flex: 1, overflowY: "auto", paddingTop: 16 }}>
+        {view === 'rankings' && category === 'pitching' && (
+          <AdvancedStatsPitching season={season} getAuthHeaders={getAuthHeaders} BACKEND_URL={BACKEND_URL}/>
+        )}
+        {view === 'rankings' && category === 'batting' && (
+          <AdvancedStatsBatting season={season} getAuthHeaders={getAuthHeaders} BACKEND_URL={BACKEND_URL}/>
+        )}
+        {view === 'profile'  && ProfileView()}
+        {view === 'compare'  && CompareView()}
+        {view === 'trends'   && TrendsView()}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/AdvancedStatsDesign.jsx
+++ b/frontend/src/components/AdvancedStatsDesign.jsx
@@ -1,0 +1,351 @@
+import React, { useState } from 'react';
+
+// ============================================================
+// Advanced Stats — New Design (仮作成・モックデータ)
+// Design: Bloomberg Terminal × ESPN Statcast
+// ============================================================
+
+const PITCHERS = [
+  { r: 1,  n: "P. Skenes",   tm: "PIT", stuff: 142, loc: 108, pitch: 128, ip: 121.1, k9: 11.4, era: 2.12, whip: 0.96, delta: "+3"  },
+  { r: 2,  n: "T. Skubal",   tm: "DET", stuff: 138, loc: 112, pitch: 126, ip: 168.0, k9: 10.9, era: 2.61, whip: 0.89, delta: "-1"  },
+  { r: 3,  n: "E. Crochet",  tm: "CWS", stuff: 136, loc: 102, pitch: 120, ip: 146.1, k9: 12.8, era: 3.42, whip: 1.08, delta: "+2"  },
+  { r: 4,  n: "C. Sale",     tm: "ATL", stuff: 131, loc: 109, pitch: 122, ip: 159.0, k9: 11.6, era: 2.42, whip: 1.01, delta: "0"   },
+  { r: 5,  n: "D. Cease",    tm: "SD",  stuff: 130, loc: 101, pitch: 117, ip: 171.0, k9: 11.2, era: 3.18, whip: 1.09, delta: "+1"  },
+  { r: 6,  n: "G. Cole",     tm: "NYY", stuff: 128, loc: 114, pitch: 124, ip: 88.2,  k9: 9.6,  era: 3.54, whip: 1.13, delta: "-2"  },
+  { r: 7,  n: "T. Glasnow",  tm: "LAD", stuff: 127, loc: 98,  pitch: 115, ip: 121.0, k9: 12.1, era: 3.52, whip: 1.02, delta: "+4"  },
+  { r: 8,  n: "Z. Wheeler",  tm: "PHI", stuff: 125, loc: 118, pitch: 124, ip: 175.2, k9: 10.5, era: 2.89, whip: 0.95, delta: "0"   },
+  { r: 9,  n: "L. Webb",     tm: "SF",  stuff: 119, loc: 116, pitch: 121, ip: 176.0, k9: 8.2,  era: 3.41, whip: 1.17, delta: "+1"  },
+  { r: 10, n: "S. Yamamoto", tm: "LAD", stuff: 118, loc: 107, pitch: 116, ip: 78.2,  k9: 10.3, era: 3.02, whip: 1.07, delta: "+6"  },
+];
+
+const ARSENAL_SKENES = [
+  { t: "FF", name: "Four-Seam", mph: 99.1, spin: 2412, iVB:  18.4, HB:  -6.2, stf: 148, usage: 48 },
+  { t: "SL", name: "Sweeper",   mph: 88.2, spin: 2914, iVB:   3.1, HB:  14.5, stf: 136, usage: 22 },
+  { t: "SI", name: "Sinker",    mph: 98.4, spin: 2180, iVB:  10.1, HB: -15.2, stf: 130, usage: 14 },
+  { t: "CH", name: "Splinker",  mph: 95.0, spin: 1420, iVB:   2.8, HB: -12.8, stf: 158, usage: 11 },
+  { t: "CB", name: "Curveball", mph: 83.4, spin: 2920, iVB: -12.4, HB:  10.1, stf: 118, usage:  5 },
+];
+
+const FILTER_TABS = ["ALL", "SP", "RP", "L/R", "L/L", "R/R", "R/L"];
+
+const HEADLINE_METRICS = [
+  { k: "LEAGUE STUFF+ MED", v: "98",   d: "±14",   tint: "var(--ink-0)" },
+  { k: "TOP 10% THRESHOLD", v: "118",  d: "N=9",   tint: "var(--amber)" },
+  { k: "STUFF+ ↔ xERA r²",  v: "0.61", d: "STRONG", tint: "var(--pos)"  },
+  { k: "ROOKIE PEAK",       v: "142",  d: "SKENES", tint: "var(--amber)" },
+];
+
+const COLOR_KEY = [
+  { v: "130+",    l: "ELITE",     c: "var(--amber)" },
+  { v: "115–129", l: "ABOVE AVG", c: "var(--pos)"   },
+  { v: "100–114", l: "AVERAGE",   c: "var(--ink-1)" },
+  { v: "90–99",   l: "BELOW",     c: "var(--ink-3)" },
+  { v: "<90",     l: "POOR",      c: "var(--neg)"   },
+];
+
+const MOST_IMPROVED = [
+  { n: "S. Yamamoto", d: "+11", f: "LAD" },
+  { n: "H. Greene",   d: "+9",  f: "CIN" },
+  { n: "T. Glasnow",  d: "+7",  f: "LAD" },
+  { n: "J. Ryan",     d: "+6",  f: "MIN" },
+  { n: "Sp. Strider", d: "+5",  f: "ATL" },
+];
+
+// Stuff+ → color
+const stuffColor = (v) => {
+  if (v >= 130) return "var(--amber)";
+  if (v >= 115) return "var(--pos)";
+  if (v >= 100) return "var(--ink-1)";
+  if (v >= 90)  return "var(--ink-3)";
+  return "var(--neg)";
+};
+
+// ============================================================
+// Leaderboard table
+// ============================================================
+const LeaderboardTable = ({ pitchers }) => (
+  <div style={{ border: "1px solid var(--rule)" }}>
+    {/* Header */}
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "32px 1fr 48px 72px 72px 72px 60px 54px 58px 58px 44px",
+      padding: "8px 14px", background: "var(--bg-1)",
+      fontSize: 9.5, letterSpacing: "0.12em", color: "var(--ink-2)", fontWeight: 600,
+    }} className="rule-b">
+      <div>#</div>
+      <div>PITCHER</div>
+      <div>TM</div>
+      <div style={{ textAlign: "right", color: "var(--amber)" }}>STUFF+</div>
+      <div style={{ textAlign: "right" }}>LOC+</div>
+      <div style={{ textAlign: "right" }}>PITCH+</div>
+      <div style={{ textAlign: "right" }}>IP</div>
+      <div style={{ textAlign: "right" }}>K/9</div>
+      <div style={{ textAlign: "right" }}>ERA</div>
+      <div style={{ textAlign: "right" }}>WHIP</div>
+      <div style={{ textAlign: "right" }}>Δ</div>
+    </div>
+
+    {pitchers.map((p, i) => {
+      const featured = p.r === 1;
+      return (
+        <div key={p.r} style={{
+          display: "grid",
+          gridTemplateColumns: "32px 1fr 48px 72px 72px 72px 60px 54px 58px 58px 44px",
+          padding: "10px 14px",
+          fontFamily: "var(--ff-mono)", fontSize: 12,
+          background: featured
+            ? "oklch(from var(--amber) l c h / 0.06)"
+            : i % 2 ? "var(--bg-1)" : "transparent",
+          borderBottom: i < pitchers.length - 1 ? "1px solid var(--rule-dim)" : "none",
+          alignItems: "center",
+          cursor: "pointer",
+          transition: "background .1s",
+        }}
+          onMouseEnter={e => { if (!featured) e.currentTarget.style.background = "var(--bg-2)"; }}
+          onMouseLeave={e => { if (!featured) e.currentTarget.style.background = i % 2 ? "var(--bg-1)" : "transparent"; }}
+        >
+          <div style={{ color: featured ? "var(--amber)" : "var(--ink-4)", fontSize: 11, fontWeight: 700 }}>{p.r}</div>
+          <div style={{ color: featured ? "var(--amber)" : "var(--ink-0)", fontWeight: 600, fontFamily: "var(--ff-text)" }}>{p.n}</div>
+          <div style={{ color: "var(--ink-3)", fontSize: 11 }}>{p.tm}</div>
+
+          {/* Stuff+ with bar */}
+          <div style={{ textAlign: "right", position: "relative" }}>
+            <div style={{
+              position: "absolute", left: 0, right: 0, top: 0, bottom: 0,
+              display: "flex", alignItems: "center", justifyContent: "flex-end", paddingRight: 2,
+            }}>
+              <div style={{
+                width: `${(p.stuff - 80) * 1.4}%`, height: 14,
+                background: stuffColor(p.stuff), opacity: 0.18,
+              }}/>
+            </div>
+            <span style={{ position: "relative", color: stuffColor(p.stuff), fontWeight: 700, fontSize: 13 }}>{p.stuff}</span>
+          </div>
+
+          <div style={{ textAlign: "right", color: stuffColor(p.loc) }}>{p.loc}</div>
+          <div style={{ textAlign: "right", color: stuffColor(p.pitch) }}>{p.pitch}</div>
+          <div style={{ textAlign: "right", color: "var(--ink-1)" }}>{p.ip.toFixed(1)}</div>
+          <div style={{ textAlign: "right", color: "var(--ink-1)" }}>{p.k9.toFixed(1)}</div>
+          <div style={{ textAlign: "right", color: "var(--ink-0)" }}>{p.era.toFixed(2)}</div>
+          <div style={{ textAlign: "right", color: "var(--ink-1)" }}>{p.whip.toFixed(2)}</div>
+          <div style={{ textAlign: "right", fontSize: 10, color: p.delta.startsWith("+") ? "var(--pos)" : p.delta.startsWith("-") ? "var(--neg)" : "var(--ink-4)" }}>
+            {p.delta}
+          </div>
+        </div>
+      );
+    })}
+  </div>
+);
+
+// ============================================================
+// Arsenal detail panel
+// ============================================================
+const ArsenalDetail = ({ arsenal }) => {
+  const W = 300, H = 220;
+
+  return (
+    <div style={{ border: "1px solid var(--rule)" }}>
+      <div className="rule-b" style={{ padding: "10px 16px", background: "var(--bg-1)", display: "flex", alignItems: "center", gap: 10 }}>
+        <span className="h-label" style={{ color: "var(--ink-0)" }}>ARSENAL DETAIL · SKENES, P. (PIT)</span>
+        <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>5 PITCH TYPES · 2,134 PITCHES</span>
+        <div style={{ flex: 1 }}/>
+        <span className="t-mono" style={{ fontSize: 10, color: "var(--amber)" }}>PEAK: SPLINKER Stf+ 158</span>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr" }}>
+        {/* Movement chart */}
+        <div style={{ padding: 16, borderRight: "1px solid var(--rule)" }}>
+          <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginBottom: 8 }}>
+            MOVEMENT PROFILE · iVB vs HB (in)
+          </div>
+          <svg viewBox={`0 0 ${W} ${H}`} style={{ width: "100%", display: "block" }}>
+            {/* axes */}
+            <line x1="150" y1="10" x2="150" y2="210" stroke="var(--rule-dim)"/>
+            <line x1="20" y1="110" x2="290" y2="110" stroke="var(--rule-dim)"/>
+            {/* gridlines */}
+            {[-15, -10, -5, 5, 10, 15].map(v => (
+              <g key={v}>
+                <line x1={150 + v * 8} y1="10" x2={150 + v * 8} y2="210" stroke="var(--rule-dim)" strokeDasharray="1 3" strokeWidth="0.5"/>
+                <line x1="20" y1={110 - v * 6} x2="290" y2={110 - v * 6} stroke="var(--rule-dim)" strokeDasharray="1 3" strokeWidth="0.5"/>
+              </g>
+            ))}
+            <text x="288" y="108" fill="var(--ink-4)" fontSize="8" textAnchor="end" fontFamily="var(--ff-mono)">HB →</text>
+            <text x="152" y="16" fill="var(--ink-4)" fontSize="8" fontFamily="var(--ff-mono)">↑ iVB</text>
+            {/* bubbles */}
+            {arsenal.map(a => {
+              const cx = 150 + a.HB * 8;
+              const cy = 110 - a.iVB * 6;
+              const r  = 6 + a.usage / 4;
+              return (
+                <g key={a.t}>
+                  <circle cx={cx} cy={cy} r={r} fill={stuffColor(a.stf)} opacity="0.25" stroke={stuffColor(a.stf)} strokeWidth="1.5"/>
+                  <text x={cx} y={cy + 3} fill={stuffColor(a.stf)} fontSize="8.5" fontWeight="700" textAnchor="middle" fontFamily="var(--ff-mono)">{a.t}</text>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+
+        {/* Arsenal table */}
+        <div>
+          <div style={{
+            display: "grid", gridTemplateColumns: "48px 1fr 52px 52px 52px",
+            padding: "7px 12px", fontSize: 9, letterSpacing: "0.1em", color: "var(--ink-3)", fontWeight: 600,
+          }} className="rule-b">
+            <div>TYPE</div>
+            <div>NAME</div>
+            <div style={{ textAlign: "right" }}>MPH</div>
+            <div style={{ textAlign: "right" }}>USE%</div>
+            <div style={{ textAlign: "right", color: "var(--amber)" }}>Stf+</div>
+          </div>
+          {arsenal.map((a, i) => (
+            <div key={a.t} style={{
+              display: "grid", gridTemplateColumns: "48px 1fr 52px 52px 52px",
+              padding: "10px 12px", fontFamily: "var(--ff-mono)", fontSize: 12,
+              borderBottom: i < arsenal.length - 1 ? "1px solid var(--rule-dim)" : "none",
+              alignItems: "center",
+            }}>
+              <div style={{ color: stuffColor(a.stf), fontWeight: 700 }}>{a.t}</div>
+              <div style={{ color: "var(--ink-1)", fontFamily: "var(--ff-text)" }}>{a.name}</div>
+              <div style={{ textAlign: "right", color: "var(--ink-1)" }}>{a.mph.toFixed(1)}</div>
+              <div style={{ textAlign: "right", color: "var(--ink-2)" }}>{a.usage}</div>
+              <div style={{ textAlign: "right", color: stuffColor(a.stf), fontWeight: 700 }}>{a.stf}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================
+// Right sidebar
+// ============================================================
+const RightPanel = () => (
+  <aside className="rule-l" style={{ width: 260, flexShrink: 0, overflowY: "auto" }}>
+    {/* Color key */}
+    <div className="rule-b" style={{ padding: "12px 16px" }}>
+      <div className="h-label" style={{ marginBottom: 10 }}>STUFF+ COLOR KEY</div>
+      {COLOR_KEY.map(l => (
+        <div key={l.v} style={{ display: "flex", alignItems: "center", gap: 10, padding: "5px 0", fontSize: 11 }}>
+          <span style={{ width: 16, height: 4, background: l.c, flexShrink: 0 }}/>
+          <span className="t-mono" style={{ color: "var(--ink-0)", width: 72 }}>{l.v}</span>
+          <span className="h-label" style={{ fontSize: 9.5, color: l.c }}>{l.l}</span>
+        </div>
+      ))}
+      <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", marginTop: 10, lineHeight: 1.6 }}>
+        100 = League avg · SD=10<br/>
+        Source: Statcast pitch-level
+      </div>
+    </div>
+
+    {/* Model info */}
+    <div className="rule-b" style={{ padding: "12px 16px" }}>
+      <div className="h-label" style={{ marginBottom: 8 }}>MODEL · STUFF+ v3.1</div>
+      <div style={{ fontSize: 11.5, color: "var(--ink-1)", lineHeight: 1.6 }}>
+        投球品質の期待ランRVを、
+        <span className="t-mono" style={{ color: "var(--amber)" }}>GBDT</span>
+        で球種・球速・回転・リリース位置から予測。
+        <span className="t-mono" style={{ color: "var(--amber)" }}> Loc+</span>はコース別xwOBA。
+        <span className="t-mono" style={{ color: "var(--amber)" }}> Pitch+</span>は総合指標
+        (0.6×Stuff + 0.4×Loc)。
+      </div>
+    </div>
+
+    {/* Most improved */}
+    <div style={{ padding: "12px 16px" }}>
+      <div className="h-label" style={{ marginBottom: 8 }}>MOST IMPROVED · 30D</div>
+      {MOST_IMPROVED.map((p, i) => (
+        <div key={i} style={{
+          display: "grid", gridTemplateColumns: "1fr 38px 40px",
+          padding: "7px 0", fontSize: 11.5,
+          borderBottom: "1px dashed var(--rule-dim)", alignItems: "center",
+        }}>
+          <span style={{ color: "var(--ink-0)" }}>{p.n}</span>
+          <span className="t-mono" style={{ color: "var(--ink-3)", fontSize: 10 }}>{p.f}</span>
+          <span className="t-mono" style={{ color: "var(--pos)", textAlign: "right", fontWeight: 700 }}>{p.d}</span>
+        </div>
+      ))}
+    </div>
+  </aside>
+);
+
+// ============================================================
+// Main component
+// ============================================================
+const AdvancedStatsDesign = () => {
+  const [activeFilter, setActiveFilter] = useState(0);
+
+  return (
+    <div style={{ flex: 1, display: "flex", minHeight: 0, background: "var(--bg-0)", overflow: "hidden" }}>
+      {/* Main content */}
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        {/* Filter bar */}
+        <div className="rule-b" style={{
+          padding: "10px 24px", display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap",
+        }}>
+          <span className="h-label" style={{ color: "var(--ink-0)" }}>
+            STUFF+ LEADERBOARD · 2024 SEASON
+          </span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>
+            MIN 50 IP · N=84 PITCHERS
+          </span>
+          <div style={{ flex: 1 }}/>
+          {FILTER_TABS.map((x, i) => (
+            <button
+              key={x}
+              onClick={() => setActiveFilter(i)}
+              style={{
+                fontSize: 10.5, padding: "4px 9px",
+                border: "1px solid var(--rule)",
+                color: activeFilter === i ? "var(--bg-0)" : "var(--ink-2)",
+                background: activeFilter === i ? "var(--amber)" : "transparent",
+                fontFamily: "var(--ff-mono)", letterSpacing: "0.06em", fontWeight: 600,
+                transition: "all .1s",
+              }}
+            >{x}</button>
+          ))}
+          <button className="t-mono" style={{
+            fontSize: 10, padding: "4px 10px",
+            border: "1px solid var(--rule-hi)", color: "var(--ink-1)", letterSpacing: "0.08em",
+          }}>
+            EXPORT CSV ↓
+          </button>
+        </div>
+
+        {/* Headline metrics */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 0 }} className="rule-b">
+          {HEADLINE_METRICS.map((m, i) => (
+            <div key={m.k} style={{
+              padding: "14px 18px",
+              borderRight: i < 3 ? "1px solid var(--rule)" : "none",
+            }}>
+              <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginBottom: 4 }}>{m.k}</div>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+                <span style={{
+                  fontSize: 28, fontFamily: "var(--ff-head)", fontWeight: 700,
+                  color: m.tint, lineHeight: 1,
+                }}>{m.v}</span>
+                <span className="t-mono" style={{ fontSize: 10.5, color: "var(--ink-3)" }}>{m.d}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Leaderboard */}
+        <div style={{ padding: "16px 24px" }}>
+          <LeaderboardTable pitchers={PITCHERS}/>
+        </div>
+
+        {/* Arsenal detail */}
+        <div style={{ padding: "0 24px 24px" }}>
+          <ArsenalDetail arsenal={ARSENAL_SKENES}/>
+        </div>
+      </div>
+
+      <RightPanel/>
+    </div>
+  );
+};
+
+export default AdvancedStatsDesign;

--- a/frontend/src/components/HotSlumpDashboard.jsx
+++ b/frontend/src/components/HotSlumpDashboard.jsx
@@ -22,34 +22,47 @@ const slumpFlagsFn = (p) => [
   { key: `is_slump_hard_hit_${p}days`, label: 'HH' },
 ];
 
-const RankRow = ({ rank, player, metricDef, period, flagDefs, accentColor }) => {
+const HOT_BADGE  = { background: "oklch(0.80 0.165 80 / 0.20)", color: "oklch(0.80 0.165 80)", border: "1px solid oklch(0.80 0.165 80 / 0.40)" };
+const SLUMP_BADGE = { background: "oklch(0.75 0.12 240 / 0.20)", color: "oklch(0.75 0.12 240)", border: "1px solid oklch(0.75 0.12 240 / 0.40)" };
+
+const TH = ({ children, align = "left" }) => (
+  <th style={{
+    padding: "6px 10px", textAlign: align, fontSize: 10,
+    color: "var(--ink-3)", fontFamily: "var(--ff-mono)",
+    fontWeight: 600, letterSpacing: "0.08em",
+    borderBottom: "1px solid var(--rule)",
+    background: "var(--bg-2)",
+    textTransform: "uppercase",
+  }}>{children}</th>
+);
+
+const RankRow = ({ rank, player, metricDef, period, flagDefs, isHot }) => {
   const col = metricDef.colFn(period);
   const value = metricDef.fmt(player[col]);
   const activeBadges = flagDefs.filter((f) => player[f.key]);
+  const accentColor = isHot ? 'oklch(0.80 0.165 80)' : 'oklch(0.75 0.12 240)';
+  const badgeStyle = isHot ? HOT_BADGE : SLUMP_BADGE;
 
   return (
-    <tr className="border-b border-gray-700 hover:bg-gray-750 transition-colors">
-      <td className="py-2 px-3 text-gray-400 text-sm w-8">{rank}</td>
-      <td className="py-2 px-3">
-        <div className="flex flex-col">
-          <span className="text-white text-sm font-medium">{player.batter_name}</span>
-          <span className="text-gray-400 text-xs">{player.team ?? '—'}</span>
-        </div>
+    <tr style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+      <td className="t-mono" style={{ padding: "7px 10px", color: "var(--ink-4)", fontSize: 11, width: 32 }}>
+        {rank}
       </td>
-      <td className="py-2 px-3 text-right">
-        <span className={`text-sm font-semibold ${accentColor}`}>{value}</span>
+      <td style={{ padding: "7px 10px" }}>
+        <div style={{ color: "var(--ink-0)", fontSize: 12, fontWeight: 600 }}>{player.batter_name}</div>
+        <div className="t-mono" style={{ color: "var(--ink-4)", fontSize: 10 }}>{player.team ?? '—'}</div>
       </td>
-      <td className="py-2 px-3">
-        <div className="flex gap-1 flex-wrap justify-end">
+      <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: accentColor, fontWeight: 700, fontSize: 13 }}>
+        {value}
+      </td>
+      <td style={{ padding: "7px 10px" }}>
+        <div style={{ display: "flex", gap: 4, flexWrap: "wrap", justifyContent: "flex-end" }}>
           {activeBadges.map((f) => (
-            <span
-              key={f.key}
-              className={`text-xs px-1.5 py-0.5 rounded font-medium ${
-                accentColor === 'text-orange-400'
-                  ? 'bg-orange-900/50 text-orange-300'
-                  : 'bg-blue-900/50 text-blue-300'
-              }`}
-            >
+            <span key={f.key} style={{
+              ...badgeStyle,
+              fontSize: 10, padding: "1px 5px",
+              fontFamily: "var(--ff-mono)", fontWeight: 600,
+            }}>
               {f.label}
             </span>
           ))}
@@ -59,28 +72,32 @@ const RankRow = ({ rank, player, metricDef, period, flagDefs, accentColor }) => 
   );
 };
 
-const RankTable = ({ title, emoji, players, metricDef, period, flagDefs, accentColor, isLoading }) => (
-  <div className="flex-1 min-w-0">
-    <h3 className="text-base font-semibold text-white mb-3 flex items-center gap-2">
+const RankTable = ({ title, emoji, players, metricDef, period, flagDefs, isHot, isLoading }) => (
+  <div style={{ flex: 1, minWidth: 0 }}>
+    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
       <span>{emoji}</span>
-      <span>{title}</span>
+      <span className="h-display" style={{ fontSize: 14 }}>{title}</span>
       {!isLoading && (
-        <span className="ml-1 text-xs text-gray-400 font-normal">({players.length}人)</span>
+        <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>({players.length}人)</span>
       )}
-    </h3>
-    <div className="bg-gray-800 rounded-lg overflow-hidden">
+    </div>
+    <div style={{ border: "1px solid var(--rule)", background: "var(--bg-1)" }}>
       {isLoading ? (
-        <div className="py-8 text-center text-gray-400 text-sm">読み込み中...</div>
+        <div style={{ padding: "24px 0", textAlign: "center", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
+          <span className="think-dot"/>
+          <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+          <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+        </div>
       ) : players.length === 0 ? (
-        <div className="py-8 text-center text-gray-400 text-sm">該当選手なし</div>
+        <div style={{ padding: "24px 0", textAlign: "center", color: "var(--ink-4)", fontSize: 12 }}>該当選手なし</div>
       ) : (
-        <table className="w-full">
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
           <thead>
-            <tr className="border-b border-gray-700">
-              <th className="py-2 px-3 text-left text-xs text-gray-400 font-medium w-8">#</th>
-              <th className="py-2 px-3 text-left text-xs text-gray-400 font-medium">選手</th>
-              <th className="py-2 px-3 text-right text-xs text-gray-400 font-medium">{metricDef.label}</th>
-              <th className="py-2 px-3 text-right text-xs text-gray-400 font-medium">該当指標</th>
+            <tr>
+              <TH>#</TH>
+              <TH>選手</TH>
+              <TH align="right">{metricDef.label}</TH>
+              <TH align="right">指標</TH>
             </tr>
           </thead>
           <tbody>
@@ -92,7 +109,7 @@ const RankTable = ({ title, emoji, players, metricDef, period, flagDefs, accentC
                 metricDef={metricDef}
                 period={period}
                 flagDefs={flagDefs}
-                accentColor={accentColor}
+                isHot={isHot}
               />
             ))}
           </tbody>
@@ -123,7 +140,6 @@ const HotSlumpDashboard = () => {
     };
   };
 
-  // period が変わったら日付リストを再取得
   useEffect(() => {
     const fetchDates = async () => {
       setSelectedDate(null);
@@ -146,7 +162,6 @@ const HotSlumpDashboard = () => {
     fetchDates();
   }, [period]);
 
-  // ランキングデータを取得
   useEffect(() => {
     if (!selectedDate) return;
     const fetchData = async () => {
@@ -172,49 +187,58 @@ const HotSlumpDashboard = () => {
   const hotFlags = hotFlagsFn(period);
   const slumpFlags = slumpFlagsFn(period);
 
+  const tabBtn = (active) => ({
+    padding: "5px 14px", fontSize: 11,
+    fontFamily: "var(--ff-mono)", letterSpacing: "0.06em",
+    background: active ? "var(--amber)" : "transparent",
+    color: active ? "var(--bg-0)" : "var(--ink-3)",
+    border: `1px solid ${active ? "var(--amber)" : "var(--rule)"}`,
+    fontWeight: active ? 600 : 400,
+    transition: "all .12s",
+  });
+
+  const metricBtn = (active) => ({
+    padding: "5px 12px", fontSize: 11,
+    fontFamily: "var(--ff-mono)", letterSpacing: "0.05em",
+    background: active ? "var(--amber)" : "var(--bg-2)",
+    color: active ? "var(--bg-0)" : "var(--ink-2)",
+    border: `1px solid ${active ? "var(--amber)" : "var(--rule)"}`,
+    fontWeight: active ? 600 : 400,
+    transition: "all .12s",
+  });
+
   return (
-    <div className="p-4 space-y-4">
-      {/* ヘッダー行 */}
-      <div className="flex items-center gap-3 flex-wrap">
-        {/* 期間トグル */}
-        <div className="flex gap-1 bg-gray-800 rounded-lg p-1">
+    <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 14 }}>
+      {/* Controls */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        {/* Period toggle */}
+        <div style={{ display: "flex", gap: 4 }}>
           {[7, 15].map((p) => (
-            <button
-              key={p}
-              onClick={() => setPeriod(p)}
-              className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                period === p
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-400 hover:text-white'
-              }`}
-            >
+            <button key={p} onClick={() => setPeriod(p)} style={tabBtn(period === p)}>
               {p}日
             </button>
           ))}
         </div>
 
-        {/* 指標タブ */}
-        <div className="flex gap-2">
+        {/* Metric tabs */}
+        <div style={{ display: "flex", gap: 4 }}>
           {METRIC_DEFS.map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setMetric(id)}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                metric === id
-                  ? 'bg-indigo-600 text-white'
-                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-              }`}
-            >
+            <button key={id} onClick={() => setMetric(id)} style={metricBtn(metric === id)}>
               {label}
             </button>
           ))}
         </div>
 
-        {/* 日付セレクター */}
+        {/* Date select */}
         <select
           value={selectedDate ?? ''}
           onChange={(e) => setSelectedDate(e.target.value)}
-          className="ml-auto bg-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2 border border-gray-600 focus:outline-none focus:border-blue-500"
+          style={{
+            marginLeft: "auto",
+            background: "var(--bg-1)", color: "var(--ink-1)",
+            fontSize: 11, padding: "5px 10px",
+            border: "1px solid var(--rule)", fontFamily: "var(--ff-mono)",
+          }}
         >
           {availableDates.map((d) => (
             <option key={d} value={d}>{d}</option>
@@ -222,17 +246,24 @@ const HotSlumpDashboard = () => {
         </select>
       </div>
 
-      {/* 判定基準の説明 */}
-      <p className="text-xs text-gray-500">
+      {/* Description */}
+      <p className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>
         直近{period}日スタッツがシーズン平均比 +20% 以上 → 🔥 Red Hot　／　−20% 以下 → 📉 Slump
       </p>
 
       {error && (
-        <div className="text-red-400 text-sm bg-red-900/20 rounded-lg px-4 py-2">{error}</div>
+        <div style={{
+          color: "var(--neg)", fontSize: 12,
+          border: "1px solid var(--neg-dim)",
+          background: "oklch(0.26 0.10 28 / 0.12)",
+          padding: "8px 12px",
+        }}>
+          {error}
+        </div>
       )}
 
-      {/* ランキング表（Hot / Slump 横並び） */}
-      <div className="flex gap-4 flex-col lg:flex-row">
+      {/* Hot / Slump tables side by side */}
+      <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
         <RankTable
           title="Red Hot Top 10"
           emoji="🔥"
@@ -240,7 +271,7 @@ const HotSlumpDashboard = () => {
           metricDef={metricDef}
           period={period}
           flagDefs={hotFlags}
-          accentColor="text-orange-400"
+          isHot={true}
           isLoading={isLoading}
         />
         <RankTable
@@ -250,7 +281,7 @@ const HotSlumpDashboard = () => {
           metricDef={metricDef}
           period={period}
           flagDefs={slumpFlags}
-          accentColor="text-blue-400"
+          isHot={false}
           isLoading={isLoading}
         />
       </div>

--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -5,7 +5,6 @@ import LeaderboardTable from './LeaderboardTable';
 
 const SEASONS = [2026, 2025, 2024, 2023, 2022, 2021];
 
-// シーズン序盤は閾値を低めに設定
 const getMinPa = (yr) => yr === new Date().getFullYear() ? 10 : 350;
 const getMinIp = (yr) => yr === new Date().getFullYear() ? 6 : 100;
 
@@ -62,24 +61,36 @@ const Leaderboard = () => {
   };
   const metricOrder = tab === 'batting' ? 'ops' : 'era';
 
+  const tabBtn = (active) => ({
+    padding: "5px 20px", fontSize: 11,
+    fontFamily: "var(--ff-mono)", letterSpacing: "0.06em",
+    background: active ? "var(--amber)" : "transparent",
+    color: active ? "var(--bg-0)" : "var(--ink-3)",
+    border: `1px solid ${active ? "var(--amber)" : "var(--rule)"}`,
+    fontWeight: active ? 600 : 400,
+    transition: "all .12s",
+  });
+
+  const smTabBtn = (active) => ({
+    padding: "4px 12px", fontSize: 10,
+    fontFamily: "var(--ff-mono)", letterSpacing: "0.06em",
+    background: active ? "var(--bg-3)" : "transparent",
+    color: active ? "var(--ink-0)" : "var(--ink-4)",
+    border: `1px solid ${active ? "var(--rule-hi)" : "var(--rule)"}`,
+    fontWeight: active ? 600 : 400,
+    transition: "all .12s",
+  });
+
   return (
-    <div className="space-y-4">
-      {/* 1行目: 打者/投手 + シーズン */}
-      <div className="flex items-center gap-3 flex-wrap">
-        <div className="flex gap-2">
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Row 1: 打者 / 投手 + season */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", gap: 4 }}>
           {[
             { id: 'batting', label: '打者' },
             { id: 'pitching', label: '投手' },
           ].map(({ id, label }) => (
-            <button
-              key={id}
-              onClick={() => setTab(id)}
-              className={`px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
-                tab === id
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-              }`}
-            >
+            <button key={id} onClick={() => setTab(id)} style={tabBtn(tab === id)}>
               {label}
             </button>
           ))}
@@ -88,7 +99,11 @@ const Leaderboard = () => {
         <select
           value={season}
           onChange={(e) => setSeason(Number(e.target.value))}
-          className="px-3 py-2 rounded-lg text-sm bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          style={{
+            background: "var(--bg-1)", color: "var(--ink-1)",
+            border: "1px solid var(--rule)", fontSize: 11,
+            padding: "5px 10px", fontFamily: "var(--ff-mono)",
+          }}
         >
           {SEASONS.map((yr) => (
             <option key={yr} value={yr}>{yr}年</option>
@@ -96,24 +111,16 @@ const Leaderboard = () => {
         </select>
       </div>
 
-      {/* 2行目: MLB / NL / AL */}
-      <div className="flex gap-2">
+      {/* Row 2: MLB / NL / AL */}
+      <div style={{ display: "flex", gap: 4 }}>
         {['MLB', 'NL', 'AL'].map((lg) => (
-          <button
-            key={lg}
-            onClick={() => setLeague(lg)}
-            className={`px-4 py-1.5 rounded-md text-xs font-semibold transition-colors ${
-              league === lg
-                ? 'bg-gray-200 dark:bg-gray-500 text-gray-900 dark:text-white'
-                : 'text-gray-400 hover:text-white hover:bg-gray-700'
-            }`}
-          >
+          <button key={lg} onClick={() => setLeague(lg)} style={smTabBtn(league === lg)}>
             {lg}
           </button>
         ))}
       </div>
 
-      {/* テーブル */}
+      {/* Table */}
       <LeaderboardTable
         data={data}
         category={category}

--- a/frontend/src/components/LeaderboardTable.jsx
+++ b/frontend/src/components/LeaderboardTable.jsx
@@ -1,14 +1,14 @@
 import { useState, useMemo } from 'react';
-import { Trophy, Medal, Award, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
+import Icon from './layout/Icon.jsx';
 
 const BATTING_METRICS = {
   'avg': 'BA', 'hr': 'HR', 'rbi': 'RBI', 'r': 'Run', 'h': 'H',
   'ops': 'OPS', 'obp': 'OBP', 'slg': 'SLG', 'woba': 'wOBA', 'war': 'WAR',
   'wrcplus': 'wRC+', 'bb': 'BB', 'so': 'SO', 'babip': 'BABIP', 'iso': 'ISO',
   'hardhitpct': 'HH%', 'barrelspct': 'Barrel%', 'pa': 'PA', 'ab': 'AB', 'g': 'G',
-  'batting_average_at_risp': 'RISP時打率',
-  'slugging_percentage_at_risp': 'RISP時長打率',
-  'home_runs_at_risp': 'RISP時HR',
+  'batting_average_at_risp': 'RISP打率',
+  'slugging_percentage_at_risp': 'RISP長打率',
+  'home_runs_at_risp': 'RISP HR',
 };
 
 const PITCHING_METRICS = {
@@ -24,11 +24,11 @@ const getMetricDisplayName = (metric, isPitching = false) => {
   return BATTING_METRICS[metric] || metric.toUpperCase();
 };
 
-const getRankIcon = (rank) => {
-  if (rank === 1) return <Trophy className="w-5 h-5 text-yellow-500" />;
-  if (rank === 2) return <Medal className="w-5 h-5 text-gray-400" />;
-  if (rank === 3) return <Award className="w-5 h-5 text-amber-600" />;
-  return <span className="w-5 h-5 flex items-center justify-center text-sm font-bold text-gray-600">{rank}</span>;
+const getRankBadge = (rank) => {
+  if (rank === 1) return <span className="t-mono" style={{ color: "var(--amber)", fontWeight: 700, fontSize: 13 }}>①</span>;
+  if (rank === 2) return <span className="t-mono" style={{ color: "var(--ink-2)", fontWeight: 700, fontSize: 12 }}>②</span>;
+  if (rank === 3) return <span className="t-mono" style={{ color: "var(--amber-dim)", fontWeight: 700, fontSize: 12 }}>③</span>;
+  return <span className="t-mono" style={{ color: "var(--ink-4)", fontSize: 11 }}>{rank}</span>;
 };
 
 const formatValue = (value, metric) => {
@@ -57,7 +57,6 @@ const LeaderboardTable = ({ data, category, metricOrder, isLoading, error }) => 
     ? ['ip', 'era', 'whip', 'so', 'w', 'l', 'fip', 'k_9', 'k_bb', 'war']
     : ['avg', 'hr', 'rbi', 'r', 'obp', 'slg', 'ops', 'war', 'wrcplus', 'batting_average_at_risp', 'slugging_percentage_at_risp', 'home_runs_at_risp'];
 
-  // ===== フック類はすべてここに集約（アーリーリターンより前）=====
   const [sortKey, setSortKey] = useState(metricOrder);
   const [sortDir, setSortDir] = useState('desc');
 
@@ -69,7 +68,6 @@ const LeaderboardTable = ({ data, category, metricOrder, isLoading, error }) => 
       return sortDir === 'desc' ? bv - av : av - bv;
     });
   }, [data, sortKey, sortDir]);
-  // ==============================================================
 
   const handleSort = (column) => {
     if (sortKey === column) {
@@ -82,103 +80,121 @@ const LeaderboardTable = ({ data, category, metricOrder, isLoading, error }) => 
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-        <span className="ml-3 text-gray-600 dark:text-gray-400">リーダーボードを読み込み中...</span>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "48px 0", gap: 8 }}>
+        <span className="think-dot"/>
+        <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+        <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+        <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 6 }}>リーダーボードを読み込み中...</span>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="text-center py-12">
-        <div className="text-red-500 mb-2">エラーが発生しました</div>
-        <div className="text-sm text-gray-600 dark:text-gray-400">{error}</div>
+      <div style={{ textAlign: "center", padding: "48px 0" }}>
+        <div style={{ color: "var(--neg)", marginBottom: 6, fontSize: 13 }}>エラーが発生しました</div>
+        <div className="t-mono" style={{ fontSize: 11, color: "var(--ink-4)" }}>{error}</div>
       </div>
     );
   }
 
   if (!data || data.length === 0) {
     return (
-      <div className="text-center py-12">
-        <div className="text-gray-500 dark:text-gray-400">データが見つかりませんでした</div>
+      <div style={{ textAlign: "center", padding: "48px 0", color: "var(--ink-4)", fontSize: 13 }}>
+        データが見つかりませんでした
       </div>
     );
   }
 
   const SortIcon = ({ column }) => {
-    if (sortKey !== column) return <ChevronsUpDown className="w-3 h-3 opacity-40" />;
+    if (sortKey !== column) return <Icon name="chevD" size={10} style={{ opacity: 0.3 }}/>;
     return sortDir === 'desc'
-      ? <ChevronDown className="w-3 h-3 text-blue-400" />
-      : <ChevronUp className="w-3 h-3 text-blue-400" />;
+      ? <Icon name="chevD" size={10} style={{ color: "var(--amber)" }}/>
+      : <Icon name="chevD" size={10} style={{ color: "var(--amber)", transform: "rotate(180deg)" }}/>;
+  };
+
+  const thBase = {
+    padding: "7px 10px",
+    fontSize: 10,
+    fontFamily: "var(--ff-mono)",
+    fontWeight: 600,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+    borderBottom: "1px solid var(--rule)",
+    whiteSpace: "nowrap",
   };
 
   return (
-    <div className="space-y-4">
-      <div className="text-center">
-        <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      {/* Header */}
+      <div style={{ textAlign: "center", paddingBottom: 8, borderBottom: "1px solid var(--rule)" }}>
+        <span className="h-display" style={{ fontSize: 15 }}>
           {isPitching ? '投手' : '打者'}リーダーボード
-        </h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+        </span>
+        <span className="t-mono" style={{ display: "block", fontSize: 10, color: "var(--ink-4)", marginTop: 4 }}>
           {getMetricDisplayName(sortKey, isPitching)} でソート済み
-        </p>
+        </span>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full bg-white dark:bg-gray-800 rounded-lg shadow">
-          <thead className="bg-gray-50 dark:bg-gray-700">
-            <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                順位
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                選手名
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                チーム
-              </th>
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+          <thead>
+            <tr style={{ background: "var(--bg-2)" }}>
+              <th style={{ ...thBase, textAlign: "left", color: "var(--ink-3)" }}>順位</th>
+              <th style={{ ...thBase, textAlign: "left", color: "var(--ink-3)" }}>選手名</th>
+              <th style={{ ...thBase, textAlign: "left", color: "var(--ink-3)" }}>チーム</th>
               {keyColumns.map((column) => (
                 <th
                   key={column}
                   onClick={() => handleSort(column)}
-                  className={`px-4 py-3 text-center text-xs font-medium uppercase tracking-wider cursor-pointer select-none transition-colors hover:bg-gray-200 dark:hover:bg-gray-600 ${
-                    sortKey === column
-                      ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
-                      : 'text-gray-500 dark:text-gray-300'
-                  }`}
+                  style={{
+                    ...thBase,
+                    textAlign: "center",
+                    cursor: "pointer",
+                    color: sortKey === column ? "var(--amber)" : "var(--ink-3)",
+                    background: sortKey === column ? "oklch(0.80 0.165 80 / 0.08)" : "var(--bg-2)",
+                    userSelect: "none",
+                  }}
                 >
-                  <div className="flex items-center justify-center gap-1">
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 3 }}>
                     {getMetricDisplayName(column, isPitching)}
-                    <SortIcon column={column} />
+                    <SortIcon column={column}/>
                   </div>
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+          <tbody>
             {sortedData.slice(0, 30).map((player, index) => (
-              <tr key={`${player.player_name || player.name}-${index}`} className="hover:bg-gray-50 dark:hover:bg-gray-700">
-                <td className="px-4 py-4 whitespace-nowrap">
-                  <div className="flex items-center">
-                    {getRankIcon(index + 1)}
-                  </div>
+              <tr
+                key={`${player.player_name || player.name}-${index}`}
+                style={{ borderBottom: "1px solid var(--rule-dim)" }}
+                onMouseEnter={e => e.currentTarget.style.background = "var(--bg-2)"}
+                onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+              >
+                <td style={{ padding: "8px 10px", whiteSpace: "nowrap" }}>
+                  {getRankBadge(index + 1)}
                 </td>
-                <td className="px-4 py-4 whitespace-nowrap">
-                  <div className="text-sm font-medium text-gray-900 dark:text-white">
-                    {player.player_name || player.name}
-                  </div>
+                <td style={{ padding: "8px 10px", whiteSpace: "nowrap", color: "var(--ink-0)", fontWeight: 600 }}>
+                  {player.player_name || player.name}
                 </td>
-                <td className="px-4 py-4 whitespace-nowrap">
-                  <div className="text-sm text-gray-900 dark:text-white">
-                    {player.team}
-                  </div>
+                <td className="t-mono" style={{ padding: "8px 10px", whiteSpace: "nowrap", color: "var(--ink-3)", fontSize: 10 }}>
+                  {player.team}
                 </td>
                 {keyColumns.map((column) => (
                   <td
                     key={column}
-                    className={`px-4 py-4 whitespace-nowrap text-center text-sm text-gray-900 dark:text-white ${
-                      sortKey === column ? 'bg-blue-50 dark:bg-blue-900/20 font-semibold' : ''
-                    }`}
+                    className="t-mono"
+                    style={{
+                      padding: "8px 10px",
+                      whiteSpace: "nowrap",
+                      textAlign: "center",
+                      fontSize: 12,
+                      color: "var(--ink-1)",
+                      fontWeight: sortKey === column ? 700 : 400,
+                      color: sortKey === column ? "var(--amber)" : "var(--ink-1)",
+                      background: sortKey === column ? "oklch(0.80 0.165 80 / 0.05)" : "transparent",
+                    }}
                   >
                     {formatValue(player[column], column)}
                   </td>
@@ -189,7 +205,7 @@ const LeaderboardTable = ({ data, category, metricOrder, isLoading, error }) => 
         </table>
       </div>
 
-      <div className="text-center text-xs text-gray-500 dark:text-gray-400">
+      <div className="t-mono" style={{ textAlign: "center", fontSize: 10, color: "var(--ink-4)" }}>
         トップ{Math.min(30, sortedData.length)}人を表示 ({sortedData.length}人中)
       </div>
     </div>

--- a/frontend/src/components/LiveMonitorBoard.jsx
+++ b/frontend/src/components/LiveMonitorBoard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { RefreshCw, X, AlertTriangle, Flame, Clock, TrendingUp, CircleDot, Zap } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import Icon from './layout/Icon.jsx';
 
 const POLL_INTERVAL_MS = 40000;
 
@@ -22,56 +22,21 @@ const detectAnomalies = (game) => {
   const alerts = [];
   const scoreDiff = Math.abs((game.away_score ?? 0) - (game.home_score ?? 0));
 
-  // 投手100球超え
   if (game.pitcher_stats?.pitches >= 100) {
-    alerts.push({
-      key: 'pitches',
-      type: 'warning',
-      icon: AlertTriangle,
-      label: `${game.pitcher_stats.pitches}球超`,
-    });
+    alerts.push({ key: 'pitches', type: 'warning', iconName: 'alert', label: `${game.pitcher_stats.pitches}球超` });
   }
-
-  // 延長戦
   if (game.inning > 9) {
-    alerts.push({
-      key: 'extra',
-      type: 'purple',
-      icon: Clock,
-      label: `延長${game.inning}回`,
-    });
+    alerts.push({ key: 'extra', type: 'purple', iconName: 'clock', label: `延長${game.inning}回` });
   }
-
-  // 接戦（7回以降・1点差以内）
   if (game.inning >= 7 && scoreDiff <= 1) {
-    alerts.push({
-      key: 'close',
-      type: 'hot',
-      icon: Flame,
-      label: scoreDiff === 0 ? '同点' : '1点差',
-    });
+    alerts.push({ key: 'close', type: 'hot', iconName: 'fire', label: scoreDiff === 0 ? '同点' : '1点差' });
   }
-
-  // 大差（5点差以上）
   if (scoreDiff >= 5) {
-    alerts.push({
-      key: 'blowout',
-      type: 'neutral',
-      icon: TrendingUp,
-      label: `${scoreDiff}点差`,
-    });
+    alerts.push({ key: 'blowout', type: 'neutral', iconName: 'chart', label: `${scoreDiff}点差` });
   }
-
-  // 満塁
   if (game.runners?.first && game.runners?.second && game.runners?.third) {
-    alerts.push({
-      key: 'bases_loaded',
-      type: 'hot',
-      icon: CircleDot,
-      label: '満塁',
-    });
+    alerts.push({ key: 'bases_loaded', type: 'hot', iconName: 'target', label: '満塁' });
   }
-
   return alerts;
 };
 
@@ -80,14 +45,12 @@ const computeFatigueAlert = (game, pitcherBaselines) => {
   const log = game.pitcher_pitch_log;
   if (!log || log.length === 0 || !pitcherBaselines) return null;
 
-  // 終了済みイニングのみ対象（現在進行中のイニングは除く）
   const completedInning = game.outs >= 3 ? game.inning : game.inning - 1;
   if (completedInning < 1) return null;
 
   const lastInningPitches = log.filter(p => p.inning === completedInning);
-  if (lastInningPitches.length < 3) return null; // サンプル少なすぎは無視
+  if (lastInningPitches.length < 3) return null;
 
-  // 球種毎に平均速度・スピンレートを集計
   const byType = {};
   lastInningPitches.forEach(p => {
     if (!byType[p.pitch_type]) byType[p.pitch_type] = { speeds: [], spins: [] };
@@ -109,7 +72,6 @@ const computeFatigueAlert = (game, pitcherBaselines) => {
     const spinDrop = spins.length > 0 && baseline.spin
       ? baseline.spin - spins.reduce((a, b) => a + b, 0) / spins.length
       : 0;
-    // speedとspinの複合スコア（speed 1mph ≈ spin 50rpm で正規化）
     const score = speedDrop + spinDrop / 50;
     if (score > maxScore) {
       maxScore = score;
@@ -130,20 +92,20 @@ const computeFatigueAlert = (game, pitcherBaselines) => {
   const detail = [speedStr, spinStr].filter(Boolean).join(' ');
 
   if (maxScore >= 2.5) {
-    return { key: 'fatigue', type: 'warning', icon: Zap, label: `疲労 ${shortType} ${detail}` };
+    return { key: 'fatigue', type: 'warning', iconName: 'bolt', label: `疲労 ${shortType} ${detail}` };
   }
   if (maxScore >= 1.5) {
-    return { key: 'fatigue', type: 'caution', icon: Zap, label: `要注意 ${shortType} ${detail}` };
+    return { key: 'fatigue', type: 'caution', iconName: 'bolt', label: `要注意 ${shortType} ${detail}` };
   }
   return null;
 };
 
 const ALERT_STYLES = {
-  warning: 'bg-orange-900/60 border-orange-600/50 text-orange-300',
-  caution: 'bg-yellow-900/60 border-yellow-600/50 text-yellow-300',
-  purple:  'bg-purple-900/60 border-purple-600/50 text-purple-300',
-  hot:     'bg-red-900/60 border-red-500/50 text-red-300',
-  neutral: 'bg-gray-700/60 border-gray-500/50 text-gray-300',
+  warning: { background: "oklch(0.32 0.10 45 / 0.6)", border: "1px solid oklch(0.50 0.14 45 / 0.5)", color: "oklch(0.82 0.14 55)" },
+  caution: { background: "oklch(0.34 0.12 72 / 0.6)", border: "1px solid oklch(0.55 0.15 72 / 0.5)", color: "var(--amber)" },
+  purple:  { background: "oklch(0.26 0.10 310 / 0.6)", border: "1px solid oklch(0.50 0.12 310 / 0.5)", color: "var(--purp)" },
+  hot:     { background: "oklch(0.26 0.10 28 / 0.6)",  border: "1px solid oklch(0.50 0.14 28 / 0.5)",  color: "var(--neg)" },
+  neutral: { background: "var(--bg-2)",                 border: "1px solid var(--rule)",                color: "var(--ink-2)" },
 };
 
 // ===== ボックススコアモーダル =====
@@ -178,93 +140,123 @@ const BoxscoreModal = ({ game, onClose, getIdToken }) => {
   const awayWin = game.away_score > game.home_score;
   const homeWin = game.home_score > game.away_score;
 
+  const thStyle = (isName) => ({
+    padding: "6px 8px",
+    fontFamily: "var(--ff-mono)",
+    fontWeight: 600,
+    fontSize: 10,
+    letterSpacing: "0.08em",
+    color: "var(--ink-3)",
+    textAlign: isName ? "left" : "right",
+    borderBottom: "1px solid var(--rule)",
+    whiteSpace: "nowrap",
+  });
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70" onClick={onClose}>
+    <div
+      style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", alignItems: "center", justifyContent: "center", padding: 16, background: "oklch(0 0 0 / 0.75)" }}
+      onClick={onClose}
+    >
       <div
-        className="bg-gray-900 border border-gray-700 rounded-2xl w-full max-w-2xl max-h-[90vh] flex flex-col overflow-hidden"
+        style={{ background: "var(--bg-0)", border: "1px solid var(--rule-hi)", width: "100%", maxWidth: 680, maxHeight: "90vh", display: "flex", flexDirection: "column", overflow: "hidden" }}
         onClick={e => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-700 flex-shrink-0">
-          <div className="flex items-center gap-3 text-white font-bold text-base">
-            <span className={awayWin ? 'text-white' : 'text-gray-500'}>{game.away_team}</span>
-            <span className={`text-xl ${awayWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.away_score}</span>
-            <span className="text-gray-600 text-sm font-normal">-</span>
-            <span className={`text-xl ${homeWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.home_score}</span>
-            <span className={homeWin ? 'text-white' : 'text-gray-500'}>{game.home_team}</span>
+        {/* Header */}
+        <div className="rule-b" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "12px 16px", flexShrink: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, fontFamily: "var(--ff-mono)", fontWeight: 700, fontSize: 14 }}>
+            <span style={{ color: awayWin ? "var(--ink-0)" : "var(--ink-4)" }}>{game.away_team}</span>
+            <span style={{ fontSize: 18, color: awayWin ? "var(--amber)" : "var(--ink-4)" }}>{game.away_score}</span>
+            <span style={{ color: "var(--ink-4)", fontSize: 12, fontWeight: 400 }}>-</span>
+            <span style={{ fontSize: 18, color: homeWin ? "var(--amber)" : "var(--ink-4)" }}>{game.home_score}</span>
+            <span style={{ color: homeWin ? "var(--ink-0)" : "var(--ink-4)" }}>{game.home_team}</span>
+            <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", fontWeight: 400, marginLeft: 4 }}>Final</span>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">
-            <X className="w-5 h-5" />
+          <button onClick={onClose} style={{ color: "var(--ink-3)", display: "flex", padding: 4 }}>
+            <Icon name="close" size={16}/>
           </button>
         </div>
 
         {loading ? (
-          <div className="flex items-center justify-center py-16 text-gray-400">
-            <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-            <span>取得中...</span>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "48px 0", gap: 8 }}>
+            <span className="think-dot"/>
+            <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+            <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+            <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 4 }}>取得中...</span>
           </div>
         ) : !boxscore ? (
-          <div className="p-8 text-center text-gray-500">データを取得できませんでした</div>
+          <div style={{ padding: 32, textAlign: "center", color: "var(--ink-3)", fontSize: 13 }}>
+            データを取得できませんでした
+          </div>
         ) : (
           <>
-            <div className="flex border-b border-gray-700 flex-shrink-0">
+            {/* Team tabs */}
+            <div className="rule-b" style={{ display: "flex", flexShrink: 0 }}>
               {['away', 'home'].map(side => (
                 <button
                   key={side}
                   onClick={() => setActiveTab(side)}
-                  className={`flex-1 py-2.5 text-sm font-medium transition-colors ${activeTab === side
-                    ? 'text-white border-b-2 border-blue-500'
-                    : 'text-gray-500 hover:text-gray-300'
-                  }`}
+                  style={{
+                    flex: 1, padding: "10px 0", fontSize: 12,
+                    fontFamily: "var(--ff-mono)", fontWeight: 600,
+                    color: activeTab === side ? "var(--amber)" : "var(--ink-3)",
+                    borderBottom: activeTab === side ? "2px solid var(--amber)" : "2px solid transparent",
+                    transition: "all .12s",
+                  }}
                 >
                   {boxscore[side]?.team}
                 </button>
               ))}
             </div>
-            <div className="overflow-y-auto flex-1 px-4 py-3">
-              <p className="text-xs text-gray-500 font-semibold uppercase tracking-wider mb-2">Pitchers</p>
-              <div className="overflow-x-auto mb-5">
-                <table className="w-full text-xs">
+
+            {/* Content */}
+            <div style={{ overflowY: "auto", flex: 1, padding: "12px 16px" }}>
+              {/* Pitchers */}
+              <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginBottom: 8 }}>PITCHERS</div>
+              <div style={{ overflowX: "auto", marginBottom: 20 }}>
+                <table style={{ width: "100%", fontSize: 11, borderCollapse: "collapse" }}>
                   <thead>
-                    <tr className="text-gray-500 border-b border-gray-700">
+                    <tr>
                       {['PITCHER','ERA','IP','H','R','ER','HR','K','BB','PT'].map(h => (
-                        <th key={h} className={`py-1.5 px-2 font-medium ${h === 'PITCHER' ? 'text-left min-w-[120px]' : 'text-right'}`}>{h}</th>
+                        <th key={h} style={thStyle(h === 'PITCHER')}>{h}</th>
                       ))}
                     </tr>
                   </thead>
                   <tbody>
                     {boxscore[activeTab]?.pitchers.map((p, i) => (
-                      <tr key={i} className="border-b border-gray-800 text-gray-300">
-                        <td className="py-2 pr-3">
-                          <div className="font-medium text-white">{p.name}</div>
-                          {p.note && <div className="text-gray-500 text-xs">{p.note}</div>}
+                      <tr key={i} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                        <td style={{ padding: "7px 8px" }}>
+                          <div style={{ fontWeight: 600, color: "var(--ink-0)" }}>{p.name}</div>
+                          {p.note && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{p.note}</div>}
                         </td>
                         {[p.era, p.ip, p.h, p.r, p.er, p.hr, p.k, p.bb, p.pitches].map((v, j) => (
-                          <td key={j} className="text-right px-2">{v}</td>
+                          <td key={j} className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{v}</td>
                         ))}
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
-              <p className="text-xs text-gray-500 font-semibold uppercase tracking-wider mb-2">Batters</p>
-              <div className="overflow-x-auto">
-                <table className="w-full text-xs">
+
+              {/* Batters */}
+              <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginBottom: 8 }}>BATTERS</div>
+              <div style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", fontSize: 11, borderCollapse: "collapse" }}>
                   <thead>
-                    <tr className="text-gray-500 border-b border-gray-700">
+                    <tr>
                       {['BATTER','AVG','AB','H','R','RBI','HR','BB','K','OBP','SLG','OPS'].map(h => (
-                        <th key={h} className={`py-1.5 px-2 font-medium ${h === 'BATTER' ? 'text-left min-w-[120px]' : 'text-right'}`}>{h}</th>
+                        <th key={h} style={thStyle(h === 'BATTER')}>{h}</th>
                       ))}
                     </tr>
                   </thead>
                   <tbody>
                     {boxscore[activeTab]?.batters.map((b, i) => (
-                      <tr key={i} className="border-b border-gray-800 text-gray-300">
-                        <td className="py-2 pr-3">
-                          <div className="font-medium text-white">{b.name}</div>
-                          <div className="text-gray-500">{b.position}</div>
+                      <tr key={i} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                        <td style={{ padding: "7px 8px" }}>
+                          <div style={{ fontWeight: 600, color: "var(--ink-0)" }}>{b.name}</div>
+                          <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{b.position}</div>
                         </td>
                         {[b.avg, b.ab, b.h, b.r, b.rbi, b.hr, b.bb, b.k, b.obp, b.slg, b.ops].map((v, j) => (
-                          <td key={j} className="text-right px-2">{v}</td>
+                          <td key={j} className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{v}</td>
                         ))}
                       </tr>
                     ))}
@@ -288,87 +280,93 @@ const MonitorCard = ({ game, status, onClick, pitcherBaselines }) => {
   const awayLeading = scoreDiff > 0;
   const homeLeading = scoreDiff < 0;
 
+  const statusBadge = () => {
+    if (status === 'live') return (
+      <span className="t-mono" style={{ fontSize: 10, color: "var(--pos)", border: "1px solid var(--pos-dim)", padding: "2px 6px", whiteSpace: "nowrap", flexShrink: 0 }}>
+        {game.inning}回{game.inning_half === 'Top' ? '表' : '裏'}
+      </span>
+    );
+    if (status === 'final') return (
+      <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", border: "1px solid var(--rule)", padding: "2px 6px", flexShrink: 0 }}>Final</span>
+    );
+    if (status === 'preview') return (
+      <span className="t-mono" style={{ fontSize: 10, color: "var(--info)", border: "1px solid var(--info)", padding: "2px 6px", flexShrink: 0, opacity: 0.7 }}>
+        {game.game_time ?? '予定'}
+      </span>
+    );
+    return null;
+  };
+
   return (
     <button
       onClick={() => onClick(game)}
-      className={`
-        w-full text-left rounded-xl border p-3 flex flex-col gap-2 transition-all duration-200
-        hover:border-gray-500 hover:bg-gray-750 active:scale-[0.98]
-        ${alerts.length > 0
-          ? 'bg-gray-800 border-gray-600 ring-1 ring-orange-500/30'
-          : 'bg-gray-800 border-gray-700'
-        }
-      `}
+      style={{
+        width: "100%", textAlign: "left",
+        border: alerts.length > 0 ? "1px solid var(--amber-dim)" : "1px solid var(--rule)",
+        background: "var(--bg-1)",
+        padding: 12,
+        display: "flex", flexDirection: "column", gap: 8,
+        transition: "all .15s",
+        boxShadow: alerts.length > 0 ? "inset 0 0 0 1px oklch(from var(--amber) l c h / 0.2)" : "none",
+      }}
+      onMouseEnter={e => { e.currentTarget.style.background = "var(--bg-2)"; e.currentTarget.style.borderColor = "var(--rule-hi)"; }}
+      onMouseLeave={e => { e.currentTarget.style.background = "var(--bg-1)"; e.currentTarget.style.borderColor = alerts.length > 0 ? "var(--amber-dim)" : "var(--rule)"; }}
     >
-      {/* スコア行 */}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <span className={`text-sm font-bold truncate ${awayLeading ? 'text-white' : 'text-gray-400'}`}>
+      {/* Score row */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0, flex: 1 }}>
+          <span className="h-display" style={{ fontSize: 11, color: awayLeading ? "var(--ink-0)" : "var(--ink-4)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {game.away_team}
           </span>
-          <span className={`text-lg font-black tabular-nums ${awayLeading ? 'text-yellow-400' : 'text-gray-300'}`}>
+          <span className="t-mono" style={{ fontSize: 16, fontWeight: 700, color: awayLeading ? "var(--amber)" : "var(--ink-2)" }}>
             {game.away_score ?? '-'}
           </span>
-          <span className="text-gray-600 text-xs">:</span>
-          <span className={`text-lg font-black tabular-nums ${homeLeading ? 'text-yellow-400' : 'text-gray-300'}`}>
+          <span style={{ color: "var(--ink-4)", fontSize: 10 }}>:</span>
+          <span className="t-mono" style={{ fontSize: 16, fontWeight: 700, color: homeLeading ? "var(--amber)" : "var(--ink-2)" }}>
             {game.home_score ?? '-'}
           </span>
-          <span className={`text-sm font-bold truncate ${homeLeading ? 'text-white' : 'text-gray-400'}`}>
+          <span className="h-display" style={{ fontSize: 11, color: homeLeading ? "var(--ink-0)" : "var(--ink-4)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {game.home_team}
           </span>
         </div>
-
-        {/* ステータスバッジ */}
-        {status === 'live' && (
-          <span className="text-xs text-green-400 bg-green-900/40 px-1.5 py-0.5 rounded-full whitespace-nowrap flex-shrink-0">
-            {game.inning}回{game.inning_half === 'Top' ? '表' : '裏'}
-          </span>
-        )}
-        {status === 'final' && (
-          <span className="text-xs text-gray-500 bg-gray-700/50 px-1.5 py-0.5 rounded-full flex-shrink-0">
-            Final
-          </span>
-        )}
-        {status === 'preview' && (
-          <span className="text-xs text-blue-400 bg-blue-900/30 px-1.5 py-0.5 rounded-full flex-shrink-0">
-            {game.game_time ?? '予定'}
-          </span>
-        )}
+        {statusBadge()}
       </div>
 
-      {/* 投手情報（ライブのみ） */}
+      {/* Pitcher info (live only) */}
       {status === 'live' && game.pitcher && (
-        <div className="flex items-center justify-between text-xs text-gray-400">
-          <span className="truncate">
-            <span className="text-gray-500">P: </span>
-            <span className="text-gray-200">{game.pitcher}</span>
+        <div className="t-mono" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", fontSize: 10, color: "var(--ink-3)" }}>
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            <span>P: </span>
+            <span style={{ color: "var(--ink-1)" }}>{game.pitcher}</span>
             {game.pitcher_stats?.pitches > 0 && (
-              <span className={`ml-1 tabular-nums ${game.pitcher_stats.pitches >= 100 ? 'text-orange-400 font-semibold' : ''}`}>
+              <span style={{ marginLeft: 4, color: game.pitcher_stats.pitches >= 100 ? "var(--amber)" : "var(--ink-3)", fontWeight: game.pitcher_stats.pitches >= 100 ? 600 : 400 }}>
                 {game.pitcher_stats.pitches}球
               </span>
             )}
           </span>
-          <span className="font-mono text-gray-500 ml-2 flex-shrink-0">
+          <span style={{ marginLeft: 8, flexShrink: 0, color: "var(--ink-4)" }}>
             {game.balls}-{game.strikes} {game.outs}out
           </span>
         </div>
       )}
 
-      {/* 異常検知バッジ */}
+      {/* Alert badges */}
       {alerts.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {alerts.map(alert => {
-            const Icon = alert.icon;
-            return (
-              <span
-                key={alert.key}
-                className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded border ${ALERT_STYLES[alert.type]}`}
-              >
-                <Icon className="w-3 h-3" />
-                {alert.label}
-              </span>
-            );
-          })}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+          {alerts.map(alert => (
+            <span
+              key={alert.key}
+              style={{
+                ...ALERT_STYLES[alert.type],
+                display: "inline-flex", alignItems: "center", gap: 4,
+                fontSize: 10, padding: "2px 6px",
+                fontFamily: "var(--ff-mono)",
+              }}
+            >
+              <Icon name={alert.iconName} size={10}/>
+              {alert.label}
+            </span>
+          ))}
         </div>
       )}
     </button>
@@ -450,8 +448,15 @@ const LiveMonitorBoard = () => {
   const formatTime = (date) =>
     date ? date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '--:--:--';
 
+  const SectionHeader = ({ dotColor, label }) => (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+      <span style={{ width: 7, height: 7, background: dotColor, display: "inline-block" }}/>
+      <span className="h-label" style={{ fontSize: 10, color: dotColor }}>{label}</span>
+    </div>
+  );
+
   return (
-    <div className="w-full">
+    <div style={{ width: "100%" }}>
       {selectedGame && (
         <BoxscoreModal
           game={selectedGame}
@@ -460,58 +465,64 @@ const LiveMonitorBoard = () => {
         />
       )}
 
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
-        <div className="flex items-center gap-3 flex-wrap">
-          <h2 className="text-xl font-bold text-white">全試合モニターボード</h2>
-          <div className="flex items-center gap-2 text-sm">
-            <span className="bg-gray-700 text-gray-300 px-2 py-0.5 rounded-full">
+      {/* Header */}
+      <div className="rule-b" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingBottom: 12, marginBottom: 16, flexWrap: "wrap", gap: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <span className="h-display" style={{ fontSize: 16 }}>全試合モニターボード</span>
+          <div style={{ display: "flex", gap: 6 }}>
+            <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", border: "1px solid var(--rule)", padding: "2px 8px" }}>
               {totalGames} games
             </span>
             {anomalyCount > 0 && (
-              <span className="bg-orange-900/60 border border-orange-600/50 text-orange-300 px-2 py-0.5 rounded-full flex items-center gap-1">
-                <AlertTriangle className="w-3 h-3" />
+              <span style={{
+                ...ALERT_STYLES.warning,
+                display: "inline-flex", alignItems: "center", gap: 4,
+                fontSize: 10, padding: "2px 8px", fontFamily: "var(--ff-mono)",
+              }}>
+                <Icon name="alert" size={10}/>
                 {anomalyCount} alerts
               </span>
             )}
           </div>
         </div>
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-gray-500">
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>
             更新: {formatTime(lastUpdated)}
           </span>
           <button
             onClick={fetchGames}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+            style={{
+              display: "flex", alignItems: "center", gap: 6,
+              padding: "5px 12px", fontSize: 11,
+              border: "1px solid var(--rule)", color: "var(--ink-2)",
+              fontFamily: "var(--ff-mono)",
+            }}
           >
-            <RefreshCw className="w-3.5 h-3.5" />
+            <Icon name="refresh" size={12}/>
             更新
           </button>
         </div>
       </div>
 
       {loading ? (
-        <div className="flex items-center justify-center py-20 text-gray-400">
-          <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-          <span>取得中...</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "80px 0", gap: 8 }}>
+          <span className="think-dot"/>
+          <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+          <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+          <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 6 }}>取得中...</span>
         </div>
       ) : error ? (
-        <div className="text-center py-12 text-red-400">{error}</div>
+        <div style={{ textAlign: "center", padding: "48px 0", color: "var(--neg)", fontSize: 13 }}>{error}</div>
       ) : totalGames === 0 ? (
-        <div className="text-center py-12 text-gray-500">本日の試合データがありません</div>
+        <div style={{ textAlign: "center", padding: "48px 0", color: "var(--ink-4)", fontSize: 13 }}>本日の試合データがありません</div>
       ) : (
-        <div className="flex flex-col gap-6">
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
 
-          {/* ===== LIVE ===== */}
+          {/* LIVE */}
           {liveGames.length > 0 && (
             <section>
-              <div className="flex items-center gap-2 mb-3">
-                <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
-                <h3 className="text-sm font-semibold text-green-400 uppercase tracking-wider">
-                  Live — {liveGames.length}試合
-                </h3>
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              <SectionHeader dotColor="var(--pos)" label={`LIVE — ${liveGames.length}試合`}/>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 10 }}>
                 {liveGames.map(game => (
                   <MonitorCard
                     key={game.gamePk}
@@ -525,16 +536,11 @@ const LiveMonitorBoard = () => {
             </section>
           )}
 
-          {/* ===== FINAL ===== */}
+          {/* FINAL */}
           {finalGames.length > 0 && (
             <section>
-              <div className="flex items-center gap-2 mb-3">
-                <span className="w-2 h-2 bg-gray-500 rounded-full" />
-                <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider">
-                  Final — {finalGames.length}試合
-                </h3>
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              <SectionHeader dotColor="var(--ink-4)" label={`FINAL — ${finalGames.length}試合`}/>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 10 }}>
                 {finalGames.map(game => (
                   <MonitorCard
                     key={game.gamePk}
@@ -547,16 +553,11 @@ const LiveMonitorBoard = () => {
             </section>
           )}
 
-          {/* ===== PREVIEW ===== */}
+          {/* PREVIEW */}
           {previewGames.length > 0 && (
             <section>
-              <div className="flex items-center gap-2 mb-3">
-                <span className="w-2 h-2 bg-blue-400 rounded-full" />
-                <h3 className="text-sm font-semibold text-blue-400 uppercase tracking-wider">
-                  Upcoming — {previewGames.length}試合
-                </h3>
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              <SectionHeader dotColor="var(--info)" label={`UPCOMING — ${previewGames.length}試合`}/>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 10 }}>
                 {previewGames.map(game => (
                   <MonitorCard
                     key={game.gamePk}

--- a/frontend/src/components/LiveScoreboard.jsx
+++ b/frontend/src/components/LiveScoreboard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Radio, RefreshCw, X } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import Icon from './layout/Icon.jsx';
 
 const POLL_INTERVAL_MS = 40000;
 
@@ -17,22 +17,29 @@ const getBackendUrl = () => {
 
 const BACKEND_URL = getBackendUrl();
 
-// 走者表示コンポーネント（ダイヤモンド形）
+// ===== 走者ダイヤモンド =====
 const BaseDiamond = ({ runners }) => {
-  const occupied = 'bg-yellow-400';
-  const empty = 'bg-gray-600';
+  const base = (occupied) => ({
+    position: "absolute", width: 14, height: 14,
+    background: occupied ? "var(--amber)" : "var(--bg-3)",
+    transform: "rotate(45deg)",
+  });
 
   return (
-    <div className="relative w-12 h-12 flex-shrink-0">
-      <div className={`absolute w-4 h-4 rotate-45 top-0 left-1/2 -translate-x-1/2 ${runners.second ? occupied : empty}`} />
-      <div className={`absolute w-4 h-4 rotate-45 top-1/2 left-0 -translate-y-1/2 ${runners.third ? occupied : empty}`} />
-      <div className={`absolute w-4 h-4 rotate-45 top-1/2 right-0 -translate-y-1/2 ${runners.first ? occupied : empty}`} />
-      <div className={`absolute w-4 h-4 rotate-45 bottom-0 left-1/2 -translate-x-1/2 bg-gray-600`} />
+    <div style={{ position: "relative", width: 48, height: 48, flexShrink: 0 }}>
+      {/* 2B - top */}
+      <div style={{ ...base(runners.second), top: 0, left: "50%", marginLeft: -7 }}/>
+      {/* 3B - left */}
+      <div style={{ ...base(runners.third), top: "50%", left: 0, marginTop: -7 }}/>
+      {/* 1B - right */}
+      <div style={{ ...base(runners.first), top: "50%", right: 0, marginTop: -7 }}/>
+      {/* Home */}
+      <div style={{ ...base(false), bottom: 0, left: "50%", marginLeft: -7 }}/>
     </div>
   );
 };
 
-// ボックススコア モーダル
+// ===== ボックススコアモーダル =====
 const BoxscoreModal = ({ game, onClose, getIdToken }) => {
   const [boxscore, setBoxscore] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -64,132 +71,138 @@ const BoxscoreModal = ({ game, onClose, getIdToken }) => {
   const awayWin = game.away_score > game.home_score;
   const homeWin = game.home_score > game.away_score;
 
+  const thStyle = (isName) => ({
+    padding: "6px 8px",
+    fontFamily: "var(--ff-mono)",
+    fontWeight: 600,
+    fontSize: 10,
+    letterSpacing: "0.08em",
+    color: "var(--ink-3)",
+    textAlign: isName ? "left" : "right",
+    borderBottom: "1px solid var(--rule)",
+    whiteSpace: "nowrap",
+  });
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70" onClick={onClose}>
+    <div
+      style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", alignItems: "center", justifyContent: "center", padding: 16, background: "oklch(0 0 0 / 0.75)" }}
+      onClick={onClose}
+    >
       <div
-        className="bg-gray-900 border border-gray-700 rounded-2xl w-full max-w-2xl max-h-[90vh] flex flex-col overflow-hidden"
+        style={{ background: "var(--bg-0)", border: "1px solid var(--rule-hi)", width: "100%", maxWidth: 680, maxHeight: "90vh", display: "flex", flexDirection: "column", overflow: "hidden" }}
         onClick={e => e.stopPropagation()}
       >
-        {/* ヘッダー */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-700 flex-shrink-0">
-          <div className="flex items-center gap-3 text-white font-bold text-base">
-            <span className={awayWin ? 'text-white' : 'text-gray-500'}>{game.away_team}</span>
-            <span className={`text-xl ${awayWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.away_score}</span>
-            <span className="text-gray-600 text-sm font-normal">-</span>
-            <span className={`text-xl ${homeWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.home_score}</span>
-            <span className={homeWin ? 'text-white' : 'text-gray-500'}>{game.home_team}</span>
-            <span className="text-xs text-gray-500 font-normal ml-1">Final</span>
+        {/* Header */}
+        <div className="rule-b" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "12px 16px", flexShrink: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, fontFamily: "var(--ff-mono)", fontWeight: 700, fontSize: 14 }}>
+            <span style={{ color: awayWin ? "var(--ink-0)" : "var(--ink-4)" }}>{game.away_team}</span>
+            <span style={{ fontSize: 18, color: awayWin ? "var(--amber)" : "var(--ink-4)" }}>{game.away_score}</span>
+            <span style={{ color: "var(--ink-4)", fontSize: 12, fontWeight: 400 }}>-</span>
+            <span style={{ fontSize: 18, color: homeWin ? "var(--amber)" : "var(--ink-4)" }}>{game.home_score}</span>
+            <span style={{ color: homeWin ? "var(--ink-0)" : "var(--ink-4)" }}>{game.home_team}</span>
+            <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", fontWeight: 400, marginLeft: 4 }}>Final</span>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-white transition-colors">
-            <X className="w-5 h-5" />
+          <button onClick={onClose} style={{ color: "var(--ink-3)", display: "flex", padding: 4 }}>
+            <Icon name="close" size={16}/>
           </button>
         </div>
 
         {loading ? (
-          <div className="flex items-center justify-center py-16 text-gray-400">
-            <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-            <span>取得中...</span>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "48px 0", gap: 8 }}>
+            <span className="think-dot"/>
+            <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+            <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+            <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 4 }}>取得中...</span>
           </div>
         ) : !boxscore ? (
-          <div className="p-8 text-center text-gray-500">データを取得できませんでした</div>
+          <div style={{ padding: 32, textAlign: "center", color: "var(--ink-3)", fontSize: 13 }}>
+            データを取得できませんでした
+          </div>
         ) : (
           <>
-            {/* チームタブ */}
-            <div className="flex border-b border-gray-700 flex-shrink-0">
+            {/* Team tabs */}
+            <div className="rule-b" style={{ display: "flex", flexShrink: 0 }}>
               {['away', 'home'].map(side => (
                 <button
                   key={side}
                   onClick={() => setActiveTab(side)}
-                  className={`flex-1 py-2.5 text-sm font-medium transition-colors ${activeTab === side
-                      ? 'text-white border-b-2 border-blue-500'
-                      : 'text-gray-500 hover:text-gray-300'
-                    }`}
+                  style={{
+                    flex: 1, padding: "10px 0", fontSize: 12,
+                    fontFamily: "var(--ff-mono)", fontWeight: 600,
+                    color: activeTab === side ? "var(--amber)" : "var(--ink-3)",
+                    borderBottom: activeTab === side ? "2px solid var(--amber)" : "2px solid transparent",
+                    transition: "all .12s",
+                  }}
                 >
                   {boxscore[side]?.team}
                 </button>
               ))}
             </div>
 
-            {/* コンテンツ */}
-            <div className="overflow-y-auto flex-1 px-4 py-3">
-              {/* 投手 */}
-              <p className="text-xs text-gray-500 font-semibold uppercase tracking-wider mb-2">Pitchers</p>
-              <div className="overflow-x-auto mb-5">
-                <table className="w-full text-xs">
+            {/* Content */}
+            <div style={{ overflowY: "auto", flex: 1, padding: "12px 16px" }}>
+              {/* Pitchers */}
+              <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginBottom: 8 }}>PITCHERS</div>
+              <div style={{ overflowX: "auto", marginBottom: 20 }}>
+                <table style={{ width: "100%", fontSize: 11, borderCollapse: "collapse" }}>
                   <thead>
-                    <tr className="text-gray-500 border-b border-gray-700">
-                      <th className="text-left py-1.5 pr-3 font-medium min-w-[120px]">PITCHER</th>
-                      <th className="text-right py-1.5 px-2 font-medium">ERA</th>
-                      <th className="text-right py-1.5 px-2 font-medium">IP</th>
-                      <th className="text-right py-1.5 px-2 font-medium">H</th>
-                      <th className="text-right py-1.5 px-2 font-medium">R</th>
-                      <th className="text-right py-1.5 px-2 font-medium">ER</th>
-                      <th className="text-right py-1.5 px-2 font-medium">HR</th>
-                      <th className="text-right py-1.5 px-2 font-medium">K</th>
-                      <th className="text-right py-1.5 px-2 font-medium">BB</th>
-                      <th className="text-right py-1.5 px-2 font-medium">PT</th>
+                    <tr>
+                      {['PITCHER','ERA','IP','H','R','ER','HR','K','BB','PT'].map(h => (
+                        <th key={h} style={thStyle(h === 'PITCHER')}>{h}</th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
                     {boxscore[activeTab]?.pitchers.map((p, i) => (
-                      <tr key={i} className="border-b border-gray-800 text-gray-300">
-                        <td className="py-2 pr-3">
-                          <div className="font-medium text-white">{p.name}</div>
-                          {p.note && <div className="text-gray-500 text-xs">{p.note}</div>}
+                      <tr key={i} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                        <td style={{ padding: "7px 8px" }}>
+                          <div style={{ fontWeight: 600, color: "var(--ink-0)" }}>{p.name}</div>
+                          {p.note && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{p.note}</div>}
                         </td>
-                        <td className="text-right px-2">{p.era}</td>
-                        <td className="text-right px-2">{p.ip}</td>
-                        <td className="text-right px-2">{p.h}</td>
-                        <td className="text-right px-2">{p.r}</td>
-                        <td className="text-right px-2">{p.er}</td>
-                        <td className="text-right px-2">{p.hr}</td>
-                        <td className="text-right px-2">{p.k}</td>
-                        <td className="text-right px-2">{p.bb}</td>
-                        <td className="text-right px-2">{p.pitches}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.era}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.ip}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.h}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.r}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.er}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.hr}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.k}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.bb}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{p.pitches}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
 
-              {/* 野手 */}
-              <p className="text-xs text-gray-500 font-semibold uppercase tracking-wider mb-2">Batters</p>
-              <div className="overflow-x-auto">
-                <table className="w-full text-xs">
+              {/* Batters */}
+              <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginBottom: 8 }}>BATTERS</div>
+              <div style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", fontSize: 11, borderCollapse: "collapse" }}>
                   <thead>
-                    <tr className="text-gray-500 border-b border-gray-700">
-                      <th className="text-left py-1.5 pr-3 font-medium min-w-[120px]">BATTER</th>
-                      <th className="text-right py-1.5 px-2 font-medium">AVG</th>
-                      <th className="text-right py-1.5 px-2 font-medium">AB</th>
-                      <th className="text-right py-1.5 px-2 font-medium">H</th>
-                      <th className="text-right py-1.5 px-2 font-medium">R</th>
-                      <th className="text-right py-1.5 px-2 font-medium">RBI</th>
-                      <th className="text-right py-1.5 px-2 font-medium">HR</th>
-                      <th className="text-right py-1.5 px-2 font-medium">BB</th>
-                      <th className="text-right py-1.5 px-2 font-medium">K</th>
-                      <th className="text-right py-1.5 px-2 font-medium">OBP</th>
-                      <th className="text-right py-1.5 px-2 font-medium">SLG</th>
-                      <th className="text-right py-1.5 px-2 font-medium">OPS</th>
+                    <tr>
+                      {['BATTER','AVG','AB','H','R','RBI','HR','BB','K','OBP','SLG','OPS'].map(h => (
+                        <th key={h} style={thStyle(h === 'BATTER')}>{h}</th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
                     {boxscore[activeTab]?.batters.map((b, i) => (
-                      <tr key={i} className="border-b border-gray-800 text-gray-300">
-                        <td className="py-2 pr-3">
-                          <div className="font-medium text-white">{b.name}</div>
-                          <div className="text-gray-500">{b.position}</div>
+                      <tr key={i} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                        <td style={{ padding: "7px 8px" }}>
+                          <div style={{ fontWeight: 600, color: "var(--ink-0)" }}>{b.name}</div>
+                          <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{b.position}</div>
                         </td>
-                        <td className="text-right px-2">{b.avg}</td>
-                        <td className="text-right px-2">{b.ab}</td>
-                        <td className="text-right px-2">{b.h}</td>
-                        <td className="text-right px-2">{b.r}</td>
-                        <td className="text-right px-2">{b.rbi}</td>
-                        <td className="text-right px-2">{b.hr}</td>
-                        <td className="text-right px-2">{b.bb}</td>
-                        <td className="text-right px-2">{b.k}</td>
-                        <td className="text-right px-2">{b.obp}</td>
-                        <td className="text-right px-2">{b.slg}</td>
-                        <td className="text-right px-2">{b.ops}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.avg}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.ab}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.h}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.r}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.rbi}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.hr}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.bb}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.k}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.obp}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.slg}</td>
+                        <td className="t-mono" style={{ textAlign: "right", padding: "7px 8px", color: "var(--ink-2)" }}>{b.ops}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -203,41 +216,46 @@ const BoxscoreModal = ({ game, onClose, getIdToken }) => {
   );
 };
 
+// ===== ゲームカード (進行中) =====
 const GameCard = ({ game }) => {
   const inningText = `${game.inning}回${game.inning_half === 'Top' ? '表' : '裏'}`;
   const hasRunners = game.runners && (game.runners.first || game.runners.second || game.runners.third);
 
   return (
-    <div className="bg-gray-800 border border-gray-700 rounded-xl p-5 flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3 text-lg font-bold text-white">
-          <span>{game.away_team}</span>
-          <span className="text-2xl text-yellow-400">{game.away_score}</span>
-          <span className="text-gray-500 text-base font-normal">vs</span>
-          <span className="text-2xl text-yellow-400">{game.home_score}</span>
-          <span>{game.home_team}</span>
+    <div style={{ border: "1px solid var(--rule)", background: "var(--bg-1)", padding: 16, display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Score + inning */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, fontFamily: "var(--ff-mono)", fontWeight: 700, fontSize: 15 }}>
+          <span style={{ color: "var(--ink-0)" }}>{game.away_team}</span>
+          <span style={{ fontSize: 22, color: "var(--amber)" }}>{game.away_score}</span>
+          <span style={{ color: "var(--ink-3)", fontSize: 13, fontWeight: 400 }}>vs</span>
+          <span style={{ fontSize: 22, color: "var(--amber)" }}>{game.home_score}</span>
+          <span style={{ color: "var(--ink-0)" }}>{game.home_team}</span>
         </div>
-        <span className="text-sm text-green-400 font-semibold bg-green-900/40 px-2 py-0.5 rounded-full">
+        <span className="t-mono" style={{ fontSize: 11, color: "var(--pos)", border: "1px solid var(--pos-dim)", padding: "2px 8px" }}>
           {inningText}
         </span>
       </div>
 
-      <div className="flex items-center gap-3">
-        <div className="grid grid-cols-2 gap-2 text-sm flex-1">
-          <div className="bg-gray-700/50 rounded-lg px-3 py-2">
-            <span className="text-gray-400 text-xs block mb-0.5">投手</span>
-            <span className="text-white font-medium">{game.pitcher}</span>
+      {/* Pitcher / Batter + Base diamond */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, flex: 1 }}>
+          {/* Pitcher */}
+          <div style={{ border: "1px solid var(--rule)", background: "var(--bg-0)", padding: "8px 10px" }}>
+            <span className="h-label" style={{ fontSize: 8, color: "var(--ink-4)", display: "block", marginBottom: 2 }}>投手</span>
+            <span style={{ fontSize: 13, color: "var(--ink-0)", fontWeight: 600 }}>{game.pitcher}</span>
             {game.pitcher_stats?.pitches > 0 && (
-              <span className="text-gray-400 text-xs block mt-0.5 font-mono">
+              <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", display: "block", marginTop: 2 }}>
                 {game.pitcher_stats.pitches}P | {game.pitcher_stats.ip}IP {game.pitcher_stats.k}K {game.pitcher_stats.er}ER
               </span>
             )}
           </div>
-          <div className="bg-gray-700/50 rounded-lg px-3 py-2">
-            <span className="text-gray-400 text-xs block mb-0.5">打者</span>
-            <span className="text-white font-medium">{game.batter}</span>
+          {/* Batter */}
+          <div style={{ border: "1px solid var(--rule)", background: "var(--bg-0)", padding: "8px 10px" }}>
+            <span className="h-label" style={{ fontSize: 8, color: "var(--ink-4)", display: "block", marginBottom: 2 }}>打者</span>
+            <span style={{ fontSize: 13, color: "var(--ink-0)", fontWeight: 600 }}>{game.batter}</span>
             {game.batter_stats && (
-              <span className="text-gray-400 text-xs block mt-0.5 font-mono">
+              <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", display: "block", marginTop: 2 }}>
                 {game.batter_stats.h}-{game.batter_stats.ab}
                 {game.batter_stats.rbi > 0 && ` | ${game.batter_stats.rbi}RBI`}
                 {game.batter_stats.hr > 0 && ` ${game.batter_stats.hr}HR`}
@@ -247,54 +265,61 @@ const GameCard = ({ game }) => {
             )}
           </div>
         </div>
-        <div className="flex flex-col items-center gap-1">
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
           <BaseDiamond runners={game.runners || {}} />
-          <span className="text-xs font-mono text-gray-300 whitespace-nowrap">
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-2)", whiteSpace: "nowrap" }}>
             {game.balls}-{game.strikes}, {game.outs} Out{game.outs !== 1 ? 's' : ''}
           </span>
         </div>
       </div>
 
-      <div className="flex items-center gap-2 text-sm flex-wrap">
+      {/* Last pitch chips */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
         {game.last_pitch?.pitch_type && (
-          <span className="bg-blue-900/50 border border-blue-700/50 text-blue-300 rounded px-2 py-1 font-medium">
+          <span className="t-mono" style={{
+            fontSize: 11, padding: "2px 8px",
+            border: "1px solid var(--info)", color: "var(--info)",
+            background: "oklch(from var(--info) l c h / 0.08)",
+          }}>
             {game.last_pitch.pitch_type}
           </span>
         )}
         {game.last_pitch?.speed && (
-          <span className="bg-gray-700 rounded px-2 py-1 text-gray-300 font-mono">
+          <span className="t-mono" style={{ fontSize: 11, padding: "2px 8px", border: "1px solid var(--rule)", color: "var(--ink-1)" }}>
             {game.last_pitch.speed.toFixed(1)} mph
           </span>
         )}
         {game.last_pitch?.pitch_call && (
-          <span className="text-gray-500 text-xs">— {game.last_pitch.pitch_call}</span>
+          <span style={{ fontSize: 11, color: "var(--ink-3)" }}>— {game.last_pitch.pitch_call}</span>
         )}
         {game.last_event && !game.last_pitch?.pitch_call && (
-          <span className="text-gray-400 truncate">— {game.last_event}</span>
+          <span style={{ fontSize: 11, color: "var(--ink-2)" }}>— {game.last_event}</span>
         )}
       </div>
 
+      {/* Runners on base */}
       {hasRunners && (
-        <div className="flex gap-3 text-xs text-gray-400">
-          {game.runners.third && <span>3塁: <span className="text-white">{game.runners.third}</span></span>}
-          {game.runners.second && <span>2塁: <span className="text-white">{game.runners.second}</span></span>}
-          {game.runners.first && <span>1塁: <span className="text-white">{game.runners.first}</span></span>}
+        <div style={{ display: "flex", gap: 12, fontSize: 11, color: "var(--ink-3)" }}>
+          {game.runners.third && <span>3塁: <span style={{ color: "var(--ink-0)" }}>{game.runners.third}</span></span>}
+          {game.runners.second && <span>2塁: <span style={{ color: "var(--ink-0)" }}>{game.runners.second}</span></span>}
+          {game.runners.first && <span>1塁: <span style={{ color: "var(--ink-0)" }}>{game.runners.first}</span></span>}
         </div>
       )}
 
+      {/* Scoring plays */}
       {game.scoring_plays?.length > 0 && (
-        <div className="flex flex-col gap-1">
-          <span className="text-xs text-gray-500">Runs</span>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span className="h-label" style={{ fontSize: 8, color: "var(--ink-4)" }}>RUNS</span>
           {game.scoring_plays.map((sp, i) => (
-            <div key={i} className="flex items-center gap-2 text-xs">
-              <span className="text-yellow-400 font-bold w-12 shrink-0">
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11 }}>
+              <span className="t-mono" style={{ color: "var(--amber)", fontWeight: 700, minWidth: 32 }}>
                 {sp.runs > 0 ? `+${sp.runs}` : '—'}
               </span>
-              <span className="text-white font-medium">{sp.batter}</span>
-              <span className="text-gray-400">
+              <span style={{ color: "var(--ink-0)", fontWeight: 600 }}>{sp.batter}</span>
+              <span style={{ color: "var(--ink-2)" }}>
                 {sp.event}{sp.season_hr != null ? ` (${sp.season_hr})` : ''}
               </span>
-              <span className="text-gray-500">
+              <span style={{ color: "var(--ink-4)" }}>
                 {sp.half === 'top' ? '表' : '裏'}{sp.inning}回
               </span>
             </div>
@@ -302,21 +327,22 @@ const GameCard = ({ game }) => {
         </div>
       )}
 
+      {/* Pitch sequence */}
       {game.pitch_sequence?.length > 0 && (
-        <div className="bg-gray-900/50 rounded-lg px-3 py-2 flex flex-col gap-1">
-          <span className="text-xs text-gray-500 mb-1">投球シーケンス</span>
+        <div style={{ border: "1px solid var(--rule-dim)", background: "var(--bg-0)", padding: "8px 12px", display: "flex", flexDirection: "column", gap: 4 }}>
+          <span className="h-label" style={{ fontSize: 8, color: "var(--ink-4)", marginBottom: 2 }}>投球シーケンス</span>
           {[...game.pitch_sequence].reverse().map((p) => {
             const call = p.pitch_call ?? '';
             const isStrike = /strike|foul/i.test(call);
             const isBall = /ball/i.test(call);
             const isInPlay = /^in play/i.test(call);
-            const callColor = isStrike ? 'text-red-400' : isBall ? 'text-blue-400' : isInPlay ? 'text-green-400' : 'text-gray-400';
+            const callColor = isStrike ? 'var(--neg)' : isBall ? 'var(--info)' : isInPlay ? 'var(--pos)' : 'var(--ink-3)';
             return (
-              <div key={p.num} className="flex items-center gap-2 text-xs font-mono">
-                <span className="text-gray-600 w-4 text-right">{p.num}:</span>
-                <span className={`font-semibold ${callColor}`}>{call || '—'}</span>
+              <div key={p.num} className="t-mono" style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11 }}>
+                <span style={{ color: "var(--ink-4)", width: 16, textAlign: "right" }}>{p.num}:</span>
+                <span style={{ fontWeight: 600, color: callColor }}>{call || '—'}</span>
                 {p.pitch_type && (
-                  <span className="text-gray-500">({p.pitch_type}{p.speed != null ? ` / ${p.speed} mph` : ''})</span>
+                  <span style={{ color: "var(--ink-4)" }}>({p.pitch_type}{p.speed != null ? ` / ${p.speed} mph` : ''})</span>
                 )}
               </div>
             );
@@ -327,7 +353,7 @@ const GameCard = ({ game }) => {
   );
 };
 
-// JST の日付情報を返すユーティリティ
+// ===== JST 日付ユーティリティ =====
 const getJstDateInfo = (offsetDays = 0) => {
   const now = new Date();
   const jst = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
@@ -338,6 +364,7 @@ const getJstDateInfo = (offsetDays = 0) => {
   return { label, dateStr };
 };
 
+// ===== メインコンポーネント =====
 const LiveScoreboard = () => {
   const { getIdToken } = useAuth();
   const getIdTokenRef = useRef(getIdToken);
@@ -425,7 +452,6 @@ const LiveScoreboard = () => {
     if (activeTab !== 'today') {
       fetchSchedule(activeTab);
     }
-    // 今日・前日タブのみハイライト取得（未来日は対象外）
     const dateStr = activeTab === 'today' ? todayInfo.dateStr : activeTab;
     if (dateStr <= todayInfo.dateStr) {
       fetchHighlights(dateStr);
@@ -434,8 +460,31 @@ const LiveScoreboard = () => {
     }
   }, [activeTab, fetchSchedule, fetchHighlights, todayInfo.dateStr]);
 
+  const tabBtn = (active) => ({
+    padding: "5px 14px",
+    fontSize: 10.5,
+    fontFamily: "var(--ff-mono)",
+    letterSpacing: "0.06em",
+    fontWeight: active ? 600 : 400,
+    background: active ? "var(--amber)" : "transparent",
+    color: active ? "var(--bg-0)" : "var(--ink-3)",
+    border: `1px solid ${active ? "var(--amber)" : "var(--rule)"}`,
+    whiteSpace: "nowrap",
+    flexShrink: 0,
+    transition: "all .12s",
+  });
+
+  const LoadingState = () => (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "80px 0", gap: 8 }}>
+      <span className="think-dot"/>
+      <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+      <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+      <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 6 }}>取得中...</span>
+    </div>
+  );
+
   return (
-    <div className="w-full">
+    <div style={{ width: "100%" }}>
       {selectedGame && (
         <BoxscoreModal
           game={selectedGame}
@@ -444,64 +493,57 @@ const LiveScoreboard = () => {
         />
       )}
 
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2">
-          <Radio className="w-5 h-5 text-green-400 animate-pulse" />
-          <h2 className="text-xl font-bold text-white">試合速報</h2>
-          <span className="text-xs text-gray-500 ml-1">（60秒ごと自動更新）</span>
+      {/* Header */}
+      <div className="rule-b" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingBottom: 12, marginBottom: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span className="live-dot"/>
+          <span className="h-display" style={{ fontSize: 16 }}>試合速報</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>60秒ごと自動更新</span>
         </div>
         <button
           onClick={fetchGames}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+          style={{
+            display: "flex", alignItems: "center", gap: 6,
+            padding: "5px 12px", fontSize: 11,
+            border: "1px solid var(--rule)", color: "var(--ink-2)",
+            fontFamily: "var(--ff-mono)",
+          }}
         >
-          <RefreshCw className="w-3.5 h-3.5" />
+          <Icon name="refresh" size={12}/>
           更新
         </button>
       </div>
 
-      {/* 日付タブ */}
-      <div className="flex gap-1 mb-4 bg-gray-800 rounded-lg p-1 overflow-x-auto w-full">
-        <button
-          onClick={() => setActiveTab(yesterdayInfo.dateStr)}
-          className={`px-4 py-1.5 rounded-md text-sm font-medium whitespace-nowrap transition-colors flex-shrink-0 ${activeTab === yesterdayInfo.dateStr ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-white'
-            }`}
-        >
+      {/* Date tabs */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 14, overflowX: "auto", paddingBottom: 2 }} className="scrollbar-none">
+        <button onClick={() => setActiveTab(yesterdayInfo.dateStr)} style={tabBtn(activeTab === yesterdayInfo.dateStr)}>
           {yesterdayInfo.label}
         </button>
-        <button
-          onClick={() => setActiveTab('today')}
-          className={`px-4 py-1.5 rounded-md text-sm font-medium whitespace-nowrap transition-colors flex-shrink-0 ${activeTab === 'today' ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-white'
-            }`}
-        >
+        <button onClick={() => setActiveTab('today')} style={tabBtn(activeTab === 'today')}>
           {todayInfo.label}
         </button>
         {futureDays.map(day => (
-          <button
-            key={day.dateStr}
-            onClick={() => setActiveTab(day.dateStr)}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium whitespace-nowrap transition-colors flex-shrink-0 ${activeTab === day.dateStr ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-white'
-              }`}
-          >
+          <button key={day.dateStr} onClick={() => setActiveTab(day.dateStr)} style={tabBtn(activeTab === day.dateStr)}>
             {day.label}
           </button>
         ))}
       </div>
 
+      {/* Last updated */}
       {lastUpdated && activeTab === 'today' && (
-        <p className="text-xs text-gray-500 mb-4">
+        <p className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", marginBottom: 12 }}>
           最終更新: {lastUpdated.toLocaleTimeString('ja-JP')}
         </p>
       )}
 
-      {/* ハイライト */}
+      {/* Highlights */}
       {highlights.length > 0 && (
-        <div className="bg-gray-800/60 border border-yellow-700/40 rounded-xl px-5 py-4 mb-4">
-          <p className="text-xs text-yellow-500/80 font-semibold uppercase tracking-wider mb-2">Highlights</p>
-          <ul className="flex flex-col gap-1.5">
+        <div style={{ border: "1px solid var(--amber-dim)", background: "oklch(from var(--bg-1) l c h / 0.6)", padding: "12px 16px", marginBottom: 16 }}>
+          <div className="h-label" style={{ fontSize: 9, color: "var(--amber)", marginBottom: 8 }}>HIGHLIGHTS</div>
+          <ul style={{ display: "flex", flexDirection: "column", gap: 6, listStyle: "none", margin: 0, padding: 0 }}>
             {highlights.map((h, i) => (
-              <li key={i} className="flex items-start gap-2 text-sm text-gray-200">
-                <span className="text-yellow-400 mt-0.5 flex-shrink-0">●</span>
+              <li key={i} style={{ display: "flex", alignItems: "flex-start", gap: 8, fontSize: 12, color: "var(--ink-1)" }}>
+                <span style={{ color: "var(--amber)", flexShrink: 0, marginTop: 2 }}>●</span>
                 <span>{h.text}</span>
               </li>
             ))}
@@ -509,67 +551,68 @@ const LiveScoreboard = () => {
         </div>
       )}
 
-      {/* 今日タブ */}
+      {/* Today tab content */}
       {activeTab === 'today' && (
-        loading ? (
-          <div className="flex items-center justify-center py-20 text-gray-400">
-            <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-            <span>取得中...</span>
-          </div>
-        ) : error ? (
-          <div className="bg-red-900/30 border border-red-700 rounded-xl p-6 text-center">
-            <p className="text-red-400 font-medium">データ取得エラー</p>
-            <p className="text-red-500 text-sm mt-1">{error}</p>
+        loading ? <LoadingState/> : error ? (
+          <div style={{ border: "1px solid var(--neg-dim)", background: "oklch(from var(--neg) l c h / 0.08)", padding: 24, textAlign: "center" }}>
+            <p style={{ color: "var(--neg)", fontWeight: 600, marginBottom: 4 }}>データ取得エラー</p>
+            <p className="t-mono" style={{ fontSize: 11, color: "var(--neg)", opacity: 0.7 }}>{error}</p>
           </div>
         ) : (
-          <div className="flex flex-col gap-6">
+          <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            {/* Live games */}
             {liveGames.length > 0 ? (
-              <div className="flex flex-col gap-4">
-                <p className="text-sm text-gray-400">{liveGames.length}試合進行中</p>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span className="live-dot"/>
+                  <span className="h-label" style={{ fontSize: 10, color: "var(--pos)" }}>{liveGames.length}試合進行中</span>
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(400px, 1fr))", gap: 14 }}>
                   {liveGames.map((game) => (
                     <GameCard key={game.gamePk} game={game} />
                   ))}
                 </div>
               </div>
             ) : (
-              <div className="bg-gray-800 border border-gray-700 rounded-xl p-8 text-center">
-                <Radio className="w-8 h-8 text-gray-600 mx-auto mb-2" />
-                <p className="text-gray-400">現在進行中の試合はありません</p>
+              <div style={{ border: "1px solid var(--rule)", background: "var(--bg-1)", padding: 32, textAlign: "center" }}>
+                <Icon name="radio" size={28} style={{ color: "var(--ink-4)", margin: "0 auto 8px" }}/>
+                <p style={{ color: "var(--ink-3)", fontSize: 13 }}>現在進行中の試合はありません</p>
               </div>
             )}
 
+            {/* Preview games */}
             {previewGames.length > 0 && (
-              <div className="flex flex-col gap-2">
-                <p className="text-sm text-gray-500 font-medium">本日予定</p>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <span className="h-label" style={{ fontSize: 10, color: "var(--ink-3)" }}>本日予定</span>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: 6 }}>
                   {previewGames.map((game) => (
                     <div
                       key={game.gamePk}
-                      className="bg-gray-800/40 border border-gray-700/40 rounded-lg px-4 py-3 flex items-center justify-between"
+                      style={{ border: "1px solid var(--rule-dim)", background: "var(--bg-1)", padding: "10px 14px", display: "flex", alignItems: "center", justifyContent: "space-between" }}
                     >
-                      <div className="flex items-center gap-2 text-sm">
-                        <div className="flex flex-col">
-                          <span className="text-gray-300">{game.away_team}</span>
-                          {game.away_wins != null && <span className="text-xs text-gray-500">{game.away_wins}-{game.away_losses}</span>}
+                      <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12 }}>
+                        <div>
+                          <div style={{ color: "var(--ink-1)" }}>{game.away_team}</div>
+                          {game.away_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.away_wins}-{game.away_losses}</div>}
                         </div>
-                        <span className="text-gray-600 mx-1">@</span>
-                        <div className="flex flex-col">
-                          <span className="text-gray-300">{game.home_team}</span>
-                          {game.home_wins != null && <span className="text-xs text-gray-500">{game.home_wins}-{game.home_losses}</span>}
+                        <span style={{ color: "var(--ink-4)", margin: "0 4px" }}>@</span>
+                        <div>
+                          <div style={{ color: "var(--ink-1)" }}>{game.home_team}</div>
+                          {game.home_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.home_wins}-{game.home_losses}</div>}
                         </div>
                       </div>
-                      <span className="text-sm text-blue-400 font-mono">{game.start_time_jst} JST</span>
+                      <span className="t-mono" style={{ fontSize: 11, color: "var(--info)" }}>{game.start_time_jst} JST</span>
                     </div>
                   ))}
                 </div>
               </div>
             )}
 
+            {/* Final games */}
             {finalGames.length > 0 && (
-              <div className="flex flex-col gap-2">
-                <p className="text-sm text-gray-500 font-medium">本日終了</p>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <span className="h-label" style={{ fontSize: 10, color: "var(--ink-3)" }}>本日終了</span>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: 6 }}>
                   {finalGames.map((game) => {
                     const awayWin = game.away_score > game.home_score;
                     const homeWin = game.home_score > game.away_score;
@@ -577,22 +620,24 @@ const LiveScoreboard = () => {
                       <button
                         key={game.gamePk}
                         onClick={() => setSelectedGame(game)}
-                        className="bg-gray-800/60 border border-gray-700/60 rounded-lg px-4 py-3 flex items-center justify-between hover:bg-gray-700/60 hover:border-gray-600 transition-colors text-left w-full"
+                        style={{ border: "1px solid var(--rule)", background: "var(--bg-1)", padding: "10px 14px", display: "flex", alignItems: "center", justifyContent: "space-between", textAlign: "left", width: "100%", transition: "all .12s" }}
+                        onMouseEnter={e => { e.currentTarget.style.background = "var(--bg-2)"; e.currentTarget.style.borderColor = "var(--rule-hi)"; }}
+                        onMouseLeave={e => { e.currentTarget.style.background = "var(--bg-1)"; e.currentTarget.style.borderColor = "var(--rule)"; }}
                       >
-                        <div className="flex items-center gap-2 text-sm">
-                          <div className="flex flex-col">
-                            <span className={awayWin ? 'text-white font-semibold' : 'text-gray-500'}>{game.away_team}</span>
-                            {game.away_wins != null && <span className="text-xs text-gray-500">{game.away_wins}-{game.away_losses}</span>}
+                        <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12 }}>
+                          <div>
+                            <div style={{ color: awayWin ? "var(--ink-0)" : "var(--ink-4)", fontWeight: awayWin ? 600 : 400 }}>{game.away_team}</div>
+                            {game.away_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.away_wins}-{game.away_losses}</div>}
                           </div>
-                          <span className={`font-bold text-base ${awayWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.away_score}</span>
-                          <span className="text-gray-600 mx-1">-</span>
-                          <span className={`font-bold text-base ${homeWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.home_score}</span>
-                          <div className="flex flex-col">
-                            <span className={homeWin ? 'text-white font-semibold' : 'text-gray-500'}>{game.home_team}</span>
-                            {game.home_wins != null && <span className="text-xs text-gray-500">{game.home_wins}-{game.home_losses}</span>}
+                          <span className="t-mono" style={{ fontSize: 15, fontWeight: 700, color: awayWin ? "var(--amber)" : "var(--ink-4)" }}>{game.away_score}</span>
+                          <span style={{ color: "var(--ink-4)" }}>-</span>
+                          <span className="t-mono" style={{ fontSize: 15, fontWeight: 700, color: homeWin ? "var(--amber)" : "var(--ink-4)" }}>{game.home_score}</span>
+                          <div>
+                            <div style={{ color: homeWin ? "var(--ink-0)" : "var(--ink-4)", fontWeight: homeWin ? 600 : 400 }}>{game.home_team}</div>
+                            {game.home_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.home_wins}-{game.home_losses}</div>}
                           </div>
                         </div>
-                        <span className="text-xs text-gray-600">Final →</span>
+                        <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", flexShrink: 0 }}>Final →</span>
                       </button>
                     );
                   })}
@@ -603,68 +648,63 @@ const LiveScoreboard = () => {
         )
       )}
 
-      {/* 前日・翌日以降タブ */}
+      {/* Other date tabs */}
       {activeTab !== 'today' && (
-        scheduleLoading ? (
-          <div className="flex items-center justify-center py-20 text-gray-400">
-            <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-            <span>取得中...</span>
-          </div>
-        ) : scheduledGames.length === 0 ? (
-          <div className="bg-gray-800 border border-gray-700 rounded-xl p-8 text-center">
-            <p className="text-gray-400">試合情報はありません</p>
+        scheduleLoading ? <LoadingState/> : scheduledGames.length === 0 ? (
+          <div style={{ border: "1px solid var(--rule)", background: "var(--bg-1)", padding: 32, textAlign: "center" }}>
+            <p style={{ color: "var(--ink-4)", fontSize: 13 }}>試合情報はありません</p>
           </div>
         ) : (
-          <div className="flex flex-col gap-2">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-              {scheduledGames.map((game) => {
-                if (game.status === 'Final') {
-                  const awayWin = game.away_score > game.home_score;
-                  const homeWin = game.home_score > game.away_score;
-                  return (
-                    <button
-                      key={game.gamePk}
-                      onClick={() => setSelectedGame(game)}
-                      className="bg-gray-800/60 border border-gray-700/60 rounded-lg px-4 py-3 flex items-center justify-between hover:bg-gray-700/60 hover:border-gray-600 transition-colors text-left w-full"
-                    >
-                      <div className="flex items-center gap-2 text-sm">
-                        <div className="flex flex-col">
-                          <span className={awayWin ? 'text-white font-semibold' : 'text-gray-500'}>{game.away_team}</span>
-                          {game.away_wins != null && <span className="text-xs text-gray-500">{game.away_wins}-{game.away_losses}</span>}
-                        </div>
-                        <span className={`font-bold text-base ${awayWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.away_score}</span>
-                        <span className="text-gray-600 mx-1">-</span>
-                        <span className={`font-bold text-base ${homeWin ? 'text-yellow-400' : 'text-gray-500'}`}>{game.home_score}</span>
-                        <div className="flex flex-col">
-                          <span className={homeWin ? 'text-white font-semibold' : 'text-gray-500'}>{game.home_team}</span>
-                          {game.home_wins != null && <span className="text-xs text-gray-500">{game.home_wins}-{game.home_losses}</span>}
-                        </div>
-                      </div>
-                      <span className="text-xs text-gray-600">Final →</span>
-                    </button>
-                  );
-                }
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: 6 }}>
+            {scheduledGames.map((game) => {
+              if (game.status === 'Final') {
+                const awayWin = game.away_score > game.home_score;
+                const homeWin = game.home_score > game.away_score;
                 return (
-                  <div
+                  <button
                     key={game.gamePk}
-                    className="bg-gray-800/40 border border-gray-700/40 rounded-lg px-4 py-3 flex items-center justify-between"
+                    onClick={() => setSelectedGame(game)}
+                    style={{ border: "1px solid var(--rule)", background: "var(--bg-1)", padding: "10px 14px", display: "flex", alignItems: "center", justifyContent: "space-between", textAlign: "left", width: "100%", transition: "all .12s" }}
+                    onMouseEnter={e => { e.currentTarget.style.background = "var(--bg-2)"; }}
+                    onMouseLeave={e => { e.currentTarget.style.background = "var(--bg-1)"; }}
                   >
-                    <div className="flex items-center gap-2 text-sm">
-                      <div className="flex flex-col">
-                        <span className="text-gray-300">{game.away_team}</span>
-                        {game.away_wins != null && <span className="text-xs text-gray-500">{game.away_wins}-{game.away_losses}</span>}
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12 }}>
+                      <div>
+                        <div style={{ color: awayWin ? "var(--ink-0)" : "var(--ink-4)", fontWeight: awayWin ? 600 : 400 }}>{game.away_team}</div>
+                        {game.away_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.away_wins}-{game.away_losses}</div>}
                       </div>
-                      <span className="text-gray-600 mx-1">@</span>
-                      <div className="flex flex-col">
-                        <span className="text-gray-300">{game.home_team}</span>
-                        {game.home_wins != null && <span className="text-xs text-gray-500">{game.home_wins}-{game.home_losses}</span>}
+                      <span className="t-mono" style={{ fontSize: 15, fontWeight: 700, color: awayWin ? "var(--amber)" : "var(--ink-4)" }}>{game.away_score}</span>
+                      <span style={{ color: "var(--ink-4)" }}>-</span>
+                      <span className="t-mono" style={{ fontSize: 15, fontWeight: 700, color: homeWin ? "var(--amber)" : "var(--ink-4)" }}>{game.home_score}</span>
+                      <div>
+                        <div style={{ color: homeWin ? "var(--ink-0)" : "var(--ink-4)", fontWeight: homeWin ? 600 : 400 }}>{game.home_team}</div>
+                        {game.home_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.home_wins}-{game.home_losses}</div>}
                       </div>
                     </div>
-                    <span className="text-sm text-blue-400 font-mono">{game.start_time_jst} JST</span>
-                  </div>
+                    <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>Final →</span>
+                  </button>
                 );
-              })}
-            </div>
+              }
+              return (
+                <div
+                  key={game.gamePk}
+                  style={{ border: "1px solid var(--rule-dim)", background: "var(--bg-1)", padding: "10px 14px", display: "flex", alignItems: "center", justifyContent: "space-between" }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12 }}>
+                    <div>
+                      <div style={{ color: "var(--ink-1)" }}>{game.away_team}</div>
+                      {game.away_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.away_wins}-{game.away_losses}</div>}
+                    </div>
+                    <span style={{ color: "var(--ink-4)", margin: "0 4px" }}>@</span>
+                    <div>
+                      <div style={{ color: "var(--ink-1)" }}>{game.home_team}</div>
+                      {game.home_wins != null && <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{game.home_wins}-{game.home_losses}</div>}
+                    </div>
+                  </div>
+                  <span className="t-mono" style={{ fontSize: 11, color: "var(--info)" }}>{game.start_time_jst} JST</span>
+                </div>
+              );
+            })}
           </div>
         )
       )}

--- a/frontend/src/components/Standings.jsx
+++ b/frontend/src/components/Standings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { RefreshCw, TrendingUp } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import Icon from './layout/Icon.jsx';
 
 const getBackendUrl = () => {
   if (window.location.hostname.includes('run.app')) {
@@ -15,88 +15,97 @@ const getBackendUrl = () => {
 
 const BACKEND_URL = getBackendUrl();
 
-// AL/NL の leagueId
 const AL_ID = 103;
 const NL_ID = 104;
 
-// 勝率の色分け
 const pctColor = (pct) => {
   const v = parseFloat(pct);
-  if (isNaN(v)) return 'text-gray-400';
-  if (v >= 0.600) return 'text-green-400 font-bold';
-  if (v >= 0.500) return 'text-gray-200';
-  return 'text-red-400';
+  if (isNaN(v)) return 'var(--ink-3)';
+  if (v >= 0.600) return 'var(--pos)';
+  if (v >= 0.500) return 'var(--ink-1)';
+  return 'var(--neg)';
 };
 
-// 連勝/連敗のバッジ色
 const streakColor = (code) => {
-  if (!code || code === '-') return 'text-gray-500';
-  if (code.startsWith('W')) return 'text-green-400';
-  return 'text-red-400';
+  if (!code || code === '-') return 'var(--ink-3)';
+  if (code.startsWith('W')) return 'var(--pos)';
+  return 'var(--neg)';
 };
+
+const TH_COLS = ["TEAM", "W", "L", "PCT", "GB", "HOME", "AWAY", "L10", "STREAK"];
 
 const DivisionTable = ({ division }) => (
-  <div className="mb-6">
-    {/* ディビジョン名ヘッダー */}
-    <div className="px-3 py-1.5 bg-gray-800 rounded-t-lg border-b border-gray-600">
-      <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+  <div style={{ marginBottom: 20 }}>
+    <div className="rule-b" style={{ padding: "5px 12px", background: "var(--bg-1)" }}>
+      <span className="h-label" style={{ fontSize: 10, color: "var(--ink-2)" }}>
         {division.division_name}
       </span>
     </div>
-
-    {/* テーブル */}
-    <div className="overflow-x-auto">
-      <table className="w-full text-xs">
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", fontSize: 11, borderCollapse: "collapse" }}>
         <thead>
-          <tr className="bg-gray-800/60 text-gray-500 uppercase">
-            <th className="text-left px-3 py-2 font-medium w-32">チーム</th>
-            <th className="text-center px-2 py-2 font-medium">W</th>
-            <th className="text-center px-2 py-2 font-medium">L</th>
-            <th className="text-center px-2 py-2 font-medium">PCT</th>
-            <th className="text-center px-2 py-2 font-medium">GB</th>
-            <th className="text-center px-2 py-2 font-medium hidden sm:table-cell">Home</th>
-            <th className="text-center px-2 py-2 font-medium hidden sm:table-cell">Away</th>
-            <th className="text-center px-2 py-2 font-medium">L10</th>
-            <th className="text-center px-2 py-2 font-medium">Streak</th>
+          <tr style={{ background: "var(--bg-1)" }}>
+            {TH_COLS.map(h => (
+              <th key={h} style={{
+                padding: "6px 8px",
+                fontFamily: "var(--ff-mono)",
+                fontWeight: 600,
+                fontSize: 10,
+                letterSpacing: "0.08em",
+                color: "var(--ink-3)",
+                textAlign: h === "TEAM" ? "left" : "center",
+                borderBottom: "1px solid var(--rule)",
+                whiteSpace: "nowrap",
+              }}>{h}</th>
+            ))}
           </tr>
         </thead>
         <tbody>
           {division.teams.map((team, idx) => (
             <tr
               key={team.team_id}
-              className={`border-b border-gray-700/50 transition-colors hover:bg-gray-700/30 ${
-                idx === 0 ? 'bg-gray-800/20' : ''
-              }`}
+              style={{
+                borderBottom: "1px solid var(--rule-dim)",
+                background: idx === 0 ? "oklch(from var(--bg-1) l c h / 0.5)" : "transparent",
+              }}
             >
-              {/* チーム名 */}
-              <td className="px-3 py-2.5">
-                <div className="flex items-center gap-2">
-                  <span className="text-gray-500 w-4 text-right text-[10px]">{idx + 1}</span>
-                  <span className={`font-semibold ${idx === 0 ? 'text-white' : 'text-gray-300'}`}>
+              <td style={{ padding: "7px 12px" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span className="t-mono" style={{ fontSize: 9, color: "var(--ink-4)", width: 14, textAlign: "right" }}>
+                    {idx + 1}
+                  </span>
+                  <span style={{
+                    fontWeight: idx === 0 ? 600 : 400,
+                    color: idx === 0 ? "var(--ink-0)" : "var(--ink-1)",
+                  }}>
                     {team.team_abbrev || team.team_name}
                   </span>
                 </div>
               </td>
-              <td className="text-center px-2 py-2.5 text-gray-200">{team.wins}</td>
-              <td className="text-center px-2 py-2.5 text-gray-200">{team.losses}</td>
-              <td className={`text-center px-2 py-2.5 ${pctColor(team.win_pct)}`}>
-                {team.win_pct}
+              <td className="t-mono" style={{ textAlign: "center", padding: "7px 8px", color: "var(--ink-1)" }}>{team.wins}</td>
+              <td className="t-mono" style={{ textAlign: "center", padding: "7px 8px", color: "var(--ink-1)" }}>{team.losses}</td>
+              <td className="t-mono" style={{
+                textAlign: "center", padding: "7px 8px",
+                color: pctColor(team.win_pct),
+                fontWeight: parseFloat(team.win_pct) >= 0.600 ? 600 : 400,
+              }}>{team.win_pct}</td>
+              <td className="t-mono" style={{ textAlign: "center", padding: "7px 8px", color: "var(--ink-3)" }}>
+                {team.games_back === '-' ? <span style={{ color: "var(--amber)" }}>—</span> : team.games_back}
               </td>
-              <td className="text-center px-2 py-2.5 text-gray-400">
-                {team.games_back === '-' ? <span className="text-yellow-400">—</span> : team.games_back}
-              </td>
-              <td className="text-center px-2 py-2.5 text-gray-400 hidden sm:table-cell">
+              <td className="t-mono" style={{ textAlign: "center", padding: "7px 8px", color: "var(--ink-3)" }}>
                 {team.home_wins}-{team.home_losses}
               </td>
-              <td className="text-center px-2 py-2.5 text-gray-400 hidden sm:table-cell">
+              <td className="t-mono" style={{ textAlign: "center", padding: "7px 8px", color: "var(--ink-3)" }}>
                 {team.away_wins}-{team.away_losses}
               </td>
-              <td className="text-center px-2 py-2.5 text-gray-300">
+              <td className="t-mono" style={{ textAlign: "center", padding: "7px 8px", color: "var(--ink-1)" }}>
                 {team.last_ten_wins}-{team.last_ten_losses}
               </td>
-              <td className={`text-center px-2 py-2.5 font-medium ${streakColor(team.streak)}`}>
-                {team.streak || '-'}
-              </td>
+              <td className="t-mono" style={{
+                textAlign: "center", padding: "7px 8px",
+                color: streakColor(team.streak),
+                fontWeight: 600,
+              }}>{team.streak || '-'}</td>
             </tr>
           ))}
         </tbody>
@@ -106,10 +115,10 @@ const DivisionTable = ({ division }) => (
 );
 
 const LeagueSection = ({ leagueName, divisions }) => (
-  <div className="mb-8">
-    <h2 className="text-sm font-bold text-blue-400 uppercase tracking-widest mb-3 px-1">
-      {leagueName}
-    </h2>
+  <div style={{ marginBottom: 28 }}>
+    <div style={{ paddingBottom: 8, borderBottom: "1px solid var(--amber-dim)", marginBottom: 12 }}>
+      <span className="h-label" style={{ color: "var(--amber)", fontSize: 11 }}>{leagueName}</span>
+    </div>
     {divisions.map((div) => (
       <DivisionTable key={div.division_name} division={div} />
     ))}
@@ -122,7 +131,7 @@ export default function Standings() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [viewMode, setViewMode] = useState('division'); // 'division' | 'league'
+  const [viewMode, setViewMode] = useState('division');
   const [activeLeague, setActiveLeague] = useState('AL');
   const [updatedAt, setUpdatedAt] = useState(null);
 
@@ -151,11 +160,9 @@ export default function Standings() {
     fetchStandings();
   }, [fetchStandings]);
 
-  // Division view: AL/NL 別に仕分け
   const alDivisions = data?.standings?.filter((d) => d.league_id === AL_ID) ?? [];
   const nlDivisions = data?.standings?.filter((d) => d.league_id === NL_ID) ?? [];
 
-  // League view: リーグ内全チームを勝率順に並べる
   const buildLeagueRanking = (divisions) =>
     divisions
       .flatMap((d) => d.teams)
@@ -169,22 +176,36 @@ export default function Standings() {
     teams: activeLeague === 'AL' ? alTeams : nlTeams,
   };
 
+  const tabBtn = (active) => ({
+    padding: "5px 16px",
+    fontSize: 11,
+    fontFamily: "var(--ff-mono)",
+    letterSpacing: "0.06em",
+    fontWeight: active ? 600 : 400,
+    background: active ? "var(--amber)" : "transparent",
+    color: active ? "var(--bg-0)" : "var(--ink-3)",
+    border: `1px solid ${active ? "var(--amber)" : "var(--rule)"}`,
+    transition: "all .12s",
+  });
+
   return (
-    <div className="w-full max-w-3xl mx-auto">
-      {/* ヘッダー */}
-      <div className="flex items-center justify-between mb-5">
-        <div className="flex items-center gap-3">
-          <TrendingUp className="w-5 h-5 text-blue-400" />
-          <h1 className="text-lg font-bold text-white">
+    <div style={{ width: "100%", maxWidth: 780, margin: "0 auto" }}>
+      {/* Header */}
+      <div className="rule-b" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingBottom: 12, marginBottom: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <Icon name="chart" size={16} style={{ color: "var(--amber)" }}/>
+          <span className="h-display" style={{ fontSize: 16 }}>
             Standings
-            {data?.season && (
-              <span className="ml-2 text-sm font-normal text-gray-500">{data.season}</span>
-            )}
-          </h1>
+          </span>
+          {data?.season && (
+            <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+              {data.season}
+            </span>
+          )}
         </div>
-        <div className="flex items-center gap-3">
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
           {updatedAt && (
-            <span className="text-[11px] text-gray-500">
+            <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>
               更新: {updatedAt.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}{' '}
               {updatedAt.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
             </span>
@@ -192,63 +213,55 @@ export default function Standings() {
           <button
             onClick={fetchStandings}
             disabled={loading}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-400 hover:text-white bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors disabled:opacity-50"
+            style={{
+              display: "flex", alignItems: "center", gap: 6,
+              padding: "5px 12px", fontSize: 11,
+              border: "1px solid var(--rule)", color: "var(--ink-2)",
+              opacity: loading ? 0.5 : 1,
+              fontFamily: "var(--ff-mono)",
+            }}
           >
-            <RefreshCw className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`} />
+            <Icon name="refresh" size={12} className={loading ? "dl-spin" : ""}/>
             更新
           </button>
         </div>
       </div>
 
-      {/* League / Division タブ */}
-      <div className="flex gap-1 mb-4 bg-gray-800 p-1 rounded-lg w-fit">
+      {/* View mode tabs */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
         {['division', 'league'].map((mode) => (
-          <button
-            key={mode}
-            onClick={() => setViewMode(mode)}
-            className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
-              viewMode === mode
-                ? 'bg-blue-600 text-white'
-                : 'text-gray-400 hover:text-white'
-            }`}
-          >
-            {mode === 'division' ? 'Division' : 'League'}
+          <button key={mode} onClick={() => setViewMode(mode)} style={tabBtn(viewMode === mode)}>
+            {mode === 'division' ? 'DIVISION' : 'LEAGUE'}
           </button>
         ))}
       </div>
 
-      {/* League ビュー時の AL/NL 切替 */}
+      {/* League view AL/NL toggle */}
       {viewMode === 'league' && (
-        <div className="flex gap-1 mb-4 bg-gray-800 p-1 rounded-lg w-fit">
+        <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
           {['AL', 'NL'].map((lg) => (
-            <button
-              key={lg}
-              onClick={() => setActiveLeague(lg)}
-              className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                activeLeague === lg
-                  ? 'bg-gray-600 text-white'
-                  : 'text-gray-400 hover:text-white'
-              }`}
-            >
+            <button key={lg} onClick={() => setActiveLeague(lg)} style={tabBtn(activeLeague === lg)}>
               {lg}
             </button>
           ))}
         </div>
       )}
 
-      {/* コンテンツ */}
+      {/* Content */}
       {loading ? (
-        <div className="flex items-center justify-center py-24 text-gray-400">
-          <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-          <span>データ取得中...</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "80px 0", gap: 8 }}>
+          <span className="think-dot"/>
+          <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+          <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+          <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 6 }}>取得中...</span>
         </div>
       ) : error ? (
-        <div className="flex flex-col items-center justify-center py-24 text-gray-500">
-          <p className="text-red-400 mb-3">データを取得できませんでした</p>
-          <p className="text-xs text-gray-600">{error}</p>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "80px 0", gap: 10 }}>
+          <span style={{ color: "var(--neg)", fontSize: 13 }}>データを取得できませんでした</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>{error}</span>
           <button
             onClick={fetchStandings}
-            className="mt-4 px-4 py-2 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            style={{ marginTop: 8, padding: "6px 16px", fontSize: 12, border: "1px solid var(--rule)", color: "var(--ink-2)" }}
           >
             再試行
           </button>
@@ -262,13 +275,13 @@ export default function Standings() {
         <DivisionTable division={leagueDivision} />
       )}
 
-      {/* 凡例 */}
+      {/* Legend */}
       {!loading && !error && (
-        <div className="mt-4 flex flex-wrap gap-3 text-[10px] text-gray-600 px-1">
-          <span>GB = Games Behind</span>
-          <span>L10 = Last 10 Games</span>
-          <span className="text-green-600">W = Winning Streak</span>
-          <span className="text-red-600">L = Losing Streak</span>
+        <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: 12 }}>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>GB = Games Behind</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>L10 = Last 10 Games</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--pos)" }}>W = Winning Streak</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--neg)" }}>L = Losing Streak</span>
         </div>
       )}
     </div>

--- a/frontend/src/components/StuffPlus.jsx
+++ b/frontend/src/components/StuffPlus.jsx
@@ -1,12 +1,24 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, Legend } from 'recharts';
-import { Target, Search, ArrowUpDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import Icon from './layout/Icon.jsx';
+
+// Recharts SVG hardcoded colors (CSS vars don't work reliably in SVG attributes)
+const C_GRID   = '#3a3520';
+const C_AXIS   = '#7a6a45';
+const C_TICK   = '#9a8a6a';
+const C_AMBER  = 'oklch(0.80 0.165 80)';
+const C_POS    = 'oklch(0.78 0.165 148)';
+const C_NEG    = 'oklch(0.70 0.180 28)';
+const C_INFO   = 'oklch(0.75 0.120 240)';
+const C_PURP   = 'oklch(0.72 0.150 310)';
+
+const PITCH_COLORS = [C_AMBER, C_NEG, C_POS, C_INFO, C_PURP,
+  'oklch(0.82 0.15 340)', 'oklch(0.78 0.14 200)', 'oklch(0.75 0.16 55)'];
 
 const StuffPlus = () => {
   const { getIdToken } = useAuth();
-  // サブビュー切替
-  const [view, setView] = useState('rankings'); // 'rankings' | 'detail' | 'compare' | 'trend'
+  const [view, setView] = useState('rankings');
 
   // Rankings state
   const [rankings, setRankings] = useState([]);
@@ -47,11 +59,9 @@ const StuffPlus = () => {
   const [trendResult, setTrendResult] = useState(null);
   const trendSearchRef = useRef(null);
 
-  // Shared
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  // Backend URL detection (既存パターン準拠)
   const getBackendUrl = () => {
     if (window.location.hostname.includes('run.app')) {
       return 'https://mlb-diamond-lens-api-907924272679.asia-northeast1.run.app';
@@ -65,7 +75,6 @@ const StuffPlus = () => {
 
   const BACKEND_URL = getBackendUrl();
 
-  // 認証ヘッダー取得
   const getAuthHeaders = async () => {
     const idToken = await getIdToken();
     return {
@@ -76,7 +85,34 @@ const StuffPlus = () => {
   };
 
   // ----------------------------------------------------------
-  // 選手名検索 API
+  // スコア色 (CSS var文字列を返す)
+  // ----------------------------------------------------------
+  const getScoreColor = (score) => {
+    if (score >= 120) return C_POS;
+    if (score >= 110) return 'oklch(0.73 0.145 148)';
+    if (score >= 90)  return C_AMBER;
+    if (score >= 80)  return 'oklch(0.78 0.16 50)';
+    return C_NEG;
+  };
+
+  const getBarColor = (score) => {
+    if (score >= 120) return C_POS;
+    if (score >= 110) return 'oklch(0.73 0.145 148)';
+    if (score >= 90)  return C_AMBER;
+    if (score >= 80)  return 'oklch(0.78 0.16 50)';
+    return C_NEG;
+  };
+
+  const getProfileStyle = (profile) => {
+    switch (profile) {
+      case 'stuff_dominant':   return { background: "oklch(0.75 0.12 240 / 0.15)", color: C_INFO, border: "1px solid oklch(0.75 0.12 240 / 0.3)" };
+      case 'command_dominant': return { background: "oklch(0.72 0.15 310 / 0.15)", color: C_PURP, border: "1px solid oklch(0.72 0.15 310 / 0.3)" };
+      default:                 return { background: "oklch(0.78 0.165 148 / 0.15)", color: C_POS,  border: "1px solid oklch(0.78 0.165 148 / 0.3)" };
+    }
+  };
+
+  // ----------------------------------------------------------
+  // 選手名検索
   // ----------------------------------------------------------
   const searchPitchers = async (query, season) => {
     if (!query || query.length < 2) return [];
@@ -91,7 +127,6 @@ const StuffPlus = () => {
     }
   };
 
-  // Detail 検索デバウンス
   useEffect(() => {
     if (detailSearchQuery.length < 2) { setDetailSuggestions([]); return; }
     const timer = setTimeout(async () => {
@@ -102,7 +137,6 @@ const StuffPlus = () => {
     return () => clearTimeout(timer);
   }, [detailSearchQuery, detailSeason]);
 
-  // Compare 検索デバウンス
   useEffect(() => {
     if (compareSearchQuery.length < 2) { setCompareSuggestions([]); return; }
     const timer = setTimeout(async () => {
@@ -113,7 +147,6 @@ const StuffPlus = () => {
     return () => clearTimeout(timer);
   }, [compareSearchQuery, compareSeason]);
 
-  // Trend 検索デバウンス
   useEffect(() => {
     if (trendSearchQuery.length < 2) { setTrendSuggestions([]); return; }
     const timer = setTimeout(async () => {
@@ -124,98 +157,45 @@ const StuffPlus = () => {
     return () => clearTimeout(timer);
   }, [trendSearchQuery, trendSeason]);
 
-  // クリック外で候補を閉じる
   useEffect(() => {
     const handleClickOutside = (e) => {
-      if (detailSearchRef.current && !detailSearchRef.current.contains(e.target)) {
-        setDetailShowSuggestions(false);
-      }
-      if (compareSearchRef.current && !compareSearchRef.current.contains(e.target)) {
-        setCompareShowSuggestions(false);
-      }
-      if (trendSearchRef.current && !trendSearchRef.current.contains(e.target)) {
-        setTrendShowSuggestions(false);
-      }
+      if (detailSearchRef.current && !detailSearchRef.current.contains(e.target)) setDetailShowSuggestions(false);
+      if (compareSearchRef.current && !compareSearchRef.current.contains(e.target)) setCompareShowSuggestions(false);
+      if (trendSearchRef.current && !trendSearchRef.current.contains(e.target)) setTrendShowSuggestions(false);
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
   // ----------------------------------------------------------
-  // スコアに応じた色
-  // ----------------------------------------------------------
-  const getScoreColor = (score) => {
-    if (score >= 120) return 'text-green-400';
-    if (score >= 110) return 'text-emerald-400';
-    if (score >= 90) return 'text-yellow-400';
-    if (score >= 80) return 'text-orange-400';
-    return 'text-red-400';
-  };
-
-  const getScoreBgColor = (score) => {
-    if (score >= 120) return 'bg-green-500/20 border-green-500/30';
-    if (score >= 110) return 'bg-emerald-500/20 border-emerald-500/30';
-    if (score >= 90) return 'bg-yellow-500/20 border-yellow-500/30';
-    if (score >= 80) return 'bg-orange-500/20 border-orange-500/30';
-    return 'bg-red-500/20 border-red-500/30';
-  };
-
-  const getBarColor = (score) => {
-    if (score >= 120) return '#22c55e';
-    if (score >= 110) return '#10b981';
-    if (score >= 90) return '#eab308';
-    if (score >= 80) return '#f97316';
-    return '#ef4444';
-  };
-
-  // ----------------------------------------------------------
-  // Rankings 取得
+  // API fetchers
   // ----------------------------------------------------------
   const fetchRankings = async () => {
-    setIsLoading(true);
-    setError(null);
+    setIsLoading(true); setError(null);
     try {
       const params = new URLSearchParams({
-        model_type: rankingsModelType,
-        season: rankingsSeason,
-        limit: rankingsLimit,
-        offset: rankingsOffset,
-        sort_order: rankingsSortOrder,
-        min_pitches: rankingsMinPitches,
+        model_type: rankingsModelType, season: rankingsSeason,
+        limit: rankingsLimit, offset: rankingsOffset,
+        sort_order: rankingsSortOrder, min_pitches: rankingsMinPitches,
       });
       const headers = await getAuthHeaders();
       const res = await fetch(`${BACKEND_URL}/api/v1/stuff-plus/rankings?${params}`, { headers });
       if (!res.ok) throw new Error(`API error: ${res.status}`);
       const data = await res.json();
-      const filtered = (data.rankings || []).filter(r => r.pitch_name !== 'Pitch Out');
-      setRankings(filtered);
+      setRankings((data.rankings || []).filter(r => r.pitch_name !== 'Pitch Out'));
       setRankingsTotal(data.total || 0);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setIsLoading(false);
-    }
+    } catch (e) { setError(e.message); } finally { setIsLoading(false); }
   };
 
   useEffect(() => {
-    if (view === 'rankings') {
-      fetchRankings();
-    }
+    if (view === 'rankings') fetchRankings();
   }, [view, rankingsModelType, rankingsSeason, rankingsSortOrder, rankingsOffset, rankingsMinPitches]);
 
-  // ----------------------------------------------------------
-  // Pitcher Detail 取得
-  // ----------------------------------------------------------
   const fetchPitcherDetail = async () => {
     if (!detailPitcherId) return;
-    setIsLoading(true);
-    setError(null);
-    setDetailResult(null);
+    setIsLoading(true); setError(null); setDetailResult(null);
     try {
-      const params = new URLSearchParams({
-        model_type: detailModelType,
-        season: detailSeason,
-      });
+      const params = new URLSearchParams({ model_type: detailModelType, season: detailSeason });
       const headers = await getAuthHeaders();
       const res = await fetch(`${BACKEND_URL}/api/v1/stuff-plus/pitcher/${detailPitcherId}?${params}`, { headers });
       if (!res.ok) {
@@ -224,32 +204,18 @@ const StuffPlus = () => {
         throw new Error(`API error: ${res.status}`);
       }
       const data = await res.json();
-      if (data.pitches) {
-        data.pitches = data.pitches.filter(p => p.pitch_name !== 'Pitch Out');
-      }
+      if (data.pitches) data.pitches = data.pitches.filter(p => p.pitch_name !== 'Pitch Out');
       setDetailResult(data);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setIsLoading(false);
-    }
+    } catch (e) { setError(e.message); } finally { setIsLoading(false); }
   };
 
-  // detailModelType 変更時に自動再取得
   useEffect(() => {
-    if (view === 'detail' && detailPitcherId) {
-      fetchPitcherDetail();
-    }
+    if (view === 'detail' && detailPitcherId) fetchPitcherDetail();
   }, [detailModelType]);
 
-  // ----------------------------------------------------------
-  // Compare 取得
-  // ----------------------------------------------------------
   const fetchCompare = async () => {
     if (!comparePitcherId) return;
-    setIsLoading(true);
-    setError(null);
-    setCompareResult(null);
+    setIsLoading(true); setError(null); setCompareResult(null);
     try {
       const params = new URLSearchParams({ season: compareSeason });
       const headers = await getAuthHeaders();
@@ -260,30 +226,16 @@ const StuffPlus = () => {
         throw new Error(`API error: ${res.status}`);
       }
       const data = await res.json();
-      if (data.comparison) {
-        data.comparison = data.comparison.filter(c => c.pitch_name !== 'Pitch Out');
-      }
+      if (data.comparison) data.comparison = data.comparison.filter(c => c.pitch_name !== 'Pitch Out');
       setCompareResult(data);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setIsLoading(false);
-    }
+    } catch (e) { setError(e.message); } finally { setIsLoading(false); }
   };
 
-  // ----------------------------------------------------------
-  // Monthly Trend 取得
-  // ----------------------------------------------------------
   const fetchTrend = async () => {
     if (!trendPitcherId) return;
-    setIsLoading(true);
-    setError(null);
-    setTrendResult(null);
+    setIsLoading(true); setError(null); setTrendResult(null);
     try {
-      const params = new URLSearchParams({
-        model_type: trendModelType,
-        season: trendSeason,
-      });
+      const params = new URLSearchParams({ model_type: trendModelType, season: trendSeason });
       const headers = await getAuthHeaders();
       const res = await fetch(`${BACKEND_URL}/api/v1/stuff-plus/pitcher/${trendPitcherId}/trend?${params}`, { headers });
       if (!res.ok) {
@@ -292,23 +244,13 @@ const StuffPlus = () => {
         throw new Error(`API error: ${res.status}`);
       }
       setTrendResult(await res.json());
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setIsLoading(false);
-    }
+    } catch (e) { setError(e.message); } finally { setIsLoading(false); }
   };
 
-  // trendModelType 変更時に自動再取得
   useEffect(() => {
-    if (view === 'trend' && trendPitcherId) {
-      fetchTrend();
-    }
+    if (view === 'trend' && trendPitcherId) fetchTrend();
   }, [trendModelType]);
 
-  // ----------------------------------------------------------
-  // Rankings ビュー内でクリックしてDetail遷移
-  // ----------------------------------------------------------
   const goToDetail = (pitcherId, playerName) => {
     setDetailPitcherId(String(pitcherId));
     setDetailSearchQuery(playerName || '');
@@ -317,190 +259,241 @@ const StuffPlus = () => {
   };
 
   // ----------------------------------------------------------
-  // カスタム Tooltip
+  // Shared style helpers
   // ----------------------------------------------------------
+  const inputStyle = {
+    border: "1px solid var(--rule)", background: "var(--bg-1)",
+    color: "var(--ink-0)", padding: "6px 10px", fontSize: 12,
+    fontFamily: "var(--ff-mono)",
+  };
+
+  const selectStyle = {
+    ...inputStyle, padding: "6px 10px",
+  };
+
+  const tabBtn = (active) => ({
+    padding: "5px 14px", fontSize: 11,
+    fontFamily: "var(--ff-mono)", letterSpacing: "0.06em",
+    background: active ? "var(--amber)" : "transparent",
+    color: active ? "var(--bg-0)" : "var(--ink-3)",
+    border: `1px solid ${active ? "var(--amber)" : "var(--rule)"}`,
+    fontWeight: active ? 600 : 400,
+    transition: "all .12s",
+  });
+
+  const MODEL_CFG = {
+    stuff_plus:        { label: "Stuff+",     color: C_INFO },
+    pitching_plus:     { label: "Pitching+",  color: C_PURP },
+    pitching_plus_plus:{ label: "Pitching++", color: C_POS  },
+  };
+
+  const modelBtn = (active, model) => {
+    const cfg = MODEL_CFG[model];
+    return {
+      padding: "5px 12px", fontSize: 11, fontFamily: "var(--ff-mono)", fontWeight: active ? 600 : 400,
+      background: active ? cfg.color : "var(--bg-2)",
+      color: active ? "var(--bg-0)" : "var(--ink-3)",
+      border: `1px solid ${active ? cfg.color : "var(--rule)"}`,
+      transition: "all .12s",
+    };
+  };
+
+  const actionBtn = (disabled) => ({
+    display: "inline-flex", alignItems: "center", gap: 6,
+    padding: "6px 16px", fontSize: 11,
+    fontFamily: "var(--ff-mono)", fontWeight: 600, letterSpacing: "0.06em",
+    background: disabled ? "var(--bg-3)" : "var(--amber)",
+    color: disabled ? "var(--ink-4)" : "var(--bg-0)",
+    border: "none", opacity: disabled ? 0.5 : 1,
+    cursor: disabled ? "not-allowed" : "pointer",
+    transition: "all .12s",
+  });
+
+  const SearchInput = ({ value, onChange, placeholder, inputRef, suggestions, showSuggestions, onSelect, season }) => (
+    <div style={{ position: "relative" }} ref={inputRef}>
+      <div style={{ position: "relative", display: "flex", alignItems: "center" }}>
+        <Icon name="search" size={13} style={{ position: "absolute", left: 8, color: "var(--ink-4)", pointerEvents: "none" }}/>
+        <input
+          type="text"
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          style={{ ...inputStyle, paddingLeft: 28, width: 200 }}
+        />
+      </div>
+      {showSuggestions && suggestions.length > 0 && (
+        <div style={{ position: "absolute", zIndex: 50, top: "100%", marginTop: 2, width: 280, background: "var(--bg-1)", border: "1px solid var(--rule-hi)", maxHeight: 240, overflowY: "auto" }}>
+          {suggestions.map((s) => (
+            <button
+              key={s.pitcher_id}
+              onClick={() => onSelect(s)}
+              style={{ width: "100%", textAlign: "left", padding: "8px 12px", display: "flex", alignItems: "center", justifyContent: "space-between", borderBottom: "1px solid var(--rule-dim)" }}
+              onMouseEnter={e => e.currentTarget.style.background = "var(--bg-2)"}
+              onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+            >
+              <span style={{ color: "var(--ink-0)", fontSize: 12, fontWeight: 600 }}>{s.player_name}</span>
+              <span className="t-mono" style={{ color: "var(--ink-4)", fontSize: 10 }}>{s.team} / {s.hand === 'R' ? 'RHP' : s.hand === 'L' ? 'LHP' : s.hand}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const chartContainer = { border: "1px solid var(--rule)", background: "var(--bg-1)", padding: 16, marginTop: 12 };
+
   const DetailChartTooltip = ({ active, payload }) => {
-    if (!active || !payload || !payload.length) return null;
+    if (!active || !payload?.length) return null;
     const d = payload[0].payload;
     return (
-      <div className="bg-gray-800 border border-gray-600 rounded-lg p-3 shadow-lg">
-        <p className="text-white font-medium">{d.pitch_name}</p>
-        <p className={`text-sm ${getScoreColor(d.score)}`}>Score: {d.score}</p>
-        <p className="text-gray-300 text-sm">投球数: {d.pitch_count}</p>
-        <p className="text-gray-300 text-sm">平均球速: {d.avg_velo} mph</p>
-        <p className="text-gray-300 text-sm">平均回転数: {d.avg_spin} rpm</p>
+      <div style={{ background: "var(--bg-1)", border: "1px solid var(--rule-hi)", padding: "10px 12px", fontSize: 12 }}>
+        <p style={{ color: "var(--ink-0)", fontWeight: 600, marginBottom: 4 }}>{d.pitch_name}</p>
+        <p style={{ color: getScoreColor(d.score) }}>Score: {d.score}</p>
+        <p style={{ color: "var(--ink-2)" }}>投球数: {d.pitch_count}</p>
+        <p style={{ color: "var(--ink-2)" }}>平均球速: {d.avg_velo} mph</p>
+        <p style={{ color: "var(--ink-2)" }}>平均回転数: {d.avg_spin} rpm</p>
       </div>
     );
   };
 
   const CompareChartTooltip = ({ active, payload }) => {
-    if (!active || !payload || !payload.length) return null;
+    if (!active || !payload?.length) return null;
     const d = payload[0].payload;
     return (
-      <div className="bg-gray-800 border border-gray-600 rounded-lg p-3 shadow-lg">
-        <p className="text-white font-medium">{d.pitch_name}</p>
-        {d.stuff_plus != null && <p className="text-blue-400 text-sm">Stuff+: {d.stuff_plus}</p>}
-        {d.pitching_plus != null && <p className="text-purple-400 text-sm">Pitching+: {d.pitching_plus}</p>}
-        {d.pitching_plus_plus != null && <p className="text-green-400 text-sm">Pitching++: {d.pitching_plus_plus}</p>}
-        {d.gap != null && <p className="text-gray-300 text-sm">Gap: {d.gap > 0 ? '+' : ''}{d.gap}</p>}
-        <p className="text-gray-300 text-sm">投球数: {d.pitch_count}</p>
+      <div style={{ background: "var(--bg-1)", border: "1px solid var(--rule-hi)", padding: "10px 12px", fontSize: 12 }}>
+        <p style={{ color: "var(--ink-0)", fontWeight: 600, marginBottom: 4 }}>{d.pitch_name}</p>
+        {d.stuff_plus != null && <p style={{ color: C_INFO }}>Stuff+: {d.stuff_plus}</p>}
+        {d.pitching_plus != null && <p style={{ color: C_PURP }}>Pitching+: {d.pitching_plus}</p>}
+        {d.pitching_plus_plus != null && <p style={{ color: C_POS }}>Pitching++: {d.pitching_plus_plus}</p>}
+        {d.gap != null && <p style={{ color: "var(--ink-2)" }}>Gap: {d.gap > 0 ? '+' : ''}{d.gap}</p>}
+        <p style={{ color: "var(--ink-2)" }}>投球数: {d.pitch_count}</p>
       </div>
     );
   };
 
-  // ----------------------------------------------------------
-  // プロファイルバッジの色
-  // ----------------------------------------------------------
-  const getProfileStyle = (profile) => {
-    switch (profile) {
-      case 'stuff_dominant':
-        return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
-      case 'command_dominant':
-        return 'bg-purple-500/20 text-purple-400 border-purple-500/30';
-      default:
-        return 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30';
-    }
+  const MONTH_LABELS = { 3: 'Mar', 4: 'Apr', 5: 'May', 6: 'Jun', 7: 'Jul', 8: 'Aug', 9: 'Sep', 10: 'Oct', 11: 'Nov' };
+
+  const TrendChartTooltip = ({ active, payload, label }) => {
+    if (!active || !payload?.length) return null;
+    const monthEntry = trendResult?.monthly?.find(m => m.month === label);
+    return (
+      <div style={{ background: "var(--bg-1)", border: "1px solid var(--rule-hi)", padding: "10px 12px", fontSize: 12 }}>
+        <p style={{ color: "var(--ink-0)", fontWeight: 600, marginBottom: 4 }}>{MONTH_LABELS[label] || `Month ${label}`}</p>
+        {payload.map((p, i) => (
+          <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+            <span style={{ width: 8, height: 8, background: p.color, display: "inline-block", flexShrink: 0 }}/>
+            <span style={{ color: "var(--ink-2)" }}>{p.name}:</span>
+            <span style={{ fontWeight: 600, color: getScoreColor(p.value) }}>{p.value}</span>
+            {monthEntry && monthEntry[`${p.name}_count`] != null && (
+              <span className="t-mono" style={{ color: "var(--ink-4)", fontSize: 10 }}>({monthEntry[`${p.name}_count`]}球)</span>
+            )}
+          </div>
+        ))}
+      </div>
+    );
   };
 
+  const tableThStyle = (align = "left") => ({
+    padding: "6px 10px", fontSize: 10, textAlign: align,
+    color: "var(--ink-3)", fontFamily: "var(--ff-mono)",
+    fontWeight: 600, letterSpacing: "0.08em",
+    borderBottom: "1px solid var(--rule)",
+    background: "var(--bg-2)", textTransform: "uppercase",
+  });
+
   // ==========================================================
-  // Rankings ビュー
+  // RankingsView
   // ==========================================================
   const RankingsView = () => (
-    <div className="space-y-4">
-      {/* コントロール */}
-      <div className="flex flex-wrap gap-3 items-center">
-        {/* Model Type 切替 */}
-        <div className="flex rounded-lg overflow-hidden border border-gray-600">
-          <button
-            onClick={() => { setRankingsModelType('stuff_plus'); setRankingsOffset(0); }}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              rankingsModelType === 'stuff_plus'
-                ? 'bg-blue-600 text-white shadow-[0_0_12px_rgba(59,130,246,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Stuff+
-          </button>
-          <button
-            onClick={() => { setRankingsModelType('pitching_plus'); setRankingsOffset(0); }}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              rankingsModelType === 'pitching_plus'
-                ? 'bg-purple-600 text-white shadow-[0_0_12px_rgba(168,85,247,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Pitching+
-          </button>
-          <button
-            onClick={() => { setRankingsModelType('pitching_plus_plus'); setRankingsOffset(0); }}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              rankingsModelType === 'pitching_plus_plus'
-                ? 'bg-green-600 text-white shadow-[0_0_12px_rgba(34,197,94,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Pitching++
-          </button>
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      {/* Controls */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+        <div style={{ display: "flex", gap: 2 }}>
+          {Object.keys(MODEL_CFG).map(m => (
+            <button key={m} onClick={() => { setRankingsModelType(m); setRankingsOffset(0); }} style={modelBtn(rankingsModelType === m, m)}>
+              {MODEL_CFG[m].label}
+            </button>
+          ))}
         </div>
 
-        {/* Season */}
-        <select
-          value={rankingsSeason}
-          onChange={(e) => { setRankingsSeason(Number(e.target.value)); setRankingsOffset(0); }}
-          className="bg-gray-700 text-white border border-gray-600 rounded-lg px-3 py-1.5 text-sm"
-        >
-          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => (
-            <option key={y} value={y}>{y}</option>
-          ))}
+        <select value={rankingsSeason} onChange={(e) => { setRankingsSeason(Number(e.target.value)); setRankingsOffset(0); }} style={selectStyle}>
+          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => <option key={y} value={y}>{y}</option>)}
         </select>
 
-        {/* Sort */}
         <button
-          onClick={() => {
-            setRankingsSortOrder(prev => prev === 'desc' ? 'asc' : 'desc');
-            setRankingsOffset(0);
-          }}
-          className="flex items-center gap-1 px-3 py-1.5 bg-gray-700 text-gray-300 border border-gray-600 rounded-lg text-sm hover:bg-gray-600 transition-colors"
+          onClick={() => { setRankingsSortOrder(prev => prev === 'desc' ? 'asc' : 'desc'); setRankingsOffset(0); }}
+          style={{ ...inputStyle, display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer" }}
         >
-          <ArrowUpDown className="w-3.5 h-3.5" />
+          <Icon name="chevD" size={12} style={{ transform: rankingsSortOrder === 'asc' ? 'rotate(180deg)' : 'none' }}/>
           {rankingsSortOrder === 'desc' ? 'High → Low' : 'Low → High'}
         </button>
 
-        {/* Min Pitches */}
-        <div className="flex items-center gap-1.5">
-          <label className="text-xs text-gray-400 whitespace-nowrap">Min投球数</label>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <label className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", whiteSpace: "nowrap" }}>MIN投球数</label>
           <input
             type="number"
             value={rankingsMinPitches}
             onChange={(e) => { setRankingsMinPitches(Number(e.target.value)); setRankingsOffset(0); }}
-            min={0}
-            max={5000}
-            step={50}
-            className="bg-gray-700 text-white border border-gray-600 rounded-lg px-2 py-1.5 text-sm w-20"
+            min={0} max={5000} step={50}
+            style={{ ...inputStyle, width: 70 }}
           />
         </div>
       </div>
 
-      {/* テーブル */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+      {/* Table */}
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
           <thead>
-            <tr className="border-b border-gray-700">
-              <th className="text-left text-gray-400 py-2 px-3">#</th>
-              <th className="text-left text-gray-400 py-2 px-3">Player</th>
-              <th className="text-left text-gray-400 py-2 px-3">Team</th>
-              <th className="text-center text-gray-400 py-2 px-3">Hand</th>
-              <th className="text-left text-gray-400 py-2 px-3">Pitch</th>
-              <th className="text-right text-gray-400 py-2 px-3">Score</th>
-              <th className="text-right text-gray-400 py-2 px-3">Count</th>
-              <th className="text-right text-gray-400 py-2 px-3">Velo <span className="text-gray-500 font-normal">(mph)</span></th>
-              <th className="text-right text-gray-400 py-2 px-3">Spin <span className="text-gray-500 font-normal">(rpm)</span></th>
+            <tr>
+              {['#','Player','Team','Hand','Pitch','Score','Count','Velo (mph)','Spin (rpm)'].map((h, i) => (
+                <th key={h} style={tableThStyle(i >= 5 ? "right" : "left")}>{h}</th>
+              ))}
             </tr>
           </thead>
           <tbody>
             {rankings.map((r, i) => (
               <tr
                 key={`${r.pitcher_id}-${r.pitch_name}-${i}`}
-                className="border-b border-gray-700/50 hover:bg-gray-700/30 cursor-pointer transition-colors"
+                style={{ borderBottom: "1px solid var(--rule-dim)", cursor: "pointer" }}
                 onClick={() => goToDetail(r.pitcher_id, r.player_name)}
+                onMouseEnter={e => e.currentTarget.style.background = "var(--bg-2)"}
+                onMouseLeave={e => e.currentTarget.style.background = "transparent"}
               >
-                <td className="py-2 px-3 text-gray-500">{rankingsOffset + i + 1}</td>
-                <td className="py-2 px-3 text-white font-medium">{r.player_name}</td>
-                <td className="py-2 px-3 text-gray-400 text-xs">{r.team}</td>
-                <td className="py-2 px-3 text-center text-gray-400 text-xs">{r.hand === 'R' ? 'RHP' : r.hand === 'L' ? 'LHP' : r.hand}</td>
-                <td className="py-2 px-3 text-gray-300">{r.pitch_name}</td>
-                <td className="py-2 px-3 text-right">
-                  <span className={`font-bold ${getScoreColor(r.score)}`}>{r.score}</span>
-                </td>
-                <td className="py-2 px-3 text-right text-gray-300">{r.pitch_count}</td>
-                <td className="py-2 px-3 text-right text-gray-300">{r.avg_velo}</td>
-                <td className="py-2 px-3 text-right text-gray-300">{r.avg_spin}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", color: "var(--ink-4)" }}>{rankingsOffset + i + 1}</td>
+                <td style={{ padding: "7px 10px", color: "var(--ink-0)", fontWeight: 600 }}>{r.player_name}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", color: "var(--ink-3)", fontSize: 10 }}>{r.team}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", color: "var(--ink-3)", fontSize: 10 }}>{r.hand === 'R' ? 'RHP' : r.hand === 'L' ? 'LHP' : r.hand}</td>
+                <td style={{ padding: "7px 10px", color: "var(--ink-1)" }}>{r.pitch_name}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: getScoreColor(r.score), fontWeight: 700 }}>{r.score}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{r.pitch_count}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{r.avg_velo}</td>
+                <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{r.avg_spin}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
 
-      {/* ページネーション */}
+      {/* Pagination */}
       {rankingsTotal > 0 && (
-        <div className="flex items-center justify-between pt-2">
-          <span className="text-sm text-gray-400">
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingTop: 4 }}>
+          <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
             {rankingsOffset + 1} - {Math.min(rankingsOffset + rankingsLimit, rankingsTotal)} / {rankingsTotal}
           </span>
-          <div className="flex gap-2">
+          <div style={{ display: "flex", gap: 6 }}>
             <button
               disabled={rankingsOffset === 0}
               onClick={() => setRankingsOffset(Math.max(0, rankingsOffset - rankingsLimit))}
-              className="p-1.5 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              style={{ padding: 6, border: "1px solid var(--rule)", color: "var(--ink-2)", opacity: rankingsOffset === 0 ? 0.4 : 1 }}
             >
-              <ChevronLeft className="w-4 h-4" />
+              <Icon name="chevL" size={14}/>
             </button>
             <button
               disabled={rankingsOffset + rankingsLimit >= rankingsTotal}
               onClick={() => setRankingsOffset(rankingsOffset + rankingsLimit)}
-              className="p-1.5 rounded-lg bg-gray-700 text-gray-300 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              style={{ padding: 6, border: "1px solid var(--rule)", color: "var(--ink-2)", opacity: rankingsOffset + rankingsLimit >= rankingsTotal ? 0.4 : 1 }}
             >
-              <ChevronRight className="w-4 h-4" />
+              <Icon name="chevR" size={14}/>
             </button>
           </div>
         </div>
@@ -509,175 +502,98 @@ const StuffPlus = () => {
   );
 
   // ==========================================================
-  // Detail ビュー
+  // DetailView
   // ==========================================================
   const DetailView = () => (
-    <div className="space-y-4">
-      {/* 入力コントロール */}
-      <div className="flex flex-wrap gap-3 items-end">
-        {/* 選手名検索 */}
-        <div className="relative" ref={detailSearchRef}>
-          <label className="block text-xs text-gray-400 mb-1">投手名</label>
-          <div className="flex items-center">
-            <Search className="absolute left-2.5 w-3.5 h-3.5 text-gray-500" />
-            <input
-              type="text"
-              value={detailSearchQuery}
-              onChange={(e) => {
-                setDetailSearchQuery(e.target.value);
-                setDetailPitcherId('');
-                setDetailShowSuggestions(true);
-              }}
-              placeholder="e.g. Yamamoto"
-              className="bg-gray-700 text-white border border-gray-600 rounded-lg pl-8 pr-3 py-1.5 text-sm w-52"
-            />
-          </div>
-          {/* オートコンプリートドロップダウン */}
-          {detailShowSuggestions && detailSuggestions.length > 0 && (
-            <div className="absolute z-50 mt-1 w-72 bg-gray-800 border border-gray-600 rounded-lg shadow-xl max-h-60 overflow-y-auto">
-              {detailSuggestions.map((s) => (
-                <button
-                  key={s.pitcher_id}
-                  onClick={() => {
-                    setDetailPitcherId(String(s.pitcher_id));
-                    setDetailSearchQuery(s.player_name);
-                    setDetailShowSuggestions(false);
-                  }}
-                  className="w-full text-left px-3 py-2 hover:bg-gray-700 transition-colors flex items-center justify-between"
-                >
-                  <span className="text-white text-sm font-medium">{s.player_name}</span>
-                  <span className="text-gray-500 text-xs">{s.team} / {s.hand === 'R' ? 'RHP' : s.hand === 'L' ? 'LHP' : s.hand}</span>
-                </button>
-              ))}
-            </div>
-          )}
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "flex-end" }}>
+        <div>
+          <div className="h-label" style={{ fontSize: 9, marginBottom: 4 }}>投手名</div>
+          <SearchInput
+            value={detailSearchQuery}
+            onChange={(e) => { setDetailSearchQuery(e.target.value); setDetailPitcherId(''); setDetailShowSuggestions(true); }}
+            placeholder="e.g. Yamamoto"
+            inputRef={detailSearchRef}
+            suggestions={detailSuggestions}
+            showSuggestions={detailShowSuggestions}
+            onSelect={(s) => { setDetailPitcherId(String(s.pitcher_id)); setDetailSearchQuery(s.player_name); setDetailShowSuggestions(false); }}
+          />
         </div>
 
-        <div className="flex rounded-lg overflow-hidden border border-gray-600">
-          <button
-            onClick={() => setDetailModelType('stuff_plus')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              detailModelType === 'stuff_plus'
-                ? 'bg-blue-600 text-white shadow-[0_0_12px_rgba(59,130,246,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Stuff+
-          </button>
-          <button
-            onClick={() => setDetailModelType('pitching_plus')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              detailModelType === 'pitching_plus'
-                ? 'bg-purple-600 text-white shadow-[0_0_12px_rgba(168,85,247,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Pitching+
-          </button>
-          <button
-            onClick={() => setDetailModelType('pitching_plus_plus')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              detailModelType === 'pitching_plus_plus'
-                ? 'bg-green-600 text-white shadow-[0_0_12px_rgba(34,197,94,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Pitching++
-          </button>
-        </div>
-
-        <select
-          value={detailSeason}
-          onChange={(e) => setDetailSeason(Number(e.target.value))}
-          className="bg-gray-700 text-white border border-gray-600 rounded-lg px-3 py-1.5 text-sm"
-        >
-          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => (
-            <option key={y} value={y}>{y}</option>
+        <div style={{ display: "flex", gap: 2 }}>
+          {Object.keys(MODEL_CFG).map(m => (
+            <button key={m} onClick={() => setDetailModelType(m)} style={modelBtn(detailModelType === m, m)}>
+              {MODEL_CFG[m].label}
+            </button>
           ))}
+        </div>
+
+        <select value={detailSeason} onChange={(e) => setDetailSeason(Number(e.target.value))} style={selectStyle}>
+          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => <option key={y} value={y}>{y}</option>)}
         </select>
 
-        <button
-          onClick={fetchPitcherDetail}
-          disabled={!detailPitcherId || isLoading}
-          className="flex items-center gap-1.5 px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          <Search className="w-3.5 h-3.5" />
-          検索
+        <button onClick={fetchPitcherDetail} disabled={!detailPitcherId || isLoading} style={actionBtn(!detailPitcherId || isLoading)}>
+          <Icon name="search" size={12}/>検索
         </button>
       </div>
 
-      {/* 結果 */}
       {detailResult && (
-        <div className="space-y-4">
-          <div className="flex items-center gap-3">
-            <h3 className="text-lg font-bold text-white">{detailResult.player_name}</h3>
-            <span className="text-sm text-gray-400">
-              {detailResult.model_type === 'stuff_plus' ? 'Stuff+' : detailResult.model_type === 'pitching_plus' ? 'Pitching+' : 'Pitching++'} / {detailResult.season}
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span className="h-display" style={{ fontSize: 16 }}>{detailResult.player_name}</span>
+            <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+              {MODEL_CFG[detailResult.model_type]?.label ?? detailResult.model_type} / {detailResult.season}
             </span>
           </div>
 
-          {/* バーチャート */}
-          <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
+          <div style={chartContainer}>
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={detailResult.pitches} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                <XAxis dataKey="pitch_name" stroke="#9ca3af" tick={{ fontSize: 12 }} />
-                <YAxis stroke="#9ca3af" tick={{ fontSize: 12 }} domain={[60, 160]} />
-                <Tooltip content={<DetailChartTooltip />} />
-                <ReferenceLine y={100} stroke="#6b7280" strokeDasharray="4 4" label={{ value: 'Avg (100)', fill: '#6b7280', fontSize: 11 }} />
-                <Bar
-                  dataKey="score"
-                  radius={[4, 4, 0, 0]}
-                  fill="#3b82f6"
-                  label={{ position: 'top', fill: '#d1d5db', fontSize: 11 }}
-                >
+                <CartesianGrid strokeDasharray="3 3" stroke={C_GRID}/>
+                <XAxis dataKey="pitch_name" stroke={C_AXIS} tick={{ fontSize: 11, fill: C_TICK }}/>
+                <YAxis stroke={C_AXIS} tick={{ fontSize: 11, fill: C_TICK }} domain={[60, 160]}/>
+                <Tooltip content={<DetailChartTooltip/>}/>
+                <ReferenceLine y={100} stroke={C_AXIS} strokeDasharray="4 4" label={{ value: 'Avg (100)', fill: C_TICK, fontSize: 10 }}/>
+                <Bar dataKey="score" radius={[2, 2, 0, 0]} label={{ position: 'top', fill: C_TICK, fontSize: 10 }}>
                   {detailResult.pitches.map((entry, index) => (
-                    <rect key={index} fill={getBarColor(entry.score)} />
+                    <rect key={index} fill={getBarColor(entry.score)}/>
                   ))}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           </div>
 
-          {/* 詳細テーブル */}
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
               <thead>
-                <tr className="border-b border-gray-700">
-                  <th className="text-left text-gray-400 py-2 px-3">Pitch</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Score</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Count</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Velo <span className="text-gray-500 font-normal">(mph)</span></th>
-                  <th className="text-right text-gray-400 py-2 px-3">Spin <span className="text-gray-500 font-normal">(rpm)</span></th>
-                  <th className="text-right text-gray-400 py-2 px-3">Pred RE</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Actual RE</th>
-                  <th className="text-center text-gray-400 py-2 px-3">Sample</th>
+                <tr>
+                  {['Pitch','Score','Count','Velo (mph)','Spin (rpm)','Pred RE','Actual RE','Sample'].map((h, i) => (
+                    <th key={h} style={tableThStyle(i === 0 ? "left" : i === 7 ? "center" : "right")}>{h}</th>
+                  ))}
                 </tr>
               </thead>
               <tbody>
                 {detailResult.pitches.map((p, i) => (
-                  <tr key={i} className="border-b border-gray-700/50">
-                    <td className="py-2 px-3 text-white font-medium">{p.pitch_name}</td>
-                    <td className="py-2 px-3 text-right">
-                      <span className={`font-bold ${getScoreColor(p.score)}`}>{p.score}</span>
-                    </td>
-                    <td className="py-2 px-3 text-right text-gray-300">{p.pitch_count}</td>
-                    <td className="py-2 px-3 text-right text-gray-300">{p.avg_velo}</td>
-                    <td className="py-2 px-3 text-right text-gray-300">{p.avg_spin}</td>
-                    <td className="py-2 px-3 text-right text-gray-300">{p.mean_pred_run_exp.toFixed(4)}</td>
-                    <td className="py-2 px-3 text-right text-gray-300">{p.actual_run_exp.toFixed(4)}</td>
-                    <td className="py-2 px-3 text-center">
+                  <tr key={i} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                    <td style={{ padding: "7px 10px", color: "var(--ink-0)", fontWeight: 600 }}>{p.pitch_name}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: getScoreColor(p.score), fontWeight: 700 }}>{p.score}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{p.pitch_count}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{p.avg_velo}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{p.avg_spin}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{p.mean_pred_run_exp.toFixed(4)}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{p.actual_run_exp.toFixed(4)}</td>
+                    <td style={{ padding: "7px 10px", textAlign: "center" }}>
                       {p.sufficient_sample
-                        ? <span className="text-green-400 text-xs">OK</span>
-                        : <span className="text-yellow-400 text-xs">Low</span>
+                        ? <span className="t-mono" style={{ color: C_POS, fontSize: 10 }}>OK</span>
+                        : <span className="t-mono" style={{ color: C_AMBER, fontSize: 10 }}>Low</span>
                       }
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
-            <p className="text-xs text-gray-500 mt-2 px-3">
-              RE = Run Expectancy (得点期待値の変化量)。負値ほど投手有利。Pred RE はモデル予測値、Actual RE は実際の結果。Sample は最低投球数を満たしているかの判定。
+            <p className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", marginTop: 8, paddingLeft: 10 }}>
+              RE = Run Expectancy（得点期待値の変化量）。負値ほど投手有利。Pred RE はモデル予測値、Actual RE は実際の結果。Sample は最低投球数を満たしているかの判定。
             </p>
           </div>
         </div>
@@ -686,149 +602,94 @@ const StuffPlus = () => {
   );
 
   // ==========================================================
-  // Compare ビュー
+  // CompareView
   // ==========================================================
   const CompareView = () => (
-    <div className="space-y-4">
-      {/* 入力コントロール */}
-      <div className="flex flex-wrap gap-3 items-end">
-        {/* 選手名検索 */}
-        <div className="relative" ref={compareSearchRef}>
-          <label className="block text-xs text-gray-400 mb-1">投手名</label>
-          <div className="flex items-center">
-            <Search className="absolute left-2.5 w-3.5 h-3.5 text-gray-500" />
-            <input
-              type="text"
-              value={compareSearchQuery}
-              onChange={(e) => {
-                setCompareSearchQuery(e.target.value);
-                setComparePitcherId('');
-                setCompareShowSuggestions(true);
-              }}
-              placeholder="e.g. Yamamoto"
-              className="bg-gray-700 text-white border border-gray-600 rounded-lg pl-8 pr-3 py-1.5 text-sm w-52"
-            />
-          </div>
-          {/* オートコンプリートドロップダウン */}
-          {compareShowSuggestions && compareSuggestions.length > 0 && (
-            <div className="absolute z-50 mt-1 w-72 bg-gray-800 border border-gray-600 rounded-lg shadow-xl max-h-60 overflow-y-auto">
-              {compareSuggestions.map((s) => (
-                <button
-                  key={s.pitcher_id}
-                  onClick={() => {
-                    setComparePitcherId(String(s.pitcher_id));
-                    setCompareSearchQuery(s.player_name);
-                    setCompareShowSuggestions(false);
-                  }}
-                  className="w-full text-left px-3 py-2 hover:bg-gray-700 transition-colors flex items-center justify-between"
-                >
-                  <span className="text-white text-sm font-medium">{s.player_name}</span>
-                  <span className="text-gray-500 text-xs">{s.team} / {s.hand === 'R' ? 'RHP' : s.hand === 'L' ? 'LHP' : s.hand}</span>
-                </button>
-              ))}
-            </div>
-          )}
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "flex-end" }}>
+        <div>
+          <div className="h-label" style={{ fontSize: 9, marginBottom: 4 }}>投手名</div>
+          <SearchInput
+            value={compareSearchQuery}
+            onChange={(e) => { setCompareSearchQuery(e.target.value); setComparePitcherId(''); setCompareShowSuggestions(true); }}
+            placeholder="e.g. Yamamoto"
+            inputRef={compareSearchRef}
+            suggestions={compareSuggestions}
+            showSuggestions={compareShowSuggestions}
+            onSelect={(s) => { setComparePitcherId(String(s.pitcher_id)); setCompareSearchQuery(s.player_name); setCompareShowSuggestions(false); }}
+          />
         </div>
 
-        <select
-          value={compareSeason}
-          onChange={(e) => setCompareSeason(Number(e.target.value))}
-          className="bg-gray-700 text-white border border-gray-600 rounded-lg px-3 py-1.5 text-sm"
-        >
-          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => (
-            <option key={y} value={y}>{y}</option>
-          ))}
+        <select value={compareSeason} onChange={(e) => setCompareSeason(Number(e.target.value))} style={selectStyle}>
+          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => <option key={y} value={y}>{y}</option>)}
         </select>
 
-        <button
-          onClick={fetchCompare}
-          disabled={!comparePitcherId || isLoading}
-          className="flex items-center gap-1.5 px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          <Search className="w-3.5 h-3.5" />
-          比較
+        <button onClick={fetchCompare} disabled={!comparePitcherId || isLoading} style={actionBtn(!comparePitcherId || isLoading)}>
+          <Icon name="search" size={12}/>比較
         </button>
       </div>
 
-      {/* 結果 */}
       {compareResult && (
-        <div className="space-y-4">
-          {/* ヘッダー + プロファイル */}
-          <div className="flex flex-wrap items-center gap-3">
-            <h3 className="text-lg font-bold text-white">{compareResult.player_name}</h3>
-            <span className={`px-3 py-1 rounded-full text-xs font-medium border ${getProfileStyle(compareResult.profile)}`}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10 }}>
+            <span className="h-display" style={{ fontSize: 16 }}>{compareResult.player_name}</span>
+            <span style={{ ...getProfileStyle(compareResult.profile), padding: "3px 10px", fontSize: 11, fontFamily: "var(--ff-mono)" }}>
               {compareResult.profile_desc}
             </span>
-            <span className="text-sm text-gray-400">
-              Avg Gap: <span className={compareResult.avg_gap > 0 ? 'text-blue-400' : compareResult.avg_gap < 0 ? 'text-purple-400' : 'text-gray-300'}>
+            <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+              Avg Gap: <span style={{ color: compareResult.avg_gap > 0 ? C_INFO : compareResult.avg_gap < 0 ? C_PURP : "var(--ink-1)", fontWeight: 600 }}>
                 {compareResult.avg_gap > 0 ? '+' : ''}{compareResult.avg_gap}
               </span>
             </span>
           </div>
 
-          {/* Grouped Bar Chart */}
-          <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
+          <div style={chartContainer}>
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={compareResult.comparison} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                <XAxis dataKey="pitch_name" stroke="#9ca3af" tick={{ fontSize: 12 }} />
-                <YAxis stroke="#9ca3af" tick={{ fontSize: 12 }} domain={[60, 160]} />
-                <Tooltip content={<CompareChartTooltip />} />
-                <Legend wrapperStyle={{ fontSize: 12, color: '#9ca3af' }} />
-                <ReferenceLine y={100} stroke="#6b7280" strokeDasharray="4 4" />
-                <Bar dataKey="stuff_plus" name="Stuff+" fill="#3b82f6" radius={[4, 4, 0, 0]} />
-                <Bar dataKey="pitching_plus" name="Pitching+" fill="#a855f7" radius={[4, 4, 0, 0]} />
-                <Bar dataKey="pitching_plus_plus" name="Pitching++" fill="#22c55e" radius={[4, 4, 0, 0]} />
+                <CartesianGrid strokeDasharray="3 3" stroke={C_GRID}/>
+                <XAxis dataKey="pitch_name" stroke={C_AXIS} tick={{ fontSize: 11, fill: C_TICK }}/>
+                <YAxis stroke={C_AXIS} tick={{ fontSize: 11, fill: C_TICK }} domain={[60, 160]}/>
+                <Tooltip content={<CompareChartTooltip/>}/>
+                <Legend wrapperStyle={{ fontSize: 11, color: C_TICK }}/>
+                <ReferenceLine y={100} stroke={C_AXIS} strokeDasharray="4 4"/>
+                <Bar dataKey="stuff_plus" name="Stuff+" fill={C_INFO} radius={[2, 2, 0, 0]}/>
+                <Bar dataKey="pitching_plus" name="Pitching+" fill={C_PURP} radius={[2, 2, 0, 0]}/>
+                <Bar dataKey="pitching_plus_plus" name="Pitching++" fill={C_POS} radius={[2, 2, 0, 0]}/>
               </BarChart>
             </ResponsiveContainer>
           </div>
 
-          {/* 比較テーブル */}
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
               <thead>
-                <tr className="border-b border-gray-700">
-                  <th className="text-left text-gray-400 py-2 px-3">Pitch</th>
-                  <th className="text-right text-blue-400 py-2 px-3">Stuff+</th>
-                  <th className="text-right text-purple-400 py-2 px-3">Pitching+</th>
-                  <th className="text-right text-green-400 py-2 px-3">Pitching++</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Gap</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Count</th>
-                  <th className="text-right text-gray-400 py-2 px-3">Velo <span className="text-gray-500 font-normal">(mph)</span></th>
+                <tr>
+                  <th style={tableThStyle("left")}>Pitch</th>
+                  <th style={{ ...tableThStyle("right"), color: C_INFO }}>Stuff+</th>
+                  <th style={{ ...tableThStyle("right"), color: C_PURP }}>Pitching+</th>
+                  <th style={{ ...tableThStyle("right"), color: C_POS }}>Pitching++</th>
+                  <th style={tableThStyle("right")}>Gap</th>
+                  <th style={tableThStyle("right")}>Count</th>
+                  <th style={tableThStyle("right")}>Velo (mph)</th>
                 </tr>
               </thead>
               <tbody>
                 {compareResult.comparison.map((c, i) => (
-                  <tr key={i} className="border-b border-gray-700/50">
-                    <td className="py-2 px-3 text-white font-medium">{c.pitch_name}</td>
-                    <td className="py-2 px-3 text-right">
-                      {c.stuff_plus != null
-                        ? <span className={`font-bold ${getScoreColor(c.stuff_plus)}`}>{c.stuff_plus}</span>
-                        : <span className="text-gray-500">-</span>
-                      }
+                  <tr key={i} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                    <td style={{ padding: "7px 10px", color: "var(--ink-0)", fontWeight: 600 }}>{c.pitch_name}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right" }}>
+                      {c.stuff_plus != null ? <span style={{ color: getScoreColor(c.stuff_plus), fontWeight: 700 }}>{c.stuff_plus}</span> : <span style={{ color: "var(--ink-4)" }}>-</span>}
                     </td>
-                    <td className="py-2 px-3 text-right">
-                      {c.pitching_plus != null
-                        ? <span className={`font-bold ${getScoreColor(c.pitching_plus)}`}>{c.pitching_plus}</span>
-                        : <span className="text-gray-500">-</span>
-                      }
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right" }}>
+                      {c.pitching_plus != null ? <span style={{ color: getScoreColor(c.pitching_plus), fontWeight: 700 }}>{c.pitching_plus}</span> : <span style={{ color: "var(--ink-4)" }}>-</span>}
                     </td>
-                    <td className="py-2 px-3 text-right">
-                      {c.pitching_plus_plus != null
-                        ? <span className={`font-bold ${getScoreColor(c.pitching_plus_plus)}`}>{c.pitching_plus_plus}</span>
-                        : <span className="text-gray-500">-</span>
-                      }
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right" }}>
+                      {c.pitching_plus_plus != null ? <span style={{ color: getScoreColor(c.pitching_plus_plus), fontWeight: 700 }}>{c.pitching_plus_plus}</span> : <span style={{ color: "var(--ink-4)" }}>-</span>}
                     </td>
-                    <td className="py-2 px-3 text-right">
-                      {c.gap != null
-                        ? <span className={c.gap > 0 ? 'text-blue-400' : c.gap < 0 ? 'text-purple-400' : 'text-gray-300'}>
-                            {c.gap > 0 ? '+' : ''}{c.gap}
-                          </span>
-                        : <span className="text-gray-500">-</span>
-                      }
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right" }}>
+                      {c.gap != null ? <span style={{ color: c.gap > 0 ? C_INFO : c.gap < 0 ? C_PURP : "var(--ink-2)", fontWeight: 600 }}>{c.gap > 0 ? '+' : ''}{c.gap}</span> : <span style={{ color: "var(--ink-4)" }}>-</span>}
                     </td>
-                    <td className="py-2 px-3 text-right text-gray-300">{c.pitch_count}</td>
-                    <td className="py-2 px-3 text-right text-gray-300">{c.avg_velo}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{c.pitch_count}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{c.avg_velo}</td>
                   </tr>
                 ))}
               </tbody>
@@ -840,199 +701,100 @@ const StuffPlus = () => {
   );
 
   // ==========================================================
-  // Trend ビュー（月別推移）
+  // TrendView
   // ==========================================================
-  const MONTH_LABELS = { 3: 'Mar', 4: 'Apr', 5: 'May', 6: 'Jun', 7: 'Jul', 8: 'Aug', 9: 'Sep', 10: 'Oct', 11: 'Nov' };
-  const PITCH_COLORS = ['#3b82f6', '#ef4444', '#22c55e', '#f59e0b', '#a855f7', '#ec4899', '#06b6d4', '#f97316'];
-
-  const TrendChartTooltip = ({ active, payload, label }) => {
-    if (!active || !payload || !payload.length) return null;
-    const monthEntry = trendResult?.monthly?.find(m => m.month === label);
-    return (
-      <div className="bg-gray-800 border border-gray-600 rounded-lg p-3 shadow-lg">
-        <p className="text-white font-medium mb-1">{MONTH_LABELS[label] || `Month ${label}`}</p>
-        {payload.map((p, i) => (
-          <div key={i} className="flex items-center gap-2 text-sm">
-            <span className="w-2 h-2 rounded-full" style={{ backgroundColor: p.color }} />
-            <span className="text-gray-300">{p.name}:</span>
-            <span className={`font-bold ${getScoreColor(p.value)}`}>{p.value}</span>
-            {monthEntry && monthEntry[`${p.name}_count`] != null && (
-              <span className="text-gray-500 text-xs">({monthEntry[`${p.name}_count`]}球)</span>
-            )}
-          </div>
-        ))}
-      </div>
-    );
-  };
-
   const TrendView = () => (
-    <div className="space-y-4">
-      {/* 入力コントロール */}
-      <div className="flex flex-wrap gap-3 items-end">
-        <div className="relative" ref={trendSearchRef}>
-          <label className="block text-xs text-gray-400 mb-1">投手名</label>
-          <div className="flex items-center">
-            <Search className="absolute left-2.5 w-3.5 h-3.5 text-gray-500" />
-            <input
-              type="text"
-              value={trendSearchQuery}
-              onChange={(e) => {
-                setTrendSearchQuery(e.target.value);
-                setTrendPitcherId('');
-                setTrendShowSuggestions(true);
-              }}
-              placeholder="e.g. Ohtani"
-              className="bg-gray-700 text-white border border-gray-600 rounded-lg pl-8 pr-3 py-1.5 text-sm w-52"
-            />
-          </div>
-          {trendShowSuggestions && trendSuggestions.length > 0 && (
-            <div className="absolute z-50 mt-1 w-72 bg-gray-800 border border-gray-600 rounded-lg shadow-xl max-h-60 overflow-y-auto">
-              {trendSuggestions.map((s) => (
-                <button
-                  key={s.pitcher_id}
-                  onClick={() => {
-                    setTrendPitcherId(String(s.pitcher_id));
-                    setTrendSearchQuery(s.player_name);
-                    setTrendShowSuggestions(false);
-                  }}
-                  className="w-full text-left px-3 py-2 hover:bg-gray-700 transition-colors flex items-center justify-between"
-                >
-                  <span className="text-white text-sm font-medium">{s.player_name}</span>
-                  <span className="text-gray-500 text-xs">{s.team} / {s.hand === 'R' ? 'RHP' : s.hand === 'L' ? 'LHP' : s.hand}</span>
-                </button>
-              ))}
-            </div>
-          )}
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "flex-end" }}>
+        <div>
+          <div className="h-label" style={{ fontSize: 9, marginBottom: 4 }}>投手名</div>
+          <SearchInput
+            value={trendSearchQuery}
+            onChange={(e) => { setTrendSearchQuery(e.target.value); setTrendPitcherId(''); setTrendShowSuggestions(true); }}
+            placeholder="e.g. Ohtani"
+            inputRef={trendSearchRef}
+            suggestions={trendSuggestions}
+            showSuggestions={trendShowSuggestions}
+            onSelect={(s) => { setTrendPitcherId(String(s.pitcher_id)); setTrendSearchQuery(s.player_name); setTrendShowSuggestions(false); }}
+          />
         </div>
 
-        <div className="flex rounded-lg overflow-hidden border border-gray-600">
-          <button
-            onClick={() => setTrendModelType('stuff_plus')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              trendModelType === 'stuff_plus'
-                ? 'bg-blue-600 text-white shadow-[0_0_12px_rgba(59,130,246,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Stuff+
-          </button>
-          <button
-            onClick={() => setTrendModelType('pitching_plus')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              trendModelType === 'pitching_plus'
-                ? 'bg-purple-600 text-white shadow-[0_0_12px_rgba(168,85,247,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Pitching+
-          </button>
-          <button
-            onClick={() => setTrendModelType('pitching_plus_plus')}
-            className={`px-3 py-1.5 text-sm font-medium transition-all ${
-              trendModelType === 'pitching_plus_plus'
-                ? 'bg-green-600 text-white shadow-[0_0_12px_rgba(34,197,94,0.5)]'
-                : 'bg-gray-700 text-gray-500 hover:bg-gray-600 hover:text-gray-300'
-            }`}
-          >
-            Pitching++
-          </button>
-        </div>
-
-        <select
-          value={trendSeason}
-          onChange={(e) => setTrendSeason(Number(e.target.value))}
-          className="bg-gray-700 text-white border border-gray-600 rounded-lg px-3 py-1.5 text-sm"
-        >
-          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => (
-            <option key={y} value={y}>{y}</option>
+        <div style={{ display: "flex", gap: 2 }}>
+          {Object.keys(MODEL_CFG).map(m => (
+            <button key={m} onClick={() => setTrendModelType(m)} style={modelBtn(trendModelType === m, m)}>
+              {MODEL_CFG[m].label}
+            </button>
           ))}
+        </div>
+
+        <select value={trendSeason} onChange={(e) => setTrendSeason(Number(e.target.value))} style={selectStyle}>
+          {[2026, 2025, 2024, 2023, 2022, 2021, 2020].map(y => <option key={y} value={y}>{y}</option>)}
         </select>
 
-        <button
-          onClick={fetchTrend}
-          disabled={!trendPitcherId || isLoading}
-          className="flex items-center gap-1.5 px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          <Search className="w-3.5 h-3.5" />
-          推移表示
+        <button onClick={fetchTrend} disabled={!trendPitcherId || isLoading} style={actionBtn(!trendPitcherId || isLoading)}>
+          <Icon name="chart" size={12}/>推移表示
         </button>
       </div>
 
-      {/* 結果 */}
       {trendResult && (
-        <div className="space-y-4">
-          <div className="flex items-center gap-3">
-            <h3 className="text-lg font-bold text-white">{trendResult.player_name}</h3>
-            <span className="text-sm text-gray-400">
-              {trendModelType === 'stuff_plus' ? 'Stuff+' : trendModelType === 'pitching_plus' ? 'Pitching+' : 'Pitching++'} / {trendResult.season} 月別推移
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span className="h-display" style={{ fontSize: 16 }}>{trendResult.player_name}</span>
+            <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+              {MODEL_CFG[trendModelType]?.label} / {trendResult.season} 月別推移
             </span>
           </div>
 
-          {/* LineChart */}
-          <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4">
+          <div style={chartContainer}>
             <ResponsiveContainer width="100%" height={350}>
               <LineChart data={trendResult.monthly} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                <XAxis
-                  dataKey="month"
-                  stroke="#9ca3af"
-                  tick={{ fontSize: 12 }}
-                  tickFormatter={(m) => MONTH_LABELS[m] || m}
-                />
-                <YAxis stroke="#9ca3af" tick={{ fontSize: 12 }} domain={[60, 160]} />
-                <Tooltip content={<TrendChartTooltip />} />
-                <Legend wrapperStyle={{ fontSize: 12, color: '#9ca3af' }} />
-                <ReferenceLine y={100} stroke="#6b7280" strokeDasharray="4 4" label={{ value: 'Avg (100)', fill: '#6b7280', fontSize: 11 }} />
+                <CartesianGrid strokeDasharray="3 3" stroke={C_GRID}/>
+                <XAxis dataKey="month" stroke={C_AXIS} tick={{ fontSize: 11, fill: C_TICK }} tickFormatter={(m) => MONTH_LABELS[m] || m}/>
+                <YAxis stroke={C_AXIS} tick={{ fontSize: 11, fill: C_TICK }} domain={[60, 160]}/>
+                <Tooltip content={<TrendChartTooltip/>}/>
+                <Legend wrapperStyle={{ fontSize: 11, color: C_TICK }}/>
+                <ReferenceLine y={100} stroke={C_AXIS} strokeDasharray="4 4" label={{ value: 'Avg (100)', fill: C_TICK, fontSize: 10 }}/>
                 {trendResult.pitch_names.map((pn, i) => (
-                  <Line
-                    key={pn}
-                    type="monotone"
-                    dataKey={pn}
-                    name={pn}
+                  <Line key={pn} type="monotone" dataKey={pn} name={pn}
                     stroke={PITCH_COLORS[i % PITCH_COLORS.length]}
-                    strokeWidth={2}
-                    dot={{ r: 4 }}
-                    activeDot={{ r: 6 }}
-                    connectNulls
-                  />
+                    strokeWidth={2} dot={{ r: 4 }} activeDot={{ r: 6 }} connectNulls/>
                 ))}
               </LineChart>
             </ResponsiveContainer>
           </div>
 
-          {/* 月別テーブル */}
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
               <thead>
-                <tr className="border-b border-gray-700">
-                  <th className="text-left text-gray-400 py-2 px-3">Month</th>
+                <tr>
+                  <th style={tableThStyle("left")}>Month</th>
                   {trendResult.pitch_names.map((pn, i) => (
-                    <th key={pn} className="text-right py-2 px-3" style={{ color: PITCH_COLORS[i % PITCH_COLORS.length] }}>{pn}</th>
+                    <th key={pn} style={{ ...tableThStyle("right"), color: PITCH_COLORS[i % PITCH_COLORS.length] }}>{pn}</th>
                   ))}
-                  <th className="text-right text-gray-400 py-2 px-3">Total</th>
+                  <th style={tableThStyle("right")}>Total</th>
                 </tr>
               </thead>
               <tbody>
                 {trendResult.monthly.map((m) => (
-                  <tr key={m.month} className="border-b border-gray-700/50">
-                    <td className="py-2 px-3 text-white font-medium">{MONTH_LABELS[m.month] || m.month}</td>
+                  <tr key={m.month} style={{ borderBottom: "1px solid var(--rule-dim)" }}>
+                    <td style={{ padding: "7px 10px", color: "var(--ink-0)", fontWeight: 600 }}>{MONTH_LABELS[m.month] || m.month}</td>
                     {trendResult.pitch_names.map((pn) => (
-                      <td key={pn} className="py-2 px-3 text-right">
+                      <td key={pn} className="t-mono" style={{ padding: "7px 10px", textAlign: "right" }}>
                         {m[pn] != null
-                          ? <span className={`font-bold ${getScoreColor(m[pn])}`}>{m[pn]}</span>
-                          : <span className="text-gray-500">-</span>
+                          ? <span style={{ color: getScoreColor(m[pn]), fontWeight: 700 }}>{m[pn]}</span>
+                          : <span style={{ color: "var(--ink-4)" }}>-</span>
                         }
                         {m[`${pn}_count`] != null && (
-                          <span className="text-gray-500 text-xs ml-1">({m[`${pn}_count`]})</span>
+                          <span style={{ color: "var(--ink-4)", fontSize: 10, marginLeft: 3 }}>({m[`${pn}_count`]})</span>
                         )}
                       </td>
                     ))}
-                    <td className="py-2 px-3 text-right text-gray-300">{m.total_count}</td>
+                    <td className="t-mono" style={{ padding: "7px 10px", textAlign: "right", color: "var(--ink-2)" }}>{m.total_count}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
-            <p className="text-xs text-gray-500 mt-2 px-3">
+            <p className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)", marginTop: 8, paddingLeft: 10 }}>
               括弧内はその月の投球数。サンプルが少ない月はスコアの信頼度が低い点に注意。
             </p>
           </div>
@@ -1042,53 +804,45 @@ const StuffPlus = () => {
   );
 
   // ==========================================================
-  // メインレンダリング
+  // Main render
   // ==========================================================
   return (
-    <div className="max-w-6xl mx-auto space-y-6">
-      {/* ヘッダー */}
-      <div className="flex items-center gap-3">
-        <div className="p-2 bg-blue-600/20 rounded-lg">
-          <Target className="w-6 h-6 text-blue-400" />
-        </div>
+    <div style={{ maxWidth: 1100, margin: "0 auto", display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Header */}
+      <div className="rule-b" style={{ display: "flex", alignItems: "center", gap: 12, paddingBottom: 12 }}>
+        <Icon name="target" size={20} style={{ color: "var(--amber)", flexShrink: 0 }}/>
         <div>
-          <h2 className="text-xl font-bold text-white">Stuff+ / Pitching+ / Pitching++</h2>
-          <p className="text-sm text-gray-400">XGBoostベースの球質・投球評価モデル</p>
+          <span className="h-display" style={{ fontSize: 17, display: "block" }}>Stuff+ / Pitching+ / Pitching++</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>XGBoostベースの球質・投球評価モデル</span>
         </div>
       </div>
 
-      {/* モデル定義 */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <div className="bg-blue-500/5 border border-blue-500/20 rounded-lg px-4 py-3">
-          <span className="text-blue-400 font-semibold text-sm">Stuff+</span>
-          <p className="text-xs text-gray-400 mt-1">球速・回転・変化量・リリースなど物理的な球質のみで評価。100 = MLB平均、15pt = 1SD。</p>
-        </div>
-        <div className="bg-purple-500/5 border border-purple-500/20 rounded-lg px-4 py-3">
-          <span className="text-purple-400 font-semibold text-sm">Pitching+</span>
-          <p className="text-xs text-gray-400 mt-1">Stuff+ に投球コースを追加。「良い球を、良い場所に投げられるか」を評価。コーナーワークに優れた投手が高スコア。</p>
-        </div>
-        <div className="bg-green-500/5 border border-green-500/20 rounded-lg px-4 py-3">
-          <span className="text-green-400 font-semibold text-sm">Pitching++</span>
-          <p className="text-xs text-gray-400 mt-1">Pitching+ に前球との球速差・リリース差・カウント状況を追加。「配球の組み立てで打者を翻弄できるか」を評価。</p>
-        </div>
+      {/* Model definitions */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 8 }}>
+        {[
+          { key: 'stuff_plus',         color: C_INFO, label: "Stuff+",     desc: "球速・回転・変化量・リリースなど物理的な球質のみで評価。100 = MLB平均、15pt = 1SD。" },
+          { key: 'pitching_plus',      color: C_PURP, label: "Pitching+",  desc: "Stuff+ に投球コースを追加。「良い球を、良い場所に投げられるか」を評価。コーナーワークに優れた投手が高スコア。" },
+          { key: 'pitching_plus_plus', color: C_POS,  label: "Pitching++", desc: "Pitching+ に前球との球速差・リリース差・カウント状況を追加。「配球の組み立てで打者を翻弄できるか」を評価。" },
+        ].map(({ key, color, label, desc }) => (
+          <div key={key} style={{ border: `1px solid ${color}30`, background: `${color}0a`, padding: "10px 14px" }}>
+            <span style={{ color, fontWeight: 600, fontSize: 12, fontFamily: "var(--ff-mono)" }}>{label}</span>
+            <p style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 4, lineHeight: 1.5 }}>{desc}</p>
+          </div>
+        ))}
       </div>
 
-      {/* サブビュータブ */}
-      <div className="flex gap-1 bg-gray-800 rounded-lg p-1 border border-gray-700 w-fit">
+      {/* Sub-view tabs */}
+      <div style={{ display: "flex", gap: 4 }}>
         {[
           { key: 'rankings', label: 'ランキング' },
-          { key: 'detail', label: '投手詳細' },
-          { key: 'trend', label: '月別推移' },
-          { key: 'compare', label: 'モデル比較' },
+          { key: 'detail',   label: '投手詳細' },
+          { key: 'trend',    label: '月別推移' },
+          { key: 'compare',  label: 'モデル比較' },
         ].map(tab => (
           <button
             key={tab.key}
             onClick={() => { setView(tab.key); setError(null); }}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
-              view === tab.key
-                ? 'bg-gray-600 text-white'
-                : 'text-gray-400 hover:text-gray-200'
-            }`}
+            style={tabBtn(view === tab.key)}
           >
             {tab.label}
           </button>
@@ -1097,26 +851,28 @@ const StuffPlus = () => {
 
       {/* Loading */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-          <span className="ml-3 text-gray-400">読み込み中...</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "40px 0", gap: 8 }}>
+          <span className="think-dot"/>
+          <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+          <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+          <span className="t-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginLeft: 6 }}>読み込み中...</span>
         </div>
       )}
 
       {/* Error */}
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 text-red-400 rounded-lg px-4 py-3 text-sm">
+        <div style={{ color: "var(--neg)", fontSize: 12, border: "1px solid var(--neg-dim)", background: "oklch(0.26 0.10 28 / 0.12)", padding: "10px 14px" }}>
           {error}
         </div>
       )}
 
-      {/* コンテンツ */}
+      {/* Content */}
       {!isLoading && !error && (
         <>
           {view === 'rankings' && RankingsView()}
-          {view === 'detail' && DetailView()}
-          {view === 'trend' && TrendView()}
-          {view === 'compare' && CompareView()}
+          {view === 'detail'   && DetailView()}
+          {view === 'trend'    && TrendView()}
+          {view === 'compare'  && CompareView()}
         </>
       )}
     </div>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -1,63 +1,141 @@
-import {
-  Activity, MessageCircle, Zap, Settings, Users, Target, BarChart3,
-  TrendingUp, Trophy, Radio, LayoutDashboard, Medal, User, LogOut,
-} from 'lucide-react';
+import React from 'react';
+import Icon, { DLMark } from './Icon.jsx';
+import { NAV_ITEMS } from '../../constants/navItems.js';
 
-const NAV_ITEMS = [
-  { mode: 'chat', icon: MessageCircle, label: 'チャット' },
-  { mode: 'quick', icon: Zap, label: 'クイック質問' },
-  // { mode: 'custom', icon: Settings, label: 'カスタムクエリ' },
-  { mode: 'statistics', icon: Activity, label: '統計分析' },
-  { mode: 'segmentation', icon: Users, label: '選手分類' },
-  { mode: 'stuff-plus', icon: Target, label: '球質評価' },
-  { mode: 'advanced-stats', icon: BarChart3, label: 'Advanced Stats' },
-  { mode: 'hot-slump', icon: TrendingUp, label: 'Hot / Slump' },
-  { mode: 'leaderboard', icon: Trophy, label: 'リーダーボード' },
-  { mode: 'live', icon: Radio, label: '試合速報' },
-  { mode: 'monitor', icon: LayoutDashboard, label: 'モニターボード' },
-  { mode: 'standings', icon: Medal, label: '順位表' },
-  { mode: 'player-profile', icon: User, label: '選手プロフィール' },
-];
+const AppSidebar = ({ mode, setMode, collapsed, setCollapsed, user, logout }) => {
+  // Derive initials from Firebase displayName (e.g. "Takeshi M" → "TM")
+  const initials = user?.displayName
+    ? user.displayName.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
+    : (user?.email?.[0] ?? '?').toUpperCase();
+  const displayName = user?.displayName ?? user?.email?.split('@')[0] ?? '—';
 
-const AppSidebar = ({ sidebarOpen, setSidebarOpen, uiMode, setUiMode, setQuickResult, setCustomResult, logout }) => (
-  <aside className={`fixed inset-y-0 left-0 z-30 flex flex-col bg-gray-900 border-r border-gray-700 transition-all duration-300 md:relative md:translate-x-0 ${sidebarOpen ? 'translate-x-0 w-56' : '-translate-x-full md:translate-x-0 md:w-14'}`}>
-    <div className="flex items-center gap-3 px-3 h-14 border-b border-gray-700 flex-shrink-0">
-      <div className="p-1.5 bg-blue-600 rounded-lg flex-shrink-0">
-        <Activity className="w-4 h-4 text-white" />
+  return (
+    <aside
+      className="rule-r"
+      style={{
+        width: collapsed ? 56 : 224,
+        flexShrink: 0,
+        background: "var(--bg-0)",
+        display: "flex", flexDirection: "column",
+        transition: "width .18s ease",
+        overflow: "hidden",
+      }}
+    >
+      {/* Brand */}
+      <div className="rule-b" style={{
+        height: 56, display: "flex", alignItems: "center",
+        gap: 10, padding: "0 14px", flexShrink: 0,
+      }}>
+        <DLMark size={22}/>
+        {!collapsed && (
+          <div style={{ lineHeight: 1, flex: 1, minWidth: 0 }}>
+            <div className="h-display" style={{ fontSize: 15, letterSpacing: "0.06em" }}>
+              DIAMOND&nbsp;LENS
+            </div>
+            <div className="h-label" style={{ fontSize: 8.5, marginTop: 3, color: "var(--amber-dim)" }}>
+              MLB INTELLIGENCE v2.6
+            </div>
+          </div>
+        )}
       </div>
-      {sidebarOpen && <span className="font-bold text-white text-sm truncate">Diamond Lens</span>}
-    </div>
 
-    <nav className="flex-1 py-2 flex flex-col gap-0.5 px-2 overflow-y-auto scrollbar-none">
-      {NAV_ITEMS.map(({ mode, icon: Icon, label }) => (
-        <button
-          key={mode}
-          onClick={() => {
-            setUiMode(mode);
-            setQuickResult(null);
-            setCustomResult(null);
-            if (window.innerWidth < 768) setSidebarOpen(false);
-          }}
-          title={!sidebarOpen ? label : undefined}
-          className={`flex items-center gap-3 px-2 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 w-full ${sidebarOpen ? '' : 'justify-center'} ${uiMode === mode ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-white hover:bg-gray-700'}`}
-        >
-          <Icon className="w-4 h-4 flex-shrink-0" />
-          {sidebarOpen && <span className="truncate">{label}</span>}
-        </button>
-      ))}
-    </nav>
+      {/* Section header */}
+      {!collapsed && (
+        <div style={{ padding: "12px 14px 6px" }}>
+          <div className="h-label" style={{ fontSize: 9, color: "var(--ink-3)" }}>
+            MODULES / モジュール
+          </div>
+        </div>
+      )}
 
-    <div className="border-t border-gray-700 p-2 flex-shrink-0">
+      {/* Nav items */}
+      <nav style={{ flex: 1, overflowY: "auto", padding: "4px 6px" }}>
+        {NAV_ITEMS.map((item, i) => {
+          const active = mode === item.id;
+          return (
+            <button
+              key={item.id}
+              onClick={() => setMode(item.id)}
+              title={collapsed ? item.jp : undefined}
+              style={{
+                display: "flex", alignItems: "center", gap: 10,
+                width: "100%", padding: collapsed ? "9px 0" : "8px 10px",
+                justifyContent: collapsed ? "center" : "flex-start",
+                color: active ? "var(--ink-0)" : "var(--ink-2)",
+                background: active ? "var(--bg-2)" : "transparent",
+                borderLeft: active ? "2px solid var(--amber)" : "2px solid transparent",
+                marginBottom: 1,
+                transition: "all .12s",
+              }}
+              onMouseEnter={e => { if (!active) e.currentTarget.style.background = "var(--bg-1)"; }}
+              onMouseLeave={e => { if (!active) e.currentTarget.style.background = "transparent"; }}
+            >
+              <Icon name={item.icon} size={15}/>
+              {!collapsed && (
+                <>
+                  <span style={{ fontSize: 12.5, fontWeight: active ? 600 : 500, flex: 1, textAlign: "left" }}>
+                    {item.jp}
+                  </span>
+                  <span className="t-mono" style={{
+                    fontSize: 9, letterSpacing: "0.04em",
+                    color: active ? "var(--amber)" : "var(--ink-4)",
+                  }}>
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                </>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      {/* User footer */}
+      <div className="rule-t" style={{ padding: collapsed ? "10px 0" : "10px 12px", flexShrink: 0 }}>
+        {!collapsed ? (
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{
+              width: 28, height: 28, background: "var(--bg-3)", flexShrink: 0,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              color: "var(--amber)", fontFamily: "var(--ff-mono)", fontSize: 11, fontWeight: 600,
+              border: "1px solid var(--rule)",
+            }}>{initials}</div>
+            <div style={{ flex: 1, minWidth: 0, lineHeight: 1.25 }}>
+              <div style={{ fontSize: 11.5, color: "var(--ink-0)", fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {displayName}
+              </div>
+              <div className="t-mono" style={{ fontSize: 9.5, color: "var(--ink-4)" }}>AUTH · ACTIVE</div>
+            </div>
+            <button onClick={logout} title="ログアウト" style={{ color: "var(--ink-3)", padding: 4 }}>
+              <Icon name="logout" size={14}/>
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <div style={{
+              width: 28, height: 28, background: "var(--bg-3)",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              color: "var(--amber)", fontFamily: "var(--ff-mono)", fontSize: 11, fontWeight: 600,
+              border: "1px solid var(--rule)",
+            }}>{initials}</div>
+          </div>
+        )}
+      </div>
+
+      {/* Collapse toggle */}
       <button
-        onClick={logout}
-        title={!sidebarOpen ? 'ログアウト' : undefined}
-        className={`flex items-center gap-3 px-2 py-2.5 rounded-lg text-sm text-gray-400 hover:text-red-400 hover:bg-gray-700 transition-colors w-full ${sidebarOpen ? '' : 'justify-center'}`}
+        onClick={() => setCollapsed(!collapsed)}
+        className="rule-t"
+        style={{
+          padding: "8px 0", color: "var(--ink-3)",
+          display: "flex", alignItems: "center", justifyContent: "center", gap: 6,
+          fontSize: 10, letterSpacing: "0.12em", fontFamily: "var(--ff-mono)",
+        }}
       >
-        <LogOut className="w-4 h-4 flex-shrink-0" />
-        {sidebarOpen && <span>ログアウト</span>}
+        <Icon name={collapsed ? "chevR" : "chevL"} size={12}/>
+        {!collapsed && <span>COLLAPSE</span>}
       </button>
-    </div>
-  </aside>
-);
+    </aside>
+  );
+};
 
 export default AppSidebar;

--- a/frontend/src/components/layout/ChatInputArea.jsx
+++ b/frontend/src/components/layout/ChatInputArea.jsx
@@ -1,4 +1,14 @@
-import { Send, Brain } from 'lucide-react';
+import React from 'react';
+import Icon from './Icon.jsx';
+
+const QUICK_PROMPTS = [
+  { k: "HR",  label: "本塁打数ランキング" },
+  { k: "BA",  label: "打率 .300 以上" },
+  { k: "K9",  label: "K/9 トップ15 投手" },
+  { k: "WAR", label: "fWAR 年間推移" },
+  { k: "OPS", label: "OPS リーダーボード" },
+  { k: "STF", label: "球種別 Stuff+" },
+];
 
 const ChatInputArea = ({
   inputMessage,
@@ -9,51 +19,126 @@ const ChatInputArea = ({
   isAgentMode,
   setIsAgentMode,
 }) => (
-  <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 sm:px-6 py-4 transition-colors duration-200">
-    <div className="flex flex-col sm:flex-row gap-3 sm:items-end">
-      {/* エージェントモード切替トグル */}
-      <div className="flex items-center gap-2 mb-2 sm:mb-0">
+  <div className="rule-t" style={{
+    background: "var(--bg-0)", padding: "12px 28px 16px", flexShrink: 0,
+  }}>
+    {/* Quick prompts */}
+    <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 10, flexWrap: "wrap" }}>
+      <span className="h-label" style={{ fontSize: 9, color: "var(--ink-3)", marginRight: 4 }}>QUICK</span>
+      {QUICK_PROMPTS.map(q => (
         <button
-          onClick={() => setIsAgentMode(!isAgentMode)}
-          title={isAgentMode ? 'エージェントモード：ON' : 'エージェントモード：OFF'}
-          className={`p-3 rounded-lg transition-all duration-200 flex items-center gap-2 ${isAgentMode
-            ? 'bg-purple-600 text-white shadow-lg shadow-purple-500/30'
-            : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
-            }`}
+          key={q.k}
+          onClick={() => setInputMessage(`${q.label}を見せて`)}
+          disabled={isLoading}
+          style={{
+            fontSize: 10.5, padding: "3px 8px",
+            border: "1px solid var(--rule)", color: "var(--ink-2)",
+            letterSpacing: "0.01em", display: "inline-flex", gap: 6,
+            transition: "border-color .1s, color .1s",
+          }}
+          onMouseEnter={e => {
+            e.currentTarget.style.borderColor = "var(--amber-dim)";
+            e.currentTarget.style.color = "var(--ink-0)";
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.borderColor = "var(--rule)";
+            e.currentTarget.style.color = "var(--ink-2)";
+          }}
         >
-          <Brain className={`w-5 h-5 ${isAgentMode ? 'animate-pulse' : ''}`} />
-          <span className="text-xs font-bold sm:hidden">エージェント</span>
+          <span className="t-mono" style={{ color: "var(--amber)" }}>{q.k}</span>
+          <span>{q.label}</span>
         </button>
-      </div>
+      ))}
+    </div>
 
-      {/* テキストエリア */}
-      <div className="flex-1">
+    {/* Composer box */}
+    <div style={{ border: "1px solid var(--rule-hi)", background: "var(--bg-1)" }}>
+      {/* Textarea */}
+      <div style={{ padding: "10px 14px" }}>
         <textarea
           value={inputMessage}
-          onChange={(e) => setInputMessage(e.target.value)}
+          onChange={e => setInputMessage(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="例: 大谷翔平の2024年の打率は？"
-          className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg resize-none focus:ring-2 focus:ring-blue-600 focus:border-transparent text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 bg-white dark:bg-gray-700 transition-colors duration-200"
-          rows="2"
+          placeholder="例: 大谷翔平の2024年打率は？Skenes の Stuff+ を月別で。"
+          rows={2}
           disabled={isLoading}
+          style={{
+            width: "100%", fontSize: 13.5, lineHeight: 1.5,
+            color: "var(--ink-0)", resize: "none",
+            fontFamily: "var(--ff-text)",
+          }}
         />
       </div>
 
-      {/* 送信ボタン */}
-      <button
-        onClick={handleSendMessageStream}
-        disabled={!inputMessage.trim() || isLoading}
-        className="px-4 sm:px-6 py-3 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 font-medium transition-colors duration-200 w-full sm:w-auto"
-      >
-        <Send className="w-4 h-4" />
-        🌊 送信
-      </button>
+      {/* Action row */}
+      <div className="rule-t" style={{ padding: "6px 10px 6px 14px", display: "flex", alignItems: "center", gap: 8 }}>
+        {/* Agent mode toggle */}
+        <button
+          onClick={() => setIsAgentMode(!isAgentMode)}
+          title={isAgentMode ? 'エージェントモード: ON' : 'エージェントモード: OFF'}
+          style={{
+            fontSize: 10.5, padding: "3px 8px",
+            border: `1px solid ${isAgentMode ? "var(--purp)" : "var(--rule-hi)"}`,
+            color: isAgentMode ? "var(--purp)" : "var(--ink-2)",
+            display: "inline-flex", alignItems: "center", gap: 5,
+            background: isAgentMode ? "oklch(from var(--purp) l c h / 0.12)" : "transparent",
+            letterSpacing: "0.04em",
+            transition: "all .12s",
+          }}
+        >
+          <Icon name="sparkle" size={11}/> AGENT {isAgentMode ? "ON" : "OFF"}
+        </button>
+
+        <button
+          style={{
+            fontSize: 10.5, padding: "3px 8px",
+            border: "1px solid var(--rule-hi)", color: "var(--ink-2)",
+            display: "inline-flex", alignItems: "center", gap: 5,
+          }}
+        >
+          <Icon name="grid" size={11}/> STATCAST
+        </button>
+
+        <div style={{ flex: 1 }}/>
+
+        <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>
+          {inputMessage.length} CHARS
+        </span>
+
+        <button style={{ padding: 5, color: "var(--ink-3)", display: "flex" }} title="音声入力">
+          <Icon name="mic" size={14}/>
+        </button>
+
+        <button
+          onClick={handleSendMessageStream}
+          disabled={!inputMessage.trim() || isLoading}
+          style={{
+            padding: "5px 14px",
+            background: inputMessage.trim() && !isLoading ? "var(--amber)" : "var(--bg-3)",
+            color: inputMessage.trim() && !isLoading ? "var(--bg-0)" : "var(--ink-4)",
+            display: "inline-flex", alignItems: "center", gap: 6,
+            fontWeight: 600, fontSize: 11.5, letterSpacing: "0.08em",
+            fontFamily: "var(--ff-mono)", transition: "all .12s",
+          }}
+        >
+          {isLoading ? (
+            <>
+              <span className="think-dot"/>
+              <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+              <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+            </>
+          ) : (
+            <>EXECUTE <Icon name="send" size={12}/></>
+          )}
+        </button>
+      </div>
     </div>
 
-    <div className="mt-3 text-center">
-      <p className="text-xs text-gray-500 dark:text-gray-400 transition-colors duration-200">
-        サンプル質問: 「大谷翔平 打率」「ヤンキース 勝率」「2024年のホームラン王トップ10を表で」
-      </p>
+    {/* Hint row */}
+    <div style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 8 }}>
+      <span className="t-mono" style={{ fontSize: 9.5, color: "var(--ink-4)" }}>
+        ⏎ 送信 · ⇧⏎ 改行
+      </span>
     </div>
   </div>
 );

--- a/frontend/src/components/layout/ChatMessageList.jsx
+++ b/frontend/src/components/layout/ChatMessageList.jsx
@@ -1,4 +1,6 @@
-import { Bot, User, AlertTriangle, ThumbsUp, ThumbsDown } from 'lucide-react';
+import React from 'react';
+import { DLMark } from './Icon.jsx';
+import Icon from './Icon.jsx';
 import AgentReasoningTracker from '../AgentReasoningTracker.jsx';
 import SimpleChatChart from '../ChatChart.jsx';
 import StatCard from '../chat/StatCard.jsx';
@@ -7,6 +9,310 @@ import MatchupAnalysisCard from '../MatchupAnalysisCard.jsx';
 import StrategyReportCard from '../StrategyReportCard.jsx';
 import { FAILURE_CATEGORY_LABELS } from '../../constants/failureCategories.js';
 
+// ============================================================
+// User message
+// ============================================================
+const UserMessage = ({ message, formatTime, user }) => {
+  const initials = user?.displayName
+    ? user.displayName.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
+    : (user?.email?.[0] ?? 'U').toUpperCase();
+  const displayName = user?.displayName ?? user?.email?.split('@')[0] ?? 'USER';
+
+  return (
+    <div className="rule-b" style={{ padding: "16px 28px", display: "flex", gap: 14 }}>
+      {/* Avatar */}
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, minWidth: 56, flexShrink: 0 }}>
+        <div style={{
+          width: 26, height: 26, background: "var(--bg-3)",
+          display: "flex", alignItems: "center", justifyContent: "center",
+          fontFamily: "var(--ff-mono)", fontSize: 10, color: "var(--ink-0)",
+          border: "1px solid var(--rule)", fontWeight: 600,
+        }}>{initials}</div>
+        <span className="h-label" style={{ fontSize: 8, color: "var(--ink-4)" }}>USER</span>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 6 }}>
+          <span style={{ fontSize: 12.5, color: "var(--ink-0)", fontWeight: 600 }}>{displayName}</span>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>
+            {formatTime(message.timestamp)}
+          </span>
+        </div>
+        <div style={{ fontSize: 14, color: "var(--ink-1)", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
+          {message.content}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================
+// Feedback buttons
+// ============================================================
+const FeedbackRow = ({
+  message, feedbackState, activeFeedbackForm,
+  feedbackFormData, setFeedbackFormData, setActiveFeedbackForm, handleFeedback,
+}) => {
+  if (!message.requestId) return null;
+  const state = feedbackState[message.id];
+  const FEEDBACK_CATEGORIES = [
+    { id: 'inaccurate',   label: '不正確・誤り' },
+    { id: 'irrelevant',   label: '無関係な回答' },
+    { id: 'wrong_player', label: '選手が違う' },
+    { id: 'wrong_stats',  label: '統計が違う' },
+    { id: 'slow',         label: '応答が遅い' },
+  ];
+
+  return (
+    <>
+      <div style={{ marginTop: 14, display: "flex", alignItems: "center", gap: 4, color: "var(--ink-3)" }}>
+        <button
+          onClick={() => handleFeedback(message.id, message.requestId, 'good')}
+          disabled={state === 'loading' || state === 'good' || state === 'bad'}
+          title="正確な回答"
+          style={{ padding: 6, display: "flex", color: state === 'good' ? "var(--pos)" : "var(--ink-3)" }}
+        >
+          <Icon name="thumbUp" size={13}/>
+        </button>
+        <button
+          onClick={() => handleFeedback(message.id, message.requestId, 'bad')}
+          disabled={state === 'loading' || state === 'good' || state === 'bad'}
+          title="改善が必要"
+          style={{ padding: 6, display: "flex", color: state === 'bad' ? "var(--neg)" : "var(--ink-3)" }}
+        >
+          <Icon name="thumbDown" size={13}/>
+        </button>
+        {state === 'error' && (
+          <span className="t-mono" style={{ fontSize: 9.5, color: "var(--neg)", marginLeft: 4 }}>送信失敗</span>
+        )}
+      </div>
+
+      {/* Detail feedback form */}
+      {activeFeedbackForm && String(activeFeedbackForm.messageId) === String(message.id) && (
+        <div style={{
+          marginTop: 10, padding: 12,
+          border: "1px solid var(--rule)", background: "var(--bg-1)",
+        }}>
+          <div className="h-label" style={{ fontSize: 9, color: "var(--ink-2)", marginBottom: 10 }}>
+            FEEDBACK DETAIL
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 10 }}>
+            {FEEDBACK_CATEGORIES.map(cat => (
+              <button
+                key={cat.id}
+                onClick={() => setFeedbackFormData(prev => ({ ...prev, category: cat.id }))}
+                style={{
+                  fontSize: 10.5, padding: "3px 8px",
+                  border: `1px solid ${feedbackFormData.category === cat.id ? "var(--amber)" : "var(--rule)"}`,
+                  color: feedbackFormData.category === cat.id ? "var(--amber)" : "var(--ink-2)",
+                  background: feedbackFormData.category === cat.id ? "var(--amber-glow)" : "transparent",
+                }}
+              >{cat.label}</button>
+            ))}
+          </div>
+          <textarea
+            value={feedbackFormData.reason}
+            onChange={e => setFeedbackFormData(prev => ({ ...prev, reason: e.target.value }))}
+            placeholder="具体的な問題点（任意）"
+            rows={2}
+            style={{ width: "100%", fontSize: 12, marginBottom: 10, padding: 8, background: "var(--bg-0)", border: "1px solid var(--rule)", color: "var(--ink-1)", resize: "none" }}
+          />
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+            <button
+              onClick={() => setActiveFeedbackForm(null)}
+              style={{ fontSize: 11, color: "var(--ink-3)", padding: "4px 10px" }}
+            >キャンセル</button>
+            <button
+              onClick={() => handleFeedback(message.id, message.requestId, 'bad', feedbackFormData)}
+              disabled={!feedbackFormData.category}
+              style={{
+                fontSize: 11, padding: "4px 12px",
+                background: feedbackFormData.category ? "var(--amber)" : "var(--bg-3)",
+                color: feedbackFormData.category ? "var(--bg-0)" : "var(--ink-4)",
+                fontWeight: 600,
+              }}
+            >送信する</button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+// ============================================================
+// Bot message
+// ============================================================
+const BotMessage = ({
+  message, feedbackState, activeFeedbackForm,
+  feedbackFormData, setFeedbackFormData, setActiveFeedbackForm, handleFeedback,
+  formatTime,
+}) => {
+  const isThinking = message.isStreaming && !message.content && !message.streamingStatus;
+  const isStreaming = message.isStreaming;
+
+  return (
+    <div style={{ padding: "20px 28px", background: "var(--bg-0)" }} className="rule-b">
+      <div style={{ display: "flex", gap: 14 }}>
+        {/* Avatar */}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, minWidth: 56, flexShrink: 0 }}>
+          <DLMark size={26}/>
+          <span className="h-label" style={{ fontSize: 8, color: "var(--amber)" }}>DL·AI</span>
+        </div>
+
+        {/* Content */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* Message header */}
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12, flexWrap: "wrap" }}>
+            <span style={{
+              fontSize: 12.5, color: "var(--ink-0)", fontWeight: 600,
+              fontFamily: "var(--ff-head)", letterSpacing: "0.04em",
+            }}>DIAMOND LENS</span>
+            <span className="t-mono" style={{
+              fontSize: 9.5, color: "var(--amber)",
+              padding: "1px 6px", border: "1px solid var(--amber-dim)", letterSpacing: "0.08em",
+            }}>
+              {isStreaming ? "STREAMING" : "SONNET"}
+            </span>
+            <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-4)" }}>
+              {formatTime(message.timestamp)}
+            </span>
+          </div>
+
+          {/* Streaming status */}
+          {isStreaming && message.streamingStatus && (
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12 }}>
+              <span className="t-mono" style={{ fontSize: 11, color: "var(--amber)", letterSpacing: "0.08em" }}>
+                {message.streamingStatus.toUpperCase()}
+              </span>
+              <span>
+                <span className="think-dot"/>
+                <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+                <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+              </span>
+            </div>
+          )}
+
+          {/* Thinking state (no content yet) */}
+          {isThinking && (
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <span className="t-mono" style={{ fontSize: 11, color: "var(--amber)", letterSpacing: "0.08em" }}>
+                PROCESSING
+              </span>
+              <span>
+                <span className="think-dot"/>
+                <span className="think-dot" style={{ animationDelay: ".2s" }}/>
+                <span className="think-dot" style={{ animationDelay: ".4s" }}/>
+              </span>
+            </div>
+          )}
+
+          {/* Quality warning */}
+          {message.qualityWarning?.has_warning && (
+            <div style={{
+              marginBottom: 12, display: "flex", alignItems: "flex-start", gap: 8,
+              padding: "8px 12px", border: "1px solid var(--neg-dim)", background: "oklch(from var(--neg) l c h / 0.08)",
+            }}>
+              <Icon name="alert" size={14} style={{ color: "var(--neg)", flexShrink: 0, marginTop: 1 }}/>
+              <div style={{ fontSize: 12, color: "var(--ink-1)", lineHeight: 1.5 }}>
+                類似の質問で精度が低かった事例があります。回答内容を慎重にご確認ください。
+                {message.qualityWarning.top_failure_category && (
+                  <span style={{ marginLeft: 6, color: "var(--neg)" }}>
+                    ({FAILURE_CATEGORY_LABELS[message.qualityWarning.top_failure_category] ?? message.qualityWarning.top_failure_category})
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Agent reasoning steps */}
+          {message.steps && message.steps.length > 0 && (
+            <div style={{ marginBottom: 14 }}>
+              <AgentReasoningTracker
+                steps={message.steps}
+                isStreaming={message.isStreaming}
+                isCollapsible={!message.isStreaming}
+              />
+            </div>
+          )}
+
+          {/* Main text */}
+          {!message.isStrategyReport && message.content && (
+            <div style={{ fontSize: 13.5, color: "var(--ink-1)", lineHeight: 1.65, marginBottom: 14, whiteSpace: "pre-wrap" }}>
+              {message.content}
+            </div>
+          )}
+
+          {/* Table */}
+          {message.isTable && message.tableData && message.columns && (
+            <div style={{ marginBottom: 14 }}>
+              <DataTable
+                tableData={message.tableData}
+                columns={message.columns}
+                isTransposed={message.isTransposed}
+                decimalColumns={message.decimalColumns}
+                grouping={message.grouping}
+              />
+            </div>
+          )}
+
+          {/* Chart */}
+          {message.isChart && message.chartData && message.chartConfig ? (
+            <div style={{ marginBottom: 14 }}>
+              <SimpleChatChart
+                chartData={message.chartData}
+                chartConfig={message.chartConfig}
+                chartType={message.chartType}
+              />
+            </div>
+          ) : message.isChart ? (
+            <div style={{ marginBottom: 14, padding: 12, border: "1px solid var(--neg-dim)", color: "var(--neg)", fontSize: 11 }}>
+              Chart data missing.
+            </div>
+          ) : null}
+
+          {/* Stats card */}
+          {message.stats && (
+            <div style={{ marginBottom: 14 }}>
+              <StatCard stats={message.stats}/>
+            </div>
+          )}
+
+          {/* Matchup card */}
+          {message.isMatchupCard && message.matchupData && (
+            <div style={{ marginBottom: 14 }}>
+              <MatchupAnalysisCard matchupData={message.matchupData}/>
+            </div>
+          )}
+
+          {/* Strategy report */}
+          {message.isStrategyReport && message.content && !message.isStreaming && (
+            <div style={{ marginBottom: 14 }}>
+              <StrategyReportCard finalAnswer={message.content} strategyData={message.strategyData}/>
+            </div>
+          )}
+
+          {/* Feedback */}
+          {!isStreaming && (
+            <FeedbackRow
+              message={message}
+              feedbackState={feedbackState}
+              activeFeedbackForm={activeFeedbackForm}
+              feedbackFormData={feedbackFormData}
+              setFeedbackFormData={setFeedbackFormData}
+              setActiveFeedbackForm={setActiveFeedbackForm}
+              handleFeedback={handleFeedback}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================
+// ChatMessageList
+// ============================================================
 const ChatMessageList = ({
   messages,
   feedbackState,
@@ -17,232 +323,27 @@ const ChatMessageList = ({
   handleFeedback,
   messagesEndRef,
   formatTime,
+  user,
 }) => (
-  <div className="px-4 sm:px-6 py-4 space-y-4 h-full">
-    {messages.map((message) => (
-      <div
-        key={message.id}
-        className={`flex gap-3 ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}
-      >
-        {/* ボットアバター */}
-        {message.type === 'bot' && (
-          <div className="w-8 h-8 rounded-full bg-blue-600 dark:bg-blue-500 flex items-center justify-center flex-shrink-0 transition-colors duration-200">
-            <Bot className="w-5 h-5 text-white" />
-          </div>
-        )}
-
-        {/* メッセージ本体 */}
-        <div className={`${message.isChart ? 'max-w-full lg:max-w-5xl' : 'max-w-full sm:max-w-2xl'} ${message.type === 'user' ? 'order-2' : ''}`}>
-          <div
-            className={`px-4 py-3 rounded-lg transition-colors duration-200 ${message.type === 'user'
-              ? 'bg-blue-600 dark:bg-blue-500 text-white'
-              : 'bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white'
-              }`}
-          >
-            {/* ストリーミングステータス */}
-            {message.isStreaming && message.streamingStatus && (
-              <div className="mb-3 flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 italic">
-                <div className="flex gap-1">
-                  <span className="w-2 h-2 bg-blue-600 dark:bg-blue-400 rounded-full animate-bounce"></span>
-                  <span className="w-2 h-2 bg-blue-600 dark:bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></span>
-                  <span className="w-2 h-2 bg-blue-600 dark:bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></span>
-                </div>
-                <span>{message.streamingStatus}</span>
-              </div>
-            )}
-
-            {/* 品質警告バナー */}
-            {message.qualityWarning?.has_warning && (
-              <div className="mb-3 flex items-start gap-2 rounded-md bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 px-3 py-2 text-sm text-amber-800 dark:text-amber-300">
-                <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-                <span>
-                  類似の質問で精度が低かった事例があります。回答内容を慎重にご確認ください。
-                  {message.qualityWarning.top_failure_category && (
-                    <span className="ml-1 text-amber-600 dark:text-amber-400">
-                      ({FAILURE_CATEGORY_LABELS[message.qualityWarning.top_failure_category] ?? message.qualityWarning.top_failure_category})
-                    </span>
-                  )}
-                </span>
-              </div>
-            )}
-
-            {/* メッセージテキスト */}
-            {!message.isStrategyReport && (
-              <div className="mb-2">
-                <p className="whitespace-pre-wrap">{message.content}</p>
-                {message.isStreaming && !message.content && (
-                  <div className="flex gap-1 text-gray-400">
-                    <span className="animate-pulse">●</span>
-                    <span className="animate-pulse" style={{ animationDelay: '0.15s' }}>●</span>
-                    <span className="animate-pulse" style={{ animationDelay: '0.3s' }}>●</span>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* ストリーミング中の戦略レポートプレースホルダー */}
-            {message.isStrategyReport && message.isStreaming && !message.content && (
-              <div className="mb-2 flex gap-1 text-gray-400">
-                <span className="animate-pulse">●</span>
-                <span className="animate-pulse" style={{ animationDelay: '0.15s' }}>●</span>
-                <span className="animate-pulse" style={{ animationDelay: '0.3s' }}>●</span>
-              </div>
-            )}
-
-            {/* 思考プロセス */}
-            {message.steps && message.steps.length > 0 && (
-              <AgentReasoningTracker
-                steps={message.steps}
-                isStreaming={message.isStreaming}
-                isCollapsible={!message.isStreaming}
-              />
-            )}
-
-            {/* テーブル表示 */}
-            {message.isTable && message.tableData && message.columns && (
-              <DataTable
-                tableData={message.tableData}
-                columns={message.columns}
-                isTransposed={message.isTransposed}
-                decimalColumns={message.decimalColumns}
-                grouping={message.grouping}
-              />
-            )}
-
-            {/* チャート表示 */}
-            {message.isChart && message.chartData && message.chartConfig ? (
-              <SimpleChatChart
-                chartData={message.chartData}
-                chartConfig={message.chartConfig}
-                chartType={message.chartType}
-              />
-            ) : message.isChart ? (
-              <div className="mt-4 p-4 bg-red-100 dark:bg-red-900 rounded-lg">
-                <p className="text-red-800 dark:text-red-200">
-                  Chart data missing: isChart={String(message.isChart)}, hasData={String(!!message.chartData)}, hasConfig={String(!!message.chartConfig)}
-                </p>
-              </div>
-            ) : null}
-
-            {/* 統計データカード */}
-            {message.stats && <StatCard stats={message.stats} />}
-
-            {/* 対戦分析カード */}
-            {message.isMatchupCard && message.matchupData && (
-              <MatchupAnalysisCard matchupData={message.matchupData} />
-            )}
-
-            {/* 戦略レポートカード */}
-            {message.isStrategyReport && message.content && !message.isStreaming && (
-              <StrategyReportCard finalAnswer={message.content} strategyData={message.strategyData} />
-            )}
-
-            {/* フィードバック UI */}
-            {message.type === 'bot' && message.requestId && (
-              <>
-                <div className="mt-3 flex items-center justify-end gap-2 border-t border-gray-100 dark:border-gray-600 pt-2">
-                  <span className="text-xs text-gray-400 dark:text-gray-500 mr-1">回答の評価:</span>
-                  <button
-                    onClick={() => handleFeedback(message.id, message.requestId, 'good')}
-                    disabled={feedbackState[message.id] === 'loading' || feedbackState[message.id] === 'good' || feedbackState[message.id] === 'bad'}
-                    className={`p-1.5 rounded-md transition-colors duration-200 ${feedbackState[message.id] === 'good'
-                      ? 'text-green-600 bg-green-50 dark:bg-green-900/20'
-                      : 'text-gray-400 hover:text-green-600 hover:bg-gray-100 dark:hover:bg-gray-600 disabled:opacity-50'
-                      }`}
-                    title="正確な回答"
-                  >
-                    <ThumbsUp className={`w-4 h-4 ${feedbackState[message.id] === 'good' ? 'fill-current' : ''}`} />
-                  </button>
-                  <button
-                    onClick={() => handleFeedback(message.id, message.requestId, 'bad')}
-                    disabled={feedbackState[message.id] === 'loading' || feedbackState[message.id] === 'good' || feedbackState[message.id] === 'bad'}
-                    className={`p-1.5 rounded-md transition-colors duration-200 ${feedbackState[message.id] === 'bad'
-                      ? 'text-red-600 bg-red-50 dark:bg-red-900/20'
-                      : 'text-gray-400 hover:text-red-600 hover:bg-gray-100 dark:hover:bg-gray-600 disabled:opacity-50'
-                      }`}
-                    title="不正確な回答/改善が必要"
-                  >
-                    <ThumbsDown className={`w-4 h-4 ${feedbackState[message.id] === 'bad' ? 'fill-current' : ''}`} />
-                  </button>
-                  {feedbackState[message.id] === 'error' && (
-                    <span className="text-xs text-red-500 ml-1">送信失敗</span>
-                  )}
-                </div>
-
-                {/* 詳細フィードバック入力パネル */}
-                {activeFeedbackForm && String(activeFeedbackForm.messageId) === String(message.id) && (
-                  <div
-                    className="mt-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg border border-yellow-200 dark:border-yellow-800"
-                    style={{ display: 'block', width: '100%', position: 'relative', zIndex: 10 }}
-                  >
-                    <h4 className="text-xs font-bold text-yellow-800 dark:text-yellow-200 mb-2">改善のための詳細</h4>
-
-                    <div className="flex flex-wrap gap-2 mb-3">
-                      {[
-                        { id: 'inaccurate', label: '不正確・誤り' },
-                        { id: 'slow', label: '応答が遅い' },
-                        { id: 'irrelevant', label: '無関係な回答' },
-                        { id: 'wrong_player', label: '選手が違う' },
-                        { id: 'wrong_stats', label: '統計が違う' },
-                      ].map(cat => (
-                        <button
-                          key={cat.id}
-                          onClick={() => setFeedbackFormData(prev => ({ ...prev, category: cat.id }))}
-                          className={`px-2 py-1.5 text-xs rounded border transition-colors ${feedbackFormData.category === cat.id
-                            ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
-                            : 'bg-white border-gray-200 text-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-600'
-                            }`}
-                        >
-                          {cat.label}
-                        </button>
-                      ))}
-                    </div>
-
-                    <textarea
-                      value={feedbackFormData.reason}
-                      onChange={(e) => setFeedbackFormData(prev => ({ ...prev, reason: e.target.value }))}
-                      placeholder="具体的な問題点（任意）"
-                      className="w-full p-2 text-xs bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md mb-3 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:text-white dark:placeholder-gray-500"
-                      rows="2"
-                    />
-
-                    <div className="flex justify-end gap-2 font-medium">
-                      <button
-                        onClick={() => setActiveFeedbackForm(null)}
-                        className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                      >
-                        キャンセル
-                      </button>
-                      <button
-                        onClick={() => handleFeedback(message.id, message.requestId, 'bad', feedbackFormData)}
-                        disabled={!feedbackFormData.category}
-                        className="px-4 py-1.5 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
-                      >
-                        送信する
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* タイムスタンプ */}
-          <p className={`text-xs text-gray-500 dark:text-gray-400 mt-1 transition-colors duration-200 ${message.type === 'user' ? 'text-right' : 'text-left'}`}>
-            {formatTime(message.timestamp)}
-          </p>
-        </div>
-
-        {/* ユーザーアバター */}
-        {message.type === 'user' && (
-          <div className="w-8 h-8 rounded-full bg-gray-600 dark:bg-gray-500 flex items-center justify-center flex-shrink-0 order-3 transition-colors duration-200">
-            <User className="w-5 h-5 text-white" />
-          </div>
-        )}
-      </div>
-    ))}
-
-    <div ref={messagesEndRef} />
+  <div style={{ paddingBottom: 8 }}>
+    {messages.map(message =>
+      message.type === 'user' ? (
+        <UserMessage key={message.id} message={message} formatTime={formatTime} user={user}/>
+      ) : (
+        <BotMessage
+          key={message.id}
+          message={message}
+          feedbackState={feedbackState}
+          activeFeedbackForm={activeFeedbackForm}
+          feedbackFormData={feedbackFormData}
+          setFeedbackFormData={setFeedbackFormData}
+          setActiveFeedbackForm={setActiveFeedbackForm}
+          handleFeedback={handleFeedback}
+          formatTime={formatTime}
+        />
+      )
+    )}
+    <div ref={messagesEndRef}/>
   </div>
 );
 

--- a/frontend/src/components/layout/ChatScreen.jsx
+++ b/frontend/src/components/layout/ChatScreen.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import Icon, { DLMark } from './Icon.jsx';
+import ChatMessageList from './ChatMessageList.jsx';
+import ChatInputArea from './ChatInputArea.jsx';
+
+// ============================================================
+// Session Panel (left 240px)
+// ============================================================
+const SessionPanel = ({ sessionId, onNewSession }) => (
+  <div className="rule-r" style={{
+    width: 240, flexShrink: 0,
+    background: "var(--bg-0)", display: "flex", flexDirection: "column",
+  }}>
+    {/* Header */}
+    <div className="rule-b" style={{ padding: "12px 16px", display: "flex", alignItems: "center", gap: 10 }}>
+      <span className="h-label" style={{ color: "var(--ink-0)" }}>SESSIONS</span>
+      <div style={{ flex: 1 }}/>
+      <button
+        onClick={onNewSession}
+        style={{ display: "flex", alignItems: "center", gap: 4, color: "var(--amber)" }}
+        title="新規セッション"
+      >
+        <Icon name="plus" size={12}/>
+        <span className="h-label" style={{ fontSize: 9.5, color: "var(--amber)" }}>NEW</span>
+      </button>
+    </div>
+
+    {/* Session list */}
+    <div style={{ flex: 1, overflowY: "auto" }}>
+      {sessionId ? (
+        <button style={{
+          width: "100%", textAlign: "left",
+          padding: "10px 14px",
+          background: "var(--bg-2)",
+          borderLeft: "2px solid var(--amber)",
+          borderBottom: "1px solid var(--rule-dim)",
+        }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginBottom: 3 }}>
+            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--amber)" }}>#001</span>
+            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--ink-4)", marginLeft: "auto" }}>現在</span>
+          </div>
+          <div style={{ fontSize: 12.5, color: "var(--ink-0)", fontWeight: 600 }}>アクティブセッション</div>
+          <div className="t-mono" style={{ fontSize: 9.5, color: "var(--ink-4)", marginTop: 4 }}>
+            {sessionId.slice(0, 16)}…
+          </div>
+        </button>
+      ) : (
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "center",
+          height: "100%", flexDirection: "column", gap: 8,
+          color: "var(--ink-4)", padding: "24px 16px", textAlign: "center",
+        }}>
+          <DLMark size={28}/>
+          <div className="t-mono" style={{ fontSize: 10, letterSpacing: "0.08em" }}>NO SESSION</div>
+          <div style={{ fontSize: 11, color: "var(--ink-3)", lineHeight: 1.5 }}>
+            質問するとセッションが開始されます
+          </div>
+        </div>
+      )}
+    </div>
+
+    {/* CTX usage footer */}
+    <div className="rule-t" style={{ padding: "10px 14px", flexShrink: 0 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4 }}>
+        <span className="h-label" style={{ fontSize: 9, color: "var(--ink-3)" }}>CTX USAGE</span>
+        <span className="t-mono" style={{ fontSize: 10, color: "var(--ink-1)" }}>— / 200K</span>
+      </div>
+      <div style={{ height: 3, background: "var(--bg-2)" }}>
+        <div style={{ width: "0%", height: "100%", background: "var(--amber)" }}/>
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================
+// Conversation header bar
+// ============================================================
+const ConversationHeader = ({ sessionId, onClearHistory }) => (
+  <div className="rule-b" style={{
+    padding: "0 28px", height: 40,
+    display: "flex", alignItems: "center", gap: 12, flexShrink: 0,
+  }}>
+    <span className="t-mono" style={{ fontSize: 10, color: "var(--amber)", letterSpacing: "0.08em" }}>
+      MLB INTELLIGENCE
+    </span>
+    <div style={{ width: 1, height: 12, background: "var(--rule)" }}/>
+    <span style={{ fontSize: 12.5, color: "var(--ink-0)", fontWeight: 500 }}>チャット</span>
+    <div style={{ flex: 1 }}/>
+    {sessionId && onClearHistory && (
+      <button
+        onClick={onClearHistory}
+        title="会話履歴をクリア"
+        style={{ display: "flex", alignItems: "center", gap: 5, color: "var(--ink-3)", padding: "3px 6px" }}
+        onMouseEnter={e => e.currentTarget.style.color = "var(--neg)"}
+        onMouseLeave={e => e.currentTarget.style.color = "var(--ink-3)"}
+      >
+        <Icon name="trash" size={13}/>
+        <span className="h-label" style={{ fontSize: 9, color: "inherit" }}>CLEAR</span>
+      </button>
+    )}
+  </div>
+);
+
+// ============================================================
+// ChatScreen — 2-panel layout
+// ============================================================
+const ChatScreen = ({
+  // message list
+  messages, feedbackState, activeFeedbackForm, feedbackFormData,
+  setFeedbackFormData, setActiveFeedbackForm, handleFeedback,
+  messagesEndRef, formatTime, user,
+  // input
+  inputMessage, setInputMessage, handleKeyDown, isLoading,
+  handleSendMessageStream, isAgentMode, setIsAgentMode,
+  // session
+  sessionId, handleClearHistory,
+}) => (
+  <div style={{ flex: 1, display: "flex", minHeight: 0, overflow: "hidden" }}>
+    <SessionPanel sessionId={sessionId} onNewSession={handleClearHistory}/>
+
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, background: "var(--bg-0)" }}>
+      <ConversationHeader sessionId={sessionId} onClearHistory={handleClearHistory}/>
+
+      {/* Messages */}
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        <ChatMessageList
+          messages={messages}
+          feedbackState={feedbackState}
+          activeFeedbackForm={activeFeedbackForm}
+          feedbackFormData={feedbackFormData}
+          setFeedbackFormData={setFeedbackFormData}
+          setActiveFeedbackForm={setActiveFeedbackForm}
+          handleFeedback={handleFeedback}
+          messagesEndRef={messagesEndRef}
+          formatTime={formatTime}
+          user={user}
+        />
+      </div>
+
+      {/* Composer */}
+      <ChatInputArea
+        inputMessage={inputMessage}
+        setInputMessage={setInputMessage}
+        handleKeyDown={handleKeyDown}
+        isLoading={isLoading}
+        handleSendMessageStream={handleSendMessageStream}
+        isAgentMode={isAgentMode}
+        setIsAgentMode={setIsAgentMode}
+      />
+    </div>
+  </div>
+);
+
+export default ChatScreen;

--- a/frontend/src/components/layout/ChatTopBar.jsx
+++ b/frontend/src/components/layout/ChatTopBar.jsx
@@ -1,46 +1,97 @@
-import { Menu, Trash2 } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import Icon from './Icon.jsx';
+import { NAV_ITEMS } from '../../constants/navItems.js';
 
-const MODE_LABELS = {
-  chat: 'MLBの統計データについて質問してください',
-  quick: 'よく使われる質問をワンクリックで実行',
-  custom: 'カスタムクエリを作成して詳細な分析を実行',
-  statistics: '統計分析モデルを使用してチームの勝率を予測',
-  segmentation: 'K-meansクラスタリングで選手タイプを分析',
-  'stuff-plus': '球質（Stuff+）評価',
-  'advanced-stats': 'Advanced Stats Rankings',
-  'hot-slump': '直近7日スタッツで打者のホット/スランプをランキング',
-  leaderboard: '打者・投手のシーズンリーダーボード',
-  live: '進行中の試合をリアルタイム表示',
-  monitor: '全試合をグリッドで一覧監視・異常検知',
-  standings: 'MLB順位表（AL/NL ディビジョン別）',
-  'player-profile': '選手名を検索してプロフィール・KPIを確認',
+const Topbar = ({ mode, collapsed, onToggleSidebar, sessionId, onClearHistory }) => {
+  const current = NAV_ITEMS.find(n => n.id === mode);
+  const idx     = NAV_ITEMS.findIndex(n => n.id === mode);
+
+  const [time, setTime] = useState(() =>
+    new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" })
+  );
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTime(new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" }));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="rule-b" style={{
+      height: 48, display: "flex", alignItems: "stretch",
+      background: "var(--bg-0)", flexShrink: 0,
+    }}>
+      {/* Sidebar toggle */}
+      <button
+        onClick={onToggleSidebar}
+        className="rule-r"
+        style={{ width: 40, display: "flex", alignItems: "center", justifyContent: "center", color: "var(--ink-2)" }}
+      >
+        <Icon name="menu" size={16}/>
+      </button>
+
+      {/* Module breadcrumb */}
+      <div className="rule-r" style={{
+        display: "flex", alignItems: "center", gap: 10,
+        padding: "0 16px", minWidth: 220, flexShrink: 0,
+      }}>
+        <span className="t-mono" style={{ fontSize: 10, color: "var(--amber)", letterSpacing: "0.1em" }}>
+          {String(idx + 1).padStart(2, "0")} / {String(NAV_ITEMS.length).padStart(2, "0")}
+        </span>
+        <div style={{ width: 1, height: 16, background: "var(--rule)" }}/>
+        <div className="h-display" style={{ fontSize: 14 }}>{current?.en || "—"}</div>
+        <div className="t-mono" style={{ fontSize: 10, color: "var(--ink-3)", letterSpacing: "0.06em" }}>
+          / {current?.jp}
+        </div>
+      </div>
+
+      {/* Command bar */}
+      <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 10, padding: "0 16px" }}>
+        <Icon name="search" size={13} style={{ color: "var(--ink-4)", flexShrink: 0 }}/>
+        <input
+          placeholder="GO / Symbol or command... 例: JUDGE, HR 2024, STUFF+ SKENES"
+          style={{
+            flex: 1, fontSize: 12.5, color: "var(--ink-1)",
+            fontFamily: "var(--ff-mono)", letterSpacing: "0.01em",
+          }}
+          readOnly
+        />
+        <span className="t-mono" style={{
+          fontSize: 9.5, color: "var(--ink-4)",
+          padding: "2px 6px", border: "1px solid var(--rule)", flexShrink: 0,
+        }}>⌘K</span>
+      </div>
+
+      {/* Status cluster */}
+      <div className="rule-l" style={{
+        display: "flex", alignItems: "center", gap: 14, padding: "0 16px", flexShrink: 0,
+      }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span className="live-dot"/>
+          <span className="h-label" style={{ fontSize: 9, color: "var(--pos)" }}>API ONLINE</span>
+        </div>
+
+        {/* Chat-only: clear history */}
+        {mode === "chat" && sessionId && onClearHistory && (
+          <button
+            onClick={onClearHistory}
+            title="会話履歴をクリア"
+            style={{ display: "flex", alignItems: "center", gap: 5, color: "var(--ink-3)", padding: "3px 6px" }}
+            onMouseEnter={e => e.currentTarget.style.color = "var(--neg)"}
+            onMouseLeave={e => e.currentTarget.style.color = "var(--ink-3)"}
+          >
+            <Icon name="trash" size={13}/>
+            <span className="h-label" style={{ fontSize: 9 }}>CLEAR</span>
+          </button>
+        )}
+
+        <div className="t-mono" style={{ fontSize: 11, color: "var(--ink-1)" }}>
+          {time} <span style={{ color: "var(--ink-4)" }}>JST</span>
+        </div>
+      </div>
+    </div>
+  );
 };
 
-const ChatTopBar = ({ sidebarOpen, setSidebarOpen, uiMode, sessionId, handleClearHistory }) => (
-  <div className="flex items-center gap-3 px-4 h-14 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex-shrink-0 transition-colors duration-200">
-    <button
-      onClick={() => setSidebarOpen(!sidebarOpen)}
-      className="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex-shrink-0"
-    >
-      <Menu className="w-5 h-5" />
-    </button>
-
-    <div className="flex-1 min-w-0">
-      <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
-        {MODE_LABELS[uiMode] ?? ''}
-      </p>
-    </div>
-
-    {uiMode === 'chat' && sessionId && (
-      <button
-        onClick={handleClearHistory}
-        className="p-1.5 text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 transition-colors rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 flex-shrink-0"
-        title="会話履歴をクリア"
-      >
-        <Trash2 className="w-4 h-4" />
-      </button>
-    )}
-  </div>
-);
-
-export default ChatTopBar;
+export default Topbar;

--- a/frontend/src/components/layout/Icon.jsx
+++ b/frontend/src/components/layout/Icon.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+const Icon = ({ name, size = 16, className = "", style = {} }) => {
+  const common = {
+    width: size, height: size, viewBox: "0 0 24 24",
+    fill: "none", stroke: "currentColor", strokeWidth: 1.5,
+    strokeLinecap: "round", strokeLinejoin: "round",
+    className, style,
+  };
+  const paths = {
+    chat:      <><path d="M4 5h16v11H9l-5 4V5Z"/></>,
+    bolt:      <><path d="M13 3 4 14h7l-1 7 9-11h-7l1-7Z"/></>,
+    chart:     <><path d="M3 20V9M9 20V4M15 20v-8M21 20v-5"/></>,
+    user:      <><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></>,
+    users:     <><circle cx="9" cy="8" r="3.5"/><circle cx="17" cy="9" r="2.5"/><path d="M3 20a6 6 0 0 1 12 0M15 20a5 5 0 0 1 8-4"/></>,
+    radio:     <><circle cx="12" cy="12" r="2"/><path d="M7.5 7.5a6 6 0 0 0 0 9M16.5 16.5a6 6 0 0 0 0-9M4.5 4.5a10 10 0 0 0 0 15M19.5 19.5a10 10 0 0 0 0-15"/></>,
+    grid:      <><rect x="3" y="3" width="8" height="8"/><rect x="13" y="3" width="8" height="8"/><rect x="3" y="13" width="8" height="8"/><rect x="13" y="13" width="8" height="8"/></>,
+    trophy:    <><path d="M7 4h10v4a5 5 0 0 1-10 0V4Z"/><path d="M5 5H2v2a3 3 0 0 0 3 3M19 5h3v2a3 3 0 0 1-3 3M10 16h4M9 20h6M12 16v4"/></>,
+    medal:     <><circle cx="12" cy="15" r="5"/><path d="M8 3h8l-2 7-2 1-2-1-2-7Z"/></>,
+    target:    <><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></>,
+    board:     <><rect x="3" y="4" width="18" height="16" rx="0"/><path d="M3 9h18M9 4v16"/></>,
+    send:      <><path d="m4 4 16 8-16 8 4-8-4-8Z"/></>,
+    trash:     <><path d="M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13"/></>,
+    logout:    <><path d="M15 4h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-3M10 16l-4-4 4-4M6 12h12"/></>,
+    thumbUp:   <><path d="M8 10V20H4V10M8 10l4-7a2 2 0 0 1 2 2v4h6a1 1 0 0 1 1 1l-2 9a2 2 0 0 1-2 2H8"/></>,
+    thumbDown: <><path d="M16 14V4h4v10M16 14l-4 7a2 2 0 0 1-2-2v-4H4a1 1 0 0 1-1-1l2-9a2 2 0 0 1 2-2h9"/></>,
+    menu:      <><path d="M3 6h18M3 12h18M3 18h18"/></>,
+    search:    <><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></>,
+    mic:       <><rect x="9" y="3" width="6" height="12" rx="3"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3"/></>,
+    alert:     <><path d="M12 4 2 20h20L12 4Z"/><path d="M12 10v4M12 17v.5"/></>,
+    check:     <><path d="m4 12 5 5 11-11"/></>,
+    chevL:     <><path d="m14 6-6 6 6 6"/></>,
+    chevR:     <><path d="m10 6 6 6-6 6"/></>,
+    chevD:     <><path d="m6 9 6 6 6-6"/></>,
+    close:     <><path d="M5 5l14 14M19 5 5 19"/></>,
+    clock:     <><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></>,
+    fire:      <><path d="M12 3c1 4 5 5 5 10a5 5 0 0 1-10 0c0-2 1-3 2-4-1 3 1 4 2 4 1-3-3-6 1-10Z"/></>,
+    sparkle:   <><path d="M12 3v6M12 15v6M3 12h6M15 12h6M6 6l4 4M14 14l4 4M18 6l-4 4M10 14l-4 4"/></>,
+    settings:  <><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 0 0-.2-1.6l2-1.5-2-3.4-2.3 1a7 7 0 0 0-2.7-1.6L13.5 2h-3L10 4.9A7 7 0 0 0 7.3 6.5l-2.3-1-2 3.4 2 1.5A7 7 0 0 0 5 12c0 .6.1 1.1.2 1.6l-2 1.5 2 3.4 2.3-1a7 7 0 0 0 2.7 1.6l.5 2.9h3l.5-2.9a7 7 0 0 0 2.7-1.6l2.3 1 2-3.4-2-1.5c.1-.5.2-1 .2-1.6Z"/></>,
+    plus:      <><path d="M12 5v14M5 12h14"/></>,
+    refresh:   <><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.5 9a9 9 0 0 0-17 3M3.5 15a9 9 0 0 0 17-3"/></>,
+  };
+  return <svg {...common}>{paths[name] || null}</svg>;
+};
+
+export const DLMark = ({ size = 22 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <rect x="2" y="2" width="20" height="20" stroke="var(--amber)" strokeWidth="1.25" transform="rotate(45 12 12)"/>
+    <text x="12" y="14.5" textAnchor="middle" fontFamily="Oswald, sans-serif" fontWeight="700" fontSize="8.5" fill="var(--amber)" letterSpacing="-0.5">DL</text>
+  </svg>
+);
+
+export default Icon;

--- a/frontend/src/components/layout/LoginScreen.jsx
+++ b/frontend/src/components/layout/LoginScreen.jsx
@@ -1,46 +1,86 @@
-import { Activity } from 'lucide-react';
+import { DLMark } from './Icon.jsx';
 
 const LoginScreen = ({ authError, isCheckingAuth, handleGoogleLogin }) => (
-  <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-black transition-colors duration-200">
-    <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-lg w-full max-w-md transition-colors duration-200">
-      <div className="text-center mb-6">
-        <div className="mx-auto w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mb-4">
-          <Activity className="w-8 h-8 text-white" />
+  <div style={{
+    position: "fixed", inset: 0,
+    display: "flex", alignItems: "center", justifyContent: "center",
+    background: "var(--bg-0)",
+  }}>
+    {/* 背景グリッド装飾 */}
+    <div style={{
+      position: "absolute", inset: 0, pointerEvents: "none",
+      backgroundImage: "linear-gradient(var(--rule-dim) 1px, transparent 1px), linear-gradient(90deg, var(--rule-dim) 1px, transparent 1px)",
+      backgroundSize: "48px 48px",
+      opacity: 0.5,
+    }} />
+
+    <div style={{
+      position: "relative",
+      background: "var(--bg-1)", border: "1px solid var(--rule)",
+      padding: "40px 48px", width: "100%", maxWidth: 380,
+    }}>
+      {/* ロゴ＋タイトル */}
+      <div style={{ textAlign: "center", marginBottom: 32 }}>
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
+          <DLMark size={48} />
         </div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Diamond Lens</h1>
-        <p className="text-gray-600 dark:text-gray-300">MLB Stats Assistant</p>
+        <h1 className="h-display" style={{ fontSize: 22, marginBottom: 6 }}>Diamond Lens</h1>
+        <p className="t-mono" style={{ fontSize: 11, color: "var(--ink-4)", letterSpacing: "0.1em" }}>
+          MLB STATS ASSISTANT
+        </p>
       </div>
 
-      <div className="space-y-4">
-        {authError && (
-          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-            <p className="text-sm text-red-600 dark:text-red-400">{authError}</p>
-          </div>
+      {/* エラー */}
+      {authError && (
+        <div style={{
+          marginBottom: 16, padding: "8px 12px",
+          background: "oklch(0.26 0.10 28 / 0.12)",
+          border: "1px solid var(--neg-dim)",
+        }}>
+          <p className="t-mono" style={{ fontSize: 11, color: "var(--neg)" }}>{authError}</p>
+        </div>
+      )}
+
+      {/* Google ログインボタン */}
+      <button
+        onClick={handleGoogleLogin}
+        disabled={isCheckingAuth}
+        style={{
+          width: "100%", padding: "10px 16px",
+          background: "var(--bg-2)", border: "1px solid var(--rule)",
+          color: "var(--ink-1)", cursor: isCheckingAuth ? "not-allowed" : "pointer",
+          opacity: isCheckingAuth ? 0.5 : 1,
+          display: "flex", alignItems: "center", justifyContent: "center", gap: 10,
+          fontFamily: "var(--ff-mono)", fontSize: 12, fontWeight: 600, letterSpacing: "0.05em",
+          transition: "all .12s",
+        }}
+        onMouseEnter={e => { if (!isCheckingAuth) e.currentTarget.style.background = "var(--bg-3)"; }}
+        onMouseLeave={e => { e.currentTarget.style.background = "var(--bg-2)"; }}
+      >
+        {isCheckingAuth ? (
+          <>
+            <span className="think-dot" />
+            <span className="think-dot" style={{ animationDelay: ".2s" }} />
+            <span className="think-dot" style={{ animationDelay: ".4s" }} />
+            <span style={{ marginLeft: 6 }}>ログイン中...</span>
+          </>
+        ) : (
+          <>
+            <svg width="18" height="18" viewBox="0 0 24 24">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+            </svg>
+            Google でログイン
+          </>
         )}
+      </button>
 
-        <button
-          onClick={handleGoogleLogin}
-          disabled={isCheckingAuth}
-          className="w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed font-medium flex items-center justify-center gap-3 transition-colors duration-200"
-        >
-          {isCheckingAuth ? (
-            <>
-              <div className="w-5 h-5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
-              ログイン中...
-            </>
-          ) : (
-            <>
-              <svg className="w-5 h-5" viewBox="0 0 24 24">
-                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-              </svg>
-              Google でログイン
-            </>
-          )}
-        </button>
-      </div>
+      {/* フッター */}
+      <p className="t-mono" style={{ textAlign: "center", fontSize: 10, color: "var(--ink-4)", marginTop: 24 }}>
+        © 2025 Diamond Lens · Powered by Statcast
+      </p>
     </div>
   </div>
 );

--- a/frontend/src/components/layout/Ticker.jsx
+++ b/frontend/src/components/layout/Ticker.jsx
@@ -1,0 +1,124 @@
+import { useState, useEffect, useRef } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+
+const POLL_INTERVAL_MS = 60000;
+
+const getBackendUrl = () => {
+  if (window.location.hostname.includes('run.app')) {
+    return 'https://mlb-diamond-lens-api-907924272679.asia-northeast1.run.app';
+  }
+  if (window.location.href.includes('app.github.dev')) {
+    return window.location.href.replace('-5173.app.github.dev', '-8000.app.github.dev').split('?')[0];
+  }
+  return 'http://localhost:8000';
+};
+
+const BACKEND_URL = getBackendUrl();
+
+const gameToChip = (game, isLive) => ({
+  type: "score",
+  away:   game.away_team,
+  home:   game.home_team,
+  aScore: game.away_score ?? 0,
+  hScore: game.home_score ?? 0,
+  status: isLive
+    ? `${game.inning_half === 'Top' ? 'TOP' : 'BOT'} ${game.inning}`
+    : (game.innings ? `F/${game.innings}` : 'F'),
+});
+
+const TickerChip = ({ item }) => {
+  if (item.type === "score") {
+    const homeWin = item.hScore > item.aScore;
+    const awayWin = item.aScore > item.hScore;
+    return (
+      <span className="t-mono" style={{
+        display: "inline-flex", alignItems: "center", gap: 8, padding: "0 14px",
+        borderRight: "1px solid var(--rule-dim)", fontSize: 11, letterSpacing: "0.04em",
+      }}>
+        <span style={{ color: awayWin ? "var(--amber)" : "var(--ink-2)", fontWeight: 600 }}>{item.away}</span>
+        <span style={{ color: awayWin ? "var(--amber)" : "var(--ink-1)" }}>{item.aScore}</span>
+        <span style={{ color: "var(--ink-4)" }}>–</span>
+        <span style={{ color: homeWin ? "var(--amber)" : "var(--ink-1)" }}>{item.hScore}</span>
+        <span style={{ color: homeWin ? "var(--amber)" : "var(--ink-2)", fontWeight: 600 }}>{item.home}</span>
+        <span style={{
+          fontSize: 9, marginLeft: 4, letterSpacing: "0.1em",
+          color: item.status.startsWith("F") ? "var(--ink-4)" : "var(--pos)",
+        }}>{item.status}</span>
+      </span>
+    );
+  }
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 8, padding: "0 14px",
+      borderRight: "1px solid var(--rule-dim)", fontSize: 11,
+    }}>
+      <span className="h-label" style={{ fontSize: 9, color: "var(--ink-3)" }}>{item.label}</span>
+      <span className="t-mono" style={{ color: "var(--ink-0)", fontWeight: 600 }}>{item.value}</span>
+      <span className="t-mono" style={{
+        fontSize: 10,
+        color: item.delta.startsWith("+") ? "var(--pos)"
+             : item.delta.startsWith("-") ? "var(--neg)"
+             : "var(--amber)",
+      }}>{item.delta}</span>
+    </span>
+  );
+};
+
+const Ticker = () => {
+  const { getIdToken } = useAuth();
+  const getIdTokenRef = useRef(getIdToken);
+  const [chips, setChips] = useState([]);
+
+  useEffect(() => {
+    const fetchScores = async () => {
+      try {
+        const idToken = await getIdTokenRef.current();
+        const headers = {
+          Accept: 'application/json',
+          ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+        };
+        const res = await fetch(`${BACKEND_URL}/api/v1/live/games/today`, { headers });
+        if (!res.ok) return;
+        const data = await res.json();
+        const liveChips  = (data.live  ?? []).map(g => gameToChip(g, true));
+        const finalChips = (data.final ?? []).map(g => gameToChip(g, false));
+        const all = [...liveChips, ...finalChips];
+        if (all.length > 0) setChips(all);
+      } catch {
+        // ネットワークエラー時は現在の表示を維持
+      }
+    };
+
+    fetchScores();
+    const timer = setInterval(fetchScores, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const items = chips.length > 0 ? [...chips, ...chips] : [];
+
+  return (
+    <div className="rule-b" style={{
+      height: 28, background: "var(--bg-0)", overflow: "hidden", position: "relative", flexShrink: 0,
+    }}>
+      {/* LIVE label overlay */}
+      <div style={{
+        position: "absolute", left: 0, top: 0, height: "100%",
+        display: "flex", alignItems: "center", gap: 0, padding: "0 12px",
+        zIndex: 2, background: "linear-gradient(90deg, var(--bg-0) 60%, transparent)",
+      }}>
+        <span className="live-dot" style={{ marginRight: 6 }}/>
+        <span className="h-label" style={{ fontSize: 9, color: "var(--pos)" }}>LIVE</span>
+      </div>
+
+      {/* Scrolling content */}
+      <div className="ticker-track" style={{
+        display: "inline-flex", whiteSpace: "nowrap", height: "100%",
+        alignItems: "center", paddingLeft: 90,
+      }}>
+        {items.map((item, i) => <TickerChip key={i} item={item}/>)}
+      </div>
+    </div>
+  );
+};
+
+export default Ticker;

--- a/frontend/src/constants/navItems.js
+++ b/frontend/src/constants/navItems.js
@@ -1,0 +1,14 @@
+export const NAV_ITEMS = [
+  { id: "chat",      icon: "chat",   code: "CHT", jp: "チャット",        en: "CHAT"       },
+  { id: "quick",     icon: "bolt",   code: "QCK", jp: "クイック質問",    en: "QUICK"      },
+  { id: "stats",     icon: "chart",  code: "STA", jp: "統計分析",        en: "STATS"      },
+  { id: "segment",   icon: "users",  code: "SEG", jp: "選手分類",        en: "SEG"        },
+  { id: "stuff",     icon: "target", code: "STF", jp: "球質評価",        en: "STUFF+"     },
+  { id: "advanced",  icon: "grid",   code: "ADV", jp: "Advanced Stats", en: "ADV.STATS"  },
+  { id: "hot",       icon: "fire",   code: "HOT", jp: "Hot / Slump",    en: "HOT/SLUMP"  },
+  { id: "leader",    icon: "trophy", code: "LDR", jp: "リーダーボード",  en: "LEADER"     },
+  { id: "live",      icon: "radio",  code: "LIV", jp: "試合速報",        en: "LIVE"       },
+  { id: "monitor",   icon: "board",  code: "MON", jp: "モニターボード",  en: "MONITOR"    },
+  { id: "standings", icon: "medal",  code: "STD", jp: "順位表",          en: "STAND"      },
+  { id: "profile",   icon: "user",   code: "PRF", jp: "選手プロフィール", en: "PLAYER"    },
+];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,84 +1,218 @@
 @import "tailwindcss";
 
-.scrollbar-none {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.scrollbar-none::-webkit-scrollbar {
-  display: none;
-}
+/* ============================================================
+   Diamond Lens — Design Tokens
+   Direction: Bloomberg Terminal × ESPN Statcast
+   dark mono + amber/gold accent
+   ============================================================ */
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  /* Base — warm near-black tones (chroma kept low; hue 60 for warm) */
+  --bg-0: oklch(0.14 0.005 60);      /* deepest */
+  --bg-1: oklch(0.17 0.006 60);      /* panels */
+  --bg-2: oklch(0.21 0.007 60);      /* raised */
+  --bg-3: oklch(0.26 0.008 60);      /* hover */
+  --bg-4: oklch(0.32 0.010 60);      /* borders-strong */
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* Rule / hairline borders */
+  --rule:      oklch(0.28 0.008 60);
+  --rule-dim:  oklch(0.22 0.006 60);
+  --rule-hi:   oklch(0.40 0.010 60);
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  /* Type */
+  --ink-0: oklch(0.97 0.008 85);     /* primary text, warm white */
+  --ink-1: oklch(0.86 0.010 80);     /* secondary */
+  --ink-2: oklch(0.68 0.012 80);     /* tertiary / labels */
+  --ink-3: oklch(0.52 0.010 75);     /* muted */
+  --ink-4: oklch(0.40 0.010 70);     /* faint */
+
+  /* Accent — amber/gold */
+  --amber:      oklch(0.80 0.165 80);
+  --amber-hi:   oklch(0.88 0.165 85);
+  --amber-dim:  oklch(0.55 0.120 78);
+  --amber-glow: oklch(0.80 0.165 80 / 0.18);
+
+  /* Status */
+  --pos:     oklch(0.78 0.165 148);   /* live / positive / +change */
+  --pos-dim: oklch(0.50 0.120 148);
+  --neg:     oklch(0.70 0.180 28);    /* negative / alert */
+  --neg-dim: oklch(0.48 0.130 28);
+  --info:    oklch(0.75 0.120 240);
+  --purp:    oklch(0.72 0.150 310);   /* agent mode */
+
+  /* Typography */
+  --ff-head: "Oswald", "Noto Sans JP", sans-serif;
+  --ff-text: "Inter", "Noto Sans JP", system-ui, sans-serif;
+  --ff-mono: "JetBrains Mono", "SF Mono", Menlo, monospace;
+
+  /* Spacing */
+  --sp-0: 2px;
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
+* { box-sizing: border-box; }
 
-body {
+html, body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-  width: 100%;
+  padding: 0;
+  height: 100%;
+  background: var(--bg-0);
+  color: var(--ink-1);
+  font-family: var(--ff-text);
+  font-size: 14px;
+  line-height: 1.45;
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
 }
 
 #root {
+  height: 100%;
   width: 100%;
-  min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+/* ============================================================
+   Typographic conventions
+   ============================================================ */
+.h-display {
+  font-family: var(--ff-head);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--ink-0);
+  line-height: 1;
+}
+.h-label {
+  font-family: var(--ff-text);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 10px;
+  color: var(--ink-2);
+}
+.t-mono   { font-family: var(--ff-mono); font-variant-numeric: tabular-nums; }
+.t-digit  { font-family: var(--ff-mono); font-variant-numeric: tabular-nums; font-weight: 600; }
+.t-body   { font-family: var(--ff-text); }
+
+/* ============================================================
+   Border utilities
+   ============================================================ */
+.rule      { border-color: var(--rule); }
+.rule-b    { border-bottom: 1px solid var(--rule); }
+.rule-t    { border-top:    1px solid var(--rule); }
+.rule-r    { border-right:  1px solid var(--rule); }
+.rule-l    { border-left:   1px solid var(--rule); }
+
+/* ============================================================
+   Scrollbar
+   ============================================================ */
+::-webkit-scrollbar       { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--bg-3); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--bg-4); }
+
+.scrollbar-none { scrollbar-width: none; -ms-overflow-style: none; }
+.scrollbar-none::-webkit-scrollbar { display: none; }
+
+/* ============================================================
+   Animations
+   ============================================================ */
+
+/* Live dot pulse */
+@keyframes pulseDot {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.35; }
+}
+.live-dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  background: var(--pos);
+  box-shadow: 0 0 0 0 var(--pos);
+  animation: pulseDot 1.6s ease-in-out infinite;
+}
+.live-dot.amber { background: var(--amber); }
+.live-dot.red   { background: var(--neg); }
+
+/* Thinking dots */
+@keyframes thinkDot {
+  0%, 80%, 100% { opacity: 0.2; }
+  40%           { opacity: 1; }
+}
+.think-dot {
+  display: inline-block;
+  width: 4px; height: 4px;
+  background: var(--amber);
+  margin: 0 1px;
+  animation: thinkDot 1.2s ease-in-out infinite;
 }
 
+/* Ticker marquee */
+@keyframes tick-marq {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+.ticker-track { animation: tick-marq 90s linear infinite; }
+
+/* Spin (refresh / loading icons) */
+@keyframes dl-spin {
+  to { transform: rotate(360deg); }
+}
+.dl-spin { animation: dl-spin 0.8s linear infinite; display: inline-block; }
+
+/* ============================================================
+   UI Primitives
+   ============================================================ */
+
+/* Diamond mark */
+.dl-diamond {
+  width: 10px; height: 10px;
+  background: var(--amber);
+  transform: rotate(45deg);
+  display: inline-block;
+}
+
+/* Selection */
+::selection { background: var(--amber-glow); color: var(--ink-0); }
+
+/* Focus */
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 1px solid var(--amber);
+  outline-offset: -1px;
+}
+
+/* Reset interactive elements */
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
+  background: transparent;
+  border: 0;
+  color: inherit;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
-  transition: border-color 0.25s;
+  padding: 0;
 }
-button:hover {
-  border-color: #646cff;
+input, textarea {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-family: inherit;
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
+input:focus, textarea:focus { outline: none; }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
+/* ============================================================
+   Table / row utilities
+   ============================================================ */
+.row-stripe > div:nth-child(even) { background: oklch(from var(--bg-1) l c h / 0.6); }
+
+/* Spark bar */
+.spark-pos { background: var(--pos); }
+.spark-neg { background: var(--neg); }
+.spark-dim { background: var(--bg-3); }
+
+/* Monospaced digit tabular */
+.tabnum { font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
## Summary
- Rewrite `LoginScreen.jsx` — replace lucide Activity icon with DLMark, apply dark terminal theme
- Rewrite `Standings.jsx`, `LiveScoreboard.jsx`, `LiveMonitorBoard.jsx` — remove lucide-react, apply CSS custom property theme
- Rewrite `HotSlumpDashboard.jsx`, `Leaderboard.jsx`, `LeaderboardTable.jsx`, `StuffPlus.jsx` — remove lucide-react, apply CSS custom property theme
- Update `Icon.jsx` — add `refresh` icon path
- Update `index.css` — add `@keyframes dl-spin` and `.dl-spin` utility class

## Background
The frontend previously used a blue-accent Tailwind dark theme with lucide-react icons scattered across components. This PR migrates the UI to a Bloomberg Terminal × ESPN Statcast aesthetic: dark amber/gold accent, monospace typography, sharp edges (no border-radius), and oklch-based CSS custom properties. All lucide-react dependencies are removed from the affected components and replaced with the shared `Icon` component. Recharts SVG attributes use hardcoded oklch constants (`C_AMBER`, `C_POS`, `C_NEG`, etc.) since CSS variables are not resolved inside SVG presentation attributes. All data-fetching and API logic is unchanged.

## Key Design Decisions
- **CSS Custom Properties over Tailwind**: All colors reference `var(--amber)`, `var(--bg-*)`, `var(--ink-*)`, `var(--rule)` etc., enabling single-point theme control via `index.css`
- **Hardcoded oklch for Recharts**: CSS vars do not work in SVG `stroke`/`fill` props, so chart colors are defined as `const C_* = 'oklch(...)'` at the top of each file
- **`think-dot` for loading states**: Replaces `animate-spin` + lucide icon combos with the existing CSS animation class for consistency
- **`DLMark` on login screen**: Replaces the generic blue circle + Activity icon with the project's own diamond logo mark

## Test Plan
- [ ] Verify login screen renders correctly with DLMark logo and grid background
- [ ] Verify Standings loads and tab/refresh buttons use amber active state
- [ ] Verify LiveScoreboard date tabs, base diamond, and pitch sequence colors render correctly
- [ ] Verify LiveMonitorBoard alert cards render with correct accent colors (warning/caution/purple/hot/neutral)
- [ ] Verify HotSlumpDashboard Hot/Slump badges use HOT_BADGE / SLUMP_BADGE styles
- [ ] Verify LeaderboardTable sort icons and rank badges (①②③) render correctly
- [ ] Verify StuffPlus all four views (Rankings, Detail, Compare, Trend) render with recharts C_* colors
- [ ] Confirm no lucide-react imports remain in any modified file
