### PR TITLE
feat: introduce Snowflake-style cross-cutting trace_id

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -120,7 +120,7 @@ app.add_middleware(
     allow_credentials=True,  # <-- これが True であることを確認
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"], # DO NOT add " *" to allow_methods
     allow_headers=["Content-Type", "Authorization"],  # DO NOT add " *" to allow_headers
-    expose_headers=['X-Request-ID'] # Frontend can read this header
+    expose_headers=['X-Request-ID', 'X-Trace-Id'] # Frontend can read these headers
 )
 
 # 重要: add_middleware は「後に登録したものが先に実行される」ので、

--- a/backend/app/middleware/request_context.py
+++ b/backend/app/middleware/request_context.py
@@ -2,6 +2,9 @@ from contextvars import ContextVar
 
 _request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 _user_id_var: ContextVar[str] = ContextVar("user_id", default="")
+# Snowflake-style 横断的 trace id。Phase 2 では request_id と並走させ、
+# Phase 3 以降で BQ ログ・SSE event payload にも流す。
+_trace_id_var: ContextVar[str] = ContextVar("trace_id", default="")
 
 
 def get_request_id() -> str:
@@ -17,3 +20,11 @@ def get_user_id() -> str:
 
 def set_user_id(user_id: str) -> None:
     _user_id_var.set(user_id)
+
+
+def get_trace_id() -> str:
+    return _trace_id_var.get()
+
+
+def set_trace_id(trace_id: str) -> None:
+    _trace_id_var.set(trace_id)

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -1,13 +1,22 @@
 import uuid
-from backend.app.middleware.request_context import set_request_id, get_request_id
+from backend.app.middleware.request_context import (
+    get_request_id,  # noqa: F401  re-exported for backward compat
+    set_request_id,
+    set_trace_id,
+)
+from backend.app.utils.snowflake import generate_id_str
 
 
 class RequestIDMiddleware:
-    """Pure ASGI middleware for request ID tracking.
+    """Pure ASGI middleware for request ID & trace ID tracking.
 
     BaseHTTPMiddleware だと call_next が別コンテキストで実行され、
     ContextVar の値がエンドポイント側に伝わらないため、
     純粋な ASGI ミドルウェアとして実装しています。
+
+    本ミドルウェアは 2 種類の識別子を扱います:
+      - X-Request-ID: 既存（uuid4）。dual-write 期間中は維持
+      - X-Trace-Id : 新規（Snowflake）。クライアント・SSE・BQ ログ横断
     """
 
     def __init__(self, app):
@@ -18,21 +27,29 @@ class RequestIDMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # リクエストヘッダーから X-Request-ID を取得、なければ新規生成
         headers = dict(scope.get("headers", []))
+
+        # X-Request-ID: 既存どおり uuid4 を維持（旧ログ互換のため）
         request_id = (
             headers.get(b"x-request-id", b"").decode() or str(uuid.uuid4())
         )
 
+        # X-Trace-Id: ヘッダ優先、なければ Snowflake を新規発行
+        trace_id = (
+            headers.get(b"x-trace-id", b"").decode() or generate_id_str()
+        )
+
         # ContextVar にセット → 同一リクエスト内のどこからでも取得可能
         set_request_id(request_id)
+        set_trace_id(trace_id)
 
-        # レスポンスヘッダーに X-Request-ID を付与
-        async def send_with_request_id(message):
+        # レスポンスヘッダに両方付与
+        async def send_with_ids(message):
             if message["type"] == "http.response.start":
-                headers = list(message.get("headers", []))
-                headers.append((b"x-request-id", request_id.encode()))
-                message["headers"] = headers
+                response_headers = list(message.get("headers", []))
+                response_headers.append((b"x-request-id", request_id.encode()))
+                response_headers.append((b"x-trace-id", trace_id.encode()))
+                message["headers"] = response_headers
             await send(message)
 
-        await self.app(scope, receive, send_with_request_id)
+        await self.app(scope, receive, send_with_ids)

--- a/backend/app/services/llm_logger_service.py
+++ b/backend/app/services/llm_logger_service.py
@@ -13,6 +13,8 @@ from google.cloud import bigquery
 import json
 import logging
 
+from backend.app.middleware.request_context import get_trace_id
+
 logger = logging.getLogger(__name__)
 
 # BigQuery 設定
@@ -29,6 +31,8 @@ class LLMLogEntry:
         self.user_id: str = ""
         self.timestamp = datetime.now(timezone.utc).isoformat()
         self.request_id: Optional[str] = None
+        # Snowflake-style 横断的 trace id（ContextVar から自動取得、明示セットで上書き可）
+        self.trace_id: Optional[str] = get_trace_id() or None
         self.session_id: Optional[str] = None
         self.user_query: str = ""
         self.resolved_query: Optional[str] = None
@@ -84,6 +88,7 @@ class LLMLogEntry:
             "timestamp": self.timestamp,
             "user_id": self.user_id,
             "request_id": self.request_id,
+            "trace_id": self.trace_id,
             "session_id": self.session_id,
             "user_query": self.user_query,
             "resolved_query": self.resolved_query,
@@ -176,6 +181,9 @@ class LLMLoggerService:
                 "log_id": str(uuid.uuid4()),
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "request_id": request_id,
+                # 元 request の trace_id が分からない場合は呼び出し元から渡す設計だが、
+                # 既存 API 互換のため当面は ContextVar から best-effort で取得
+                "trace_id": get_trace_id() or None,
                 "session_id": session_id,
                 "user_rating": user_rating,
                 "feedback_category": category,

--- a/backend/app/services/shadow_logger_service.py
+++ b/backend/app/services/shadow_logger_service.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from backend.app.config.settings import get_settings
+from backend.app.middleware.request_context import get_trace_id
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,8 @@ class ShadowComparisonEntry:
     def __init__(self):
         self.comparison_id: str = str(uuid.uuid4())
         self.request_id: str = ""
+        # Snowflake-style 横断的 trace id（ContextVar から自動取得、明示セットで上書き可）
+        self.trace_id: Optional[str] = get_trace_id() or None
         self.session_id: Optional[str] = None
         self.user_id: Optional[str] = None
         self.user_query: str = ""
@@ -80,6 +83,7 @@ class ShadowComparisonEntry:
         return {
             "comparison_id": self.comparison_id,
             "request_id": self.request_id,
+            "trace_id": self.trace_id,
             "session_id": self.session_id,
             "user_id": self.user_id,
             "user_query": self.user_query[:2000] if self.user_query else "",

--- a/backend/app/utils/snowflake.py
+++ b/backend/app/utils/snowflake.py
@@ -1,0 +1,163 @@
+"""
+Snowflake-style 64-bit Trace ID generator.
+
+Layout (MSB → LSB):
+  sign(1) | timestamp_ms(41) | region(4) | instance(6) | sequence(12)
+"""
+import os
+import time
+import hashlib
+import threading
+from typing import NamedTuple, Optional
+
+# ──────────────────────────────────────────────────────────────
+# 定数
+# ──────────────────────────────────────────────────────────────
+
+# カスタムエポック: 2026-01-01T00:00:00Z (UTC)
+# datetime(2026,1,1,tzinfo=timezone.utc).timestamp() * 1000
+CUSTOM_EPOCH_MS = 1767225600000
+
+# 各フィールドのビット幅
+TIMESTAMP_BITS = 41
+REGION_BITS = 4
+INSTANCE_BITS = 6
+SEQUENCE_BITS = 12
+
+# 各フィールドのシフト量（LSB からの位置）
+SEQUENCE_SHIFT = 0
+INSTANCE_SHIFT = SEQUENCE_BITS                                   # 12
+REGION_SHIFT = SEQUENCE_BITS + INSTANCE_BITS                     # 18
+TIMESTAMP_SHIFT = SEQUENCE_BITS + INSTANCE_BITS + REGION_BITS    # 22
+
+# 各フィールドのマスク（n bit ぶんすべて 1）
+SEQUENCE_MASK = (1 << SEQUENCE_BITS) - 1   # 0xFFF (4095)
+INSTANCE_MASK = (1 << INSTANCE_BITS) - 1   # 0x3F  (63)
+REGION_MASK = (1 << REGION_BITS) - 1       # 0xF   (15)
+TIMESTAMP_MASK = (1 << TIMESTAMP_BITS) - 1
+
+# GCP リージョンの番号マッピング（4bit に収まる範囲）
+REGION_MAP = {
+    "asia-northeast1": 1,
+    "us-central1": 2,
+    "europe-west1": 3,
+    "asia-southeast1": 4,
+}
+
+
+class DecodedSnowflake(NamedTuple):
+    """decode() の戻り値"""
+    timestamp_ms: int
+    region: int
+    instance: int
+    sequence: int
+
+
+# ──────────────────────────────────────────────────────────────
+# Generator
+# ──────────────────────────────────────────────────────────────
+
+class SnowflakeGenerator:
+    """スレッドセーフな Snowflake ID 発行器。"""
+
+    def __init__(self, region: int, instance: int):
+        if not 0 <= region <= REGION_MASK:
+            raise ValueError(f"region must be 0..{REGION_MASK}, got {region}")
+        if not 0 <= instance <= INSTANCE_MASK:
+            raise ValueError(f"instance must be 0..{INSTANCE_MASK}, got {instance}")
+        self.region = region
+        self.instance = instance
+        self._sequence = 0
+        self._last_timestamp = -1
+        self._lock = threading.Lock()
+
+    def generate(self) -> int:
+        with self._lock:
+            now = self._current_ms()
+
+            # クロック後退検知: NTP 補正等で時計が戻ったら、追いつくまで待機
+            if now < self._last_timestamp:
+                while now < self._last_timestamp:
+                    time.sleep(0.001)
+                    now = self._current_ms()
+
+            if now == self._last_timestamp:
+                # 同一 ms 内: シーケンスをインクリメント
+                self._sequence = (self._sequence + 1) & SEQUENCE_MASK
+                if self._sequence == 0:
+                    # 4096 個使い切ったので次の ms までスピンウェイト
+                    while now <= self._last_timestamp:
+                        now = self._current_ms()
+            else:
+                # 新しい ms: シーケンスを 0 にリセット
+                self._sequence = 0
+
+            self._last_timestamp = now
+            elapsed = now - CUSTOM_EPOCH_MS
+
+            return (
+                (elapsed << TIMESTAMP_SHIFT)
+                | (self.region << REGION_SHIFT)
+                | (self.instance << INSTANCE_SHIFT)
+                | self._sequence
+            )
+
+    @staticmethod
+    def _current_ms() -> int:
+        return int(time.time() * 1000)
+
+
+# ──────────────────────────────────────────────────────────────
+# decoder（デバッグ・運用用）
+# ──────────────────────────────────────────────────────────────
+
+def decode(snowflake_id: int) -> DecodedSnowflake:
+    """ID を 4 つのフィールドに分解する。BQ クエリでも同等のロジックを再現可能。"""
+    sequence = snowflake_id & SEQUENCE_MASK
+    instance = (snowflake_id >> INSTANCE_SHIFT) & INSTANCE_MASK
+    region = (snowflake_id >> REGION_SHIFT) & REGION_MASK
+    timestamp = ((snowflake_id >> TIMESTAMP_SHIFT) & TIMESTAMP_MASK) + CUSTOM_EPOCH_MS
+    return DecodedSnowflake(timestamp, region, instance, sequence)
+
+
+# ──────────────────────────────────────────────────────────────
+# プロセス全体で共有するシングルトン
+# ──────────────────────────────────────────────────────────────
+
+_generator: Optional[SnowflakeGenerator] = None
+_generator_lock = threading.Lock()
+
+
+def _resolve_region() -> int:
+    """環境変数 GCP_REGION から region 番号を解決。未マップは 0。"""
+    name = os.getenv("GCP_REGION", "asia-northeast1")
+    return REGION_MAP.get(name, 0)
+
+
+def _resolve_instance() -> int:
+    """Cloud Run の K_REVISION（or hostname）の SHA-256 下位 6bit。"""
+    revision = os.getenv("K_REVISION") or os.getenv("HOSTNAME") or "local"
+    digest = hashlib.sha256(revision.encode()).digest()
+    return digest[-1] & INSTANCE_MASK
+
+
+def get_generator() -> SnowflakeGenerator:
+    global _generator
+    if _generator is None:
+        with _generator_lock:
+            if _generator is None:
+                _generator = SnowflakeGenerator(
+                    region=_resolve_region(),
+                    instance=_resolve_instance(),
+                )
+    return _generator
+
+
+def generate_id() -> int:
+    """64bit 整数の Snowflake ID を発行する。"""
+    return get_generator().generate()
+
+
+def generate_id_str() -> str:
+    """JS 53bit 精度問題を避けるため、外に出すときの文字列形式。"""
+    return str(generate_id())

--- a/backend/app/utils/streaming.py
+++ b/backend/app/utils/streaming.py
@@ -2,23 +2,36 @@
 SSE (Server-Sent Events) Streaming
 """
 import json
-from typing import AsyncGenerator, Dict, Any
+from typing import AsyncGenerator, Dict, Any, Optional
 import logging
+
+from backend.app.middleware.request_context import get_trace_id
 
 logger = logging.getLogger(__name__)
 
 
-def format_sse(data: Dict[str, Any], event: str = None) -> str:
+def format_sse(
+    data: Dict[str, Any],
+    event: Optional[str] = None,
+    trace_id: Optional[str] = None,
+) -> str:
     """
     Generate a SSE formatted message
 
     Args:
         data: 送信するデータ (辞書形式)
         event: イベント名 (オプション)
-    
+        trace_id: 明示的に上書きしたい場合に指定。None の場合は ContextVar から取得。
+                  payload に既に trace_id がある場合は変更しない。
+
     Returns:
         SSE形式の文字列
     """
+    # trace_id を payload に必ず埋め込む（フロントが SSE event ↔ BQ ログを突合できるように）
+    resolved_trace_id = trace_id if trace_id is not None else get_trace_id()
+    if resolved_trace_id and "trace_id" not in data:
+        data = {**data, "trace_id": resolved_trace_id}
+
     msg = ""
     if event:
         msg += f"event: {event}\n"
@@ -31,10 +44,10 @@ async def stream_json_events(
 ) -> AsyncGenerator[str, None]:
     """
     JSONイベントをSSE形式でストリーミングします
-    
+
     Args:
         generator: イベントを生成する非同期ジェネレーター
-    
+
     Yields:
         SSE形式の文字列
     """

--- a/backend/app/utils/structured_logger.py
+++ b/backend/app/utils/structured_logger.py
@@ -9,6 +9,7 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, Optional
 from backend.app.middleware.request_id import get_request_id
+from backend.app.middleware.request_context import get_trace_id
 
 
 class StructuredLogger:
@@ -42,6 +43,7 @@ class StructuredLogger:
                     "message": record.getMessage(),
                     "logger": record.name,
                     "request_id": get_request_id(),
+                    "trace_id": get_trace_id(),
                 }
 
                 # Add extra fields if present

--- a/backend/tests/utils/test_snowflake.py
+++ b/backend/tests/utils/test_snowflake.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for backend/app/utils/snowflake.py
+"""
+import threading
+import pytest
+
+from backend.app.utils.snowflake import (
+    SnowflakeGenerator,
+    decode,
+    CUSTOM_EPOCH_MS,
+    SEQUENCE_MASK,
+    INSTANCE_MASK,
+    REGION_MASK,
+)
+
+
+def test_generate_returns_positive_int_under_int64():
+    gen = SnowflakeGenerator(region=1, instance=7)
+    sf = gen.generate()
+    assert sf > 0
+    assert sf < (1 << 63)  # 符号付き int64 に収まる
+
+
+def test_generate_is_strictly_monotonic():
+    gen = SnowflakeGenerator(region=1, instance=7)
+    prev = gen.generate()
+    for _ in range(10_000):
+        curr = gen.generate()
+        assert curr > prev, f"not monotonic: {prev} -> {curr}"
+        prev = curr
+
+
+def test_no_collision_single_thread_100k():
+    gen = SnowflakeGenerator(region=1, instance=7)
+    ids = {gen.generate() for _ in range(100_000)}
+    assert len(ids) == 100_000
+
+
+def test_no_collision_8_threads_each_10k():
+    gen = SnowflakeGenerator(region=1, instance=7)
+    ids: set[int] = set()
+    lock = threading.Lock()
+
+    def worker():
+        local = [gen.generate() for _ in range(10_000)]
+        with lock:
+            ids.update(local)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(ids) == 8 * 10_000
+
+
+def test_decode_recovers_fields():
+    gen = SnowflakeGenerator(region=3, instance=42)
+    sf = gen.generate()
+    d = decode(sf)
+    assert d.region == 3
+    assert d.instance == 42
+    assert 0 <= d.sequence <= SEQUENCE_MASK
+    assert d.timestamp_ms >= CUSTOM_EPOCH_MS
+
+
+def test_region_out_of_range_raises():
+    with pytest.raises(ValueError):
+        SnowflakeGenerator(region=REGION_MASK + 1, instance=0)
+
+
+def test_instance_out_of_range_raises():
+    with pytest.raises(ValueError):
+        SnowflakeGenerator(region=0, instance=INSTANCE_MASK + 1)
+
+
+def test_sequence_overflow_advances_ms():
+    """同一 ms 内で 4096 個発行 → 次 ms に繰り越されることを確認。"""
+    gen = SnowflakeGenerator(region=1, instance=1)
+    ids = [gen.generate() for _ in range(SEQUENCE_MASK + 2)]
+    assert len(set(ids)) == len(ids)

--- a/backend/tests/utils/test_trace_id_propagation.py
+++ b/backend/tests/utils/test_trace_id_propagation.py
@@ -1,0 +1,92 @@
+"""
+Phase 3-4 propagation tests: trace_id flows from ContextVar into
+LLMLogEntry.to_dict(), ShadowComparisonEntry.to_dict(),
+StructuredLogger JSON, and format_sse() payloads.
+"""
+import json
+
+from backend.app.middleware.request_context import set_trace_id
+from backend.app.utils.snowflake import generate_id_str
+
+
+def test_llm_log_entry_picks_trace_id_from_contextvar():
+    from backend.app.services.llm_logger_service import LLMLogEntry
+
+    sf = generate_id_str()
+    set_trace_id(sf)
+
+    entry = LLMLogEntry()
+    d = entry.to_dict()
+
+    assert d.get("trace_id") == sf
+    assert isinstance(d["trace_id"], str)
+
+
+def test_llm_log_entry_explicit_override_wins():
+    from backend.app.services.llm_logger_service import LLMLogEntry
+
+    set_trace_id(generate_id_str())
+
+    entry = LLMLogEntry()
+    override = "111111111111111111"
+    entry.trace_id = override
+    d = entry.to_dict()
+
+    assert d["trace_id"] == override
+
+
+def test_shadow_entry_picks_trace_id_from_contextvar():
+    from backend.app.services.shadow_logger_service import ShadowComparisonEntry
+
+    sf = generate_id_str()
+    set_trace_id(sf)
+
+    entry = ShadowComparisonEntry()
+    d = entry.to_dict()
+
+    assert d.get("trace_id") == sf
+
+
+def test_format_sse_auto_attaches_trace_id():
+    from backend.app.utils.streaming import format_sse
+
+    sf = generate_id_str()
+    set_trace_id(sf)
+
+    raw = format_sse({"type": "token", "content": "hello"}, event="token")
+    # SSE 形式: "event: ...\ndata: {...}\n\n"
+    payload_line = [l for l in raw.split("\n") if l.startswith("data: ")][0]
+    payload = json.loads(payload_line[len("data: "):])
+
+    assert payload["trace_id"] == sf
+    assert payload["content"] == "hello"
+
+
+def test_format_sse_does_not_overwrite_existing_trace_id():
+    from backend.app.utils.streaming import format_sse
+
+    set_trace_id(generate_id_str())  # この値を上書きしないことを確認
+
+    raw = format_sse(
+        {"type": "token", "content": "hello", "trace_id": "preset-123"},
+        event="token",
+    )
+    payload_line = [l for l in raw.split("\n") if l.startswith("data: ")][0]
+    payload = json.loads(payload_line[len("data: "):])
+
+    assert payload["trace_id"] == "preset-123"
+
+
+def test_structured_logger_emits_trace_id(capsys):
+    from backend.app.utils.structured_logger import StructuredLogger
+
+    sf = generate_id_str()
+    set_trace_id(sf)
+
+    log = StructuredLogger("test-trace-id")
+    log.info("hello")
+
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    record = json.loads(out)
+    assert record["trace_id"] == sf
+    assert record["message"] == "hello"


### PR DESCRIPTION
Add 64-bit Snowflake ID generator (utils/snowflake.py) and propagate the resulting trace_id through middleware ContextVar, structured logs, SSE event payloads, and BigQuery log entries (LLMLogEntry, ShadowComparisonEntry).

Layout: sign(1) | timestamp_ms(41) | region(4) | instance(6) | sequence(12) The existing uuid4 request_id is kept in dual-write mode for backward compatibility; trace_id is exposed as the X-Trace-Id response header and JS-safe (string) on the wire.

- utils/snowflake.py: thread-safe generator + decode() + singleton
- middleware/request_context.py: _trace_id_var ContextVar
- middleware/request_id.py: emit X-Trace-Id, accept inbound header
- services/llm_logger_service.py: trace_id field on LLMLogEntry
- services/shadow_logger_service.py: trace_id field on ShadowComparisonEntry
- utils/streaming.py: format_sse() auto-attaches trace_id to payload
- utils/structured_logger.py: include trace_id in JSON log output
- main.py: expose X-Trace-Id via CORS expose_headers
- tests/utils/: 14 unit tests (collision/monotonic/decode/propagation)