### PR TITLE
feat: unified search autocomplete with in-memory Trie

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,62 @@ Synthesizer → user (sentence) or DataTable (table)
 
 ---
 
+### 23. Search Autocomplete System (Full Stack, Vol.1)
+**Status**: ✅ Production-ready (canary via `VITE_USE_AUTOCOMPLETE_API` flag)
+
+Replaces four scattered `LIKE '%q%'` BigQuery search endpoints with a single in-memory Trie + popularity-ranked autocomplete service. Loaded once at Cloud Run startup and held in process memory.
+
+**Why this exists**:
+- The legacy frontend hit four separate endpoints (`/players/search`, `/advanced-stats/{pitching|batting}/search`, `/stuff-plus/search`), each running a `LIKE '%q%'` query against BigQuery on every keystroke.
+- Substring matching produced noise (typing `oh` returned `Yamamoto`, `Bishop`, `Varsho`), and popularity ranking was absent so retired players ranked alongside active stars.
+- BigQuery costs and p95 latency were both keystroke-bound; with cache disabled (frontend `lru_cache(128)` did not benefit prefix reuse) every typed character round-tripped.
+
+**Capabilities**:
+- **🌳 In-memory Trie**: ~7,000 players (filtered to `mlb_debut_year >= 2000 OR mlb_last_year >= 2000`) inserted under both `full_name` and `last_name` keys for partial-name lookup.
+- **🏷️ Tag-based context filtering**: Each player carries `statcast_pitcher_seasons` / `statcast_batter_seasons` / `stuffplus_seasons` as `frozenset[int]`. A single Trie serves four contexts (`all` / `statcast_pitcher` / `statcast_batter` / `stuffplus`) by post-filtering on tags.
+- **📊 Popularity scoring**: Pre-computed `log(1 + PA + IP*3) + (active ? 1.0 : 0.0)` from recent 3 seasons (2024-2025 from `fact_*` layer, 2026+ from `mart_*` layer via UNION ALL). Scores are baked into entries at build time.
+- **⚡ LRU Prefix Cache**: 4,096-entry `OrderedDict` keyed by `(context, season, prefix)` with O(1) lookup.
+- **🔄 Background warmup with fallback**: FastAPI `lifespan` runs `build()` in `asyncio.to_thread` so cold-start traffic is never blocked. Until ready (or on build failure), the endpoint falls back to legacy `/players/search`.
+- **🚦 Frontend feature flag**: `VITE_USE_AUTOCOMPLETE_API=true` switches all four search call sites (`useBackendAPI.searchPlayers`, `AdvancedStats trends`, `StrategyReportPage PlayerSearchPicker`, Stuff+ pitcher search) to the unified endpoint.
+- **🆔 ID alias mapping**: New API returns `mlbid`; legacy callers expecting `pitcher_id` / `batter_id` get transparent aliasing in the hook layer to preserve existing component contracts.
+
+**Architecture**:
+```
+Cloud Run cold start
+    ↓
+lifespan → asyncio.to_thread(AutocompleteService.build)
+    ↓ single BigQuery query (LEFT JOIN dim_players_master + dim_teams
+    ↓                       + ARRAY_AGG over statcast_master / stuff_plus_rankings
+    ↓                       + UNION ALL fact_*/mart_* for PA/IP)
+Trie populated (~7,000 entries, ~3-5s, ~5-10 MB)
+    ↓
+app.state.autocomplete_ready = True
+
+Per request:
+GET /api/v1/players/autocomplete?q=oht&context=statcast_pitcher&season=2026
+    ↓
+PrefixCache.get((context, season, "oht"))  → hit returns "cache"
+    ↓ miss
+Trie.search_prefix("oht")  → DFS subtree, dedup by mlbid
+    ↓
+ContextFilter.apply(entries, context, season)  → tag-based filter
+    ↓
+sort by popularity_score DESC, slice [:limit]
+    ↓ "trie" served_from
+PrefixCache.put(...)
+```
+
+**Observability**:
+- **Build log** (`autocomplete_build_completed`): `entries_loaded`, `elapsed_query_ms`, `elapsed_total_ms`.
+- **Request log** (`autocomplete_request`): `prefix`, `context`, `season`, `served_from` (`cache` / `trie` / `fallback`), `latency_ms`, `result_count`.
+- All logs auto-tagged with Snowflake `trace_id` via `StructuredLogger`.
+
+**Technologies**: FastAPI (lifespan), BigQuery (`dim_players_master`, `statcast_master`, `stuff_plus_rankings`, `fact_batting_stats_with_risp`, `fact_pitching_stats_master`, `mart_batter_season_stats`, `mart_pitcher_season_stats`), Python (Trie, OrderedDict-LRU, dataclass), React (Vite env-flag), Cloud Logging.
+
+**Related design doc**: [docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md](docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md).
+
+---
+
 ### Technical Features
 - **AI-Powered Processing**: Uses Gemini 2.5 Flash for query parsing and response generation
 - **Real-time Interface**: Interactive experience with loading states and live updates

--- a/README_JP.md
+++ b/README_JP.md
@@ -551,6 +551,61 @@ Synthesizer → ユーザー（文章 or DataTable）
 
 ---
 
+### 23. 検索オートコンプリートシステム（フルスタック、Vol.1）
+**ステータス**: ✅ `VITE_USE_AUTOCOMPLETE_API` フラグによるカナリア展開で本番稼働
+
+4 系統に分散していた `LIKE '%q%'` BigQuery 検索エンドポイントを、起動時にメモリ常駐させた Trie + 人気度ランキング付きオートコンプリートサービスに統合しました。Cloud Run コンテナ起動時に 1 回だけロードしプロセスメモリに保持します。
+
+**この機能が必要な理由**:
+- 旧フロントエンドは 4 つの別エンドポイント (`/players/search`, `/advanced-stats/{pitching|batting}/search`, `/stuff-plus/search`) を打鍵ごとに叩き、いずれも BigQuery への `LIKE '%q%'` クエリを毎回実行していました
+- 部分一致のためノイズが多く（`oh` で `Yamamoto` `Bishop` `Varsho` が混入）、人気度ランキングが無いため引退選手が現役スターと並列で返却されていました
+- BigQuery コストと p95 レイテンシは打鍵数に比例。フロントの `lru_cache(128)` はプレフィックス再利用に効かず、毎打鍵で BigQuery まで往復していました
+
+**機能**:
+- **🌳 メモリ常駐 Trie**: `mlb_debut_year >= 2000 OR mlb_last_year >= 2000` で絞った約 7,000 選手を `full_name` と `last_name` の 2 通りで insert し、部分一致を高速化
+- **🏷️ タグベースのコンテキスト絞り込み**: 各 PlayerEntry に `statcast_pitcher_seasons` / `statcast_batter_seasons` / `stuffplus_seasons` を `frozenset[int]` で持たせ、Trie 1 本で 4 コンテキスト（`all` / `statcast_pitcher` / `statcast_batter` / `stuffplus`）を post-filter で振り分け
+- **📊 人気度スコア事前計算**: 直近 3 シーズン（2024〜2025 は `fact_*` 層、2026〜は `mart_*` 層を UNION ALL）から `log(1 + PA + IP*3) + (現役なら +1.0)` を計算し、Trie 構築時に各エントリに焼き込み
+- **⚡ LRU プレフィックスキャッシュ**: `(context, season, prefix)` をキーにする 4,096 件の `OrderedDict` で O(1) 参照
+- **🔄 バックグラウンド warmup + フォールバック**: FastAPI の `lifespan` で `asyncio.to_thread` 経由で `build()` を非同期実行し、コールドスタート時のリクエストを止めない。構築未完了 / 失敗時は旧 `/players/search` に自動退避
+- **🚦 フロントエンド feature flag**: `VITE_USE_AUTOCOMPLETE_API=true` で 4 つの検索呼出箇所（`useBackendAPI.searchPlayers`、`AdvancedStats trends`、`StrategyReportPage PlayerSearchPicker`、Stuff+ 投手検索）を統合エンドポイントへ一括切替
+- **🆔 ID エイリアスマッピング**: 新 API は `mlbid` を返すが、旧呼出側で `pitcher_id` / `batter_id` を期待しているコードへは hook 層で透過的にエイリアスし、既存コンポーネント契約を破壊しない
+
+**アーキテクチャ**:
+```
+Cloud Run コールドスタート
+    ↓
+lifespan → asyncio.to_thread(AutocompleteService.build)
+    ↓ BigQuery 1 本（dim_players_master + dim_teams + statcast_master / stuff_plus_rankings の ARRAY_AGG
+    ↓                + fact_*/mart_* の UNION ALL で PA/IP）
+Trie 構築完了（約 7,000 件、3〜5 秒、5〜10 MB）
+    ↓
+app.state.autocomplete_ready = True
+
+リクエスト時:
+GET /api/v1/players/autocomplete?q=oht&context=statcast_pitcher&season=2026
+    ↓
+PrefixCache.get((context, season, "oht"))  → ヒット時は "cache" を返却
+    ↓ ミス
+Trie.search_prefix("oht")  → サブツリーを DFS、mlbid 単位で dedup
+    ↓
+ContextFilter.apply(entries, context, season)  → タグで絞り込み
+    ↓
+popularity_score 降順ソート → 上位 N 件
+    ↓ "trie" served_from
+PrefixCache.put(...)
+```
+
+**観測性**:
+- **起動ログ** (`autocomplete_build_completed`): `entries_loaded`, `elapsed_query_ms`, `elapsed_total_ms`
+- **リクエストログ** (`autocomplete_request`): `prefix`, `context`, `season`, `served_from`（`cache` / `trie` / `fallback`）, `latency_ms`, `result_count`
+- 全ログに Snowflake `trace_id` を `StructuredLogger` 経由で自動付与
+
+**技術**: FastAPI（lifespan）、BigQuery（`dim_players_master`, `statcast_master`, `stuff_plus_rankings`, `fact_batting_stats_with_risp`, `fact_pitching_stats_master`, `mart_batter_season_stats`, `mart_pitcher_season_stats`）、Python（Trie、OrderedDict-LRU、dataclass）、React（Vite env-flag）、Cloud Logging
+
+**関連設計ドキュメント**: [docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md](docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md)
+
+---
+
 ### 技術機能
 - **AI搭載処理**: Gemini 2.5 Flashを使用したクエリ解析とレスポンス生成
 - **リアルタイムインターフェース**: ローディング状態とライブ更新付きのインタラクティブ体験

--- a/README_architecture.md
+++ b/README_architecture.md
@@ -826,6 +826,26 @@ python scripts/train_stuff_plus.py --season 2025 --min-pitches 100
 | **Output** | Per-pitch-type whiff rate prediction |
 | **Frontend** | `PitcherWhiffPredictor.jsx` — multi-filter panel + color-coded bar chart |
 
+### 8p. Search Autocomplete System (Vol.1)
+
+| Property | Value |
+|----------|-------|
+| **Status** | Production-ready (canary via `VITE_USE_AUTOCOMPLETE_API`) |
+| **Service** | `backend/app/services/sandbox/autocomplete_service.py` |
+| **Endpoint** | `GET /api/v1/players/autocomplete?q=&context=&season=&limit=` |
+| **Replaces** | 4 legacy `LIKE '%q%'` endpoints: `/players/search`, `/advanced-stats/{pitching\|batting}/search`, `/stuff-plus/search` |
+| **Data Sources** | BigQuery: `dim_players_master`, `dim_teams`, `statcast_master`, `stuff_plus_rankings`, `fact_batting_stats_with_risp`, `fact_pitching_stats_master`, `mart_batter_season_stats`, `mart_pitcher_season_stats` |
+| **Build** | Single BigQuery query at Cloud Run cold start via FastAPI `lifespan` + `asyncio.to_thread`. ~7,000 entries, 3–5s, 5–10 MB resident |
+| **Player Filter** | `mlb_debut_year >= 2000 OR mlb_last_year >= 2000` |
+| **Data Structures** | (1) Trie keyed by `full_name` and `last_name` lowercase. (2) `ContextFilter` post-filters by `frozenset[int]` season tags per context. (3) `OrderedDict` LRU `PrefixCache` (max 4096 entries) |
+| **Popularity Score** | Pre-computed `log(1 + PA + IP*3) + (active ? 1.0 : 0.0)`. PA/IP from recent 3 seasons via UNION ALL of fact (≤2025) + mart (≥2026) layers |
+| **Contexts** | `all` (no filter), `statcast_pitcher`, `statcast_batter`, `stuffplus` — last three require `season` query param |
+| **Request Flow** | `Cache → Trie → ContextFilter → sort by score DESC → top N`, returns `served_from` ∈ {`cache`, `trie`, `fallback`} |
+| **Fallback** | If `app.state.autocomplete_ready=False` (build failed or in progress), endpoint falls back to `get_players_by_name` (legacy `LIKE`) |
+| **Frontend Integration** | `VITE_USE_AUTOCOMPLETE_API=true` switches 4 call sites: `useBackendAPI.searchPlayers`, `AdvancedStats.handleSearchChange`, `StrategyReportPage.PlayerSearchPicker`, Stuff+ search hook. Hook layer aliases `mlbid → pitcher_id / batter_id` for legacy contracts |
+| **Observability** | `autocomplete_build_completed` (entries_loaded / elapsed_query_ms / elapsed_total_ms) and `autocomplete_request` (prefix / context / season / served_from / latency_ms / result_count) via `StructuredLogger`, auto-tagged with Snowflake `trace_id` |
+| **Design Doc** | `docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md` |
+
 ---
 
 ### 8. Orchestration

--- a/backend/app/api/endpoints/player_endpoints.py
+++ b/backend/app/api/endpoints/player_endpoints.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from typing import Optional
 import logging
+import time
 
 # サービス層とスキーマをインポート
 from backend.app.services.player_service import get_players_by_name
@@ -8,7 +9,12 @@ from backend.app.services.player_profile_service import get_player_profile
 from backend.app.api.schemas import (
     PlayerSearchResults,
     PlayerProfileResponse,
+    AutocompleteResponse,
+    AutocompletePlayerItem,
 )
+from backend.app.utils.structured_logger import get_logger
+
+structured_logger = get_logger("diamond-lens")
 
 # ロガーの設定
 logging.basicConfig(level=logging.INFO)
@@ -45,6 +51,116 @@ async def search_players_endpoint(
     # PlayerSearchResultsモデルのインスタンスを構築して返す
     # search_results_listは既にPlayerSearchItemのリストなので、そのままresultsに渡す
     return PlayerSearchResults(query=q, results=search_results_list)
+
+
+@router.get(
+    "/players/autocomplete",
+    response_model=AutocompleteResponse,
+    summary="選手名オートコンプリート（統合版）",
+    description=(
+        "メモリ常駐の Trie から候補上位 N 件を返す。"
+        "context により候補プールを切り替える: "
+        "all / statcast_pitcher / statcast_batter / stuffplus。"
+        "Trie 構築未完了 / 失敗時は /players/search へフォールバック。"
+    ),
+    tags=["players"],
+)
+async def autocomplete_players_endpoint(
+    request: Request,
+    q: str = Query(..., min_length=1, max_length=64, description="検索プレフィックス"),
+    context: str = Query("all", description="all / statcast_pitcher / statcast_batter / stuffplus"),
+    season: Optional[int] = Query(None, ge=2000, le=2100, description="context!=all のとき必須"),
+    limit: int = Query(10, ge=1, le=50, description="返却件数の上限"),
+):
+    """選手名オートコンプリート用の統合エンドポイント。"""
+    valid_contexts = {"all", "statcast_pitcher", "statcast_batter", "stuffplus"}
+    if context not in valid_contexts:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid context. Must be one of {sorted(valid_contexts)}.",
+        )
+    if context != "all" and season is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"season is required when context='{context}'.",
+        )
+
+    service = getattr(request.app.state, "autocomplete_service", None)
+    is_ready = bool(getattr(request.app.state, "autocomplete_ready", False))
+    started = time.monotonic()
+
+    # Trie 構築完了 → 通常パス
+    if service is not None and is_ready:
+        try:
+            entries, served_from = service.query(
+                prefix=q, context=context, season=season, limit=limit
+            )
+            results = [
+                AutocompletePlayerItem(
+                    mlbid=e.mlbid,
+                    full_name=e.full_name,
+                    team=e.team,
+                    primary_position=e.primary_position,
+                    bat_side=e.bat_side,
+                    pitch_hand=e.pitch_hand,
+                    active=e.active,
+                    score=e.popularity_score,
+                )
+                for e in entries
+            ]
+            structured_logger.info(
+                "autocomplete_request",
+                prefix=q,
+                context=context,
+                season=season,
+                served_from=served_from,
+                latency_ms=int((time.monotonic() - started) * 1000),
+                result_count=len(results),
+            )
+            return AutocompleteResponse(
+                query=q,
+                context=context,
+                season=season,
+                served_from=served_from,
+                results=results,
+            )
+        except Exception as e:
+            logger.error(f"Autocomplete trie query failed: {e}", exc_info=True)
+            # 例外時は fallback に落とす
+
+    # フォールバック: 既存 /players/search 相当のロジックで候補を返す
+    # （context によるサブセット絞り込みは Vol.1 の fallback ではスキップ）
+    fallback_results_raw = get_players_by_name(q) or []
+    fallback_results = [
+        AutocompletePlayerItem(
+            mlbid=item.mlbid if item.mlbid is not None else 0,
+            full_name=item.player_name,
+            team=item.team,
+            primary_position=None,
+            bat_side=None,
+            pitch_hand=None,
+            active=False,
+            score=0.0,
+        )
+        for item in fallback_results_raw
+        if item.mlbid is not None
+    ][:limit]
+    structured_logger.info(
+        "autocomplete_request",
+        prefix=q,
+        context=context,
+        season=season,
+        served_from="fallback",
+        latency_ms=int((time.monotonic() - started) * 1000),
+        result_count=len(fallback_results),
+    )
+    return AutocompleteResponse(
+        query=q,
+        context=context,
+        season=season,
+        served_from="fallback",
+        results=fallback_results,
+    )
 
 
 @router.get(

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -575,6 +575,31 @@ class PlayerSearchResults(BaseModel):
     results: List[PlayerSearchItem] = Field([], description="検索に一致した選手のリスト")
 
 
+class AutocompletePlayerItem(BaseModel):
+    """
+    オートコンプリート結果の各項目（メモリ常駐 Trie から返す詳細情報付き）。
+    """
+    mlbid: int = Field(..., description="MLB選手ID")
+    full_name: str = Field(..., description="選手名（フルネーム）")
+    team: Optional[str] = Field(None, description="所属チーム略称")
+    primary_position: Optional[str] = Field(None, description="主ポジション")
+    bat_side: Optional[str] = Field(None, description="打席（L/R/S）")
+    pitch_hand: Optional[str] = Field(None, description="投球側（L/R）")
+    active: bool = Field(False, description="現役フラグ")
+    score: float = Field(0.0, description="popularity_score（並べ替え用）")
+
+
+class AutocompleteResponse(BaseModel):
+    """
+    /api/v1/players/autocomplete のレスポンス。
+    """
+    query: str = Field(..., description="正規化前の検索クエリ")
+    context: str = Field("all", description="all / statcast_pitcher / statcast_batter / stuffplus")
+    season: Optional[int] = Field(None, description="context!=all のとき必須のシーズン")
+    served_from: str = Field(..., description="cache / trie / fallback")
+    results: List[AutocompletePlayerItem] = Field([], description="候補上位 N 件")
+
+
 # ★★★ 修正箇所: ランキング結果用のPydanticモデルを追加 ★★★
 class PlayerRankingResult(BaseModel):
     # ランキングの指標名とその順位を動的に保持するため、Extra を許可する

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,10 +2,13 @@ from fastapi import FastAPI, Request
 from backend.app.api.endpoints.router import api_router  # For Development, add backend. path
 # from backend.app.api.endpoints import ai_analytics_endpoints  # For Development, add backend. path
 from fastapi.middleware.cors import CORSMiddleware
+import asyncio
 import logging
 import time
+from contextlib import asynccontextmanager
 from backend.app.utils.structured_logger import get_logger
 from backend.app.services.monitoring_service import get_monitoring_service
+from backend.app.services.sandbox.autocomplete_service import AutocompleteService
 from backend.app.middleware.request_id import RequestIDMiddleware
 from backend.app.middleware.firebase_auth import FirebaseAuthMiddleware
 from slowapi.errors import RateLimitExceeded
@@ -21,11 +24,40 @@ structured_logger = get_logger("diamond-lens")
 # 初期化すると起動が9秒前後遅くなるため、middleware/handler 内で
 # `get_monitoring_service()` を呼ぶ形に変更（シングルトンなので初回のみ初期化）。
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """起動時に AutocompleteService.build() をバックグラウンド実行する。
+
+    Cloud Run のコールドスタートを伸ばさないため、build はリクエスト処理と
+    並行して走らせる。完了するまで autocomplete エンドポイントは
+    fallback 動線（既存 4 系統）に退避する設計とする
+    （詳細: docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md）。
+    """
+    app.state.autocomplete_service = AutocompleteService()
+    app.state.autocomplete_ready = False
+
+    async def _build_autocomplete() -> None:
+        try:
+            await asyncio.to_thread(app.state.autocomplete_service.build)
+            app.state.autocomplete_ready = True
+            logger.info("Autocomplete service ready")
+        except Exception as e:
+            app.state.autocomplete_ready = False
+            logger.error(f"Autocomplete build failed: {e}", exc_info=True)
+
+    # タスクの参照を保持しないと GC で途中破棄される可能性があるため app.state に保持
+    app.state.autocomplete_build_task = asyncio.create_task(_build_autocomplete())
+
+    yield
+
+
 # Create the FastAPI app instance
 app = FastAPI(
     title="MLB Analytics API",
     description="API for MLB Analytics Dashboard V2",
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 # Add rate limiting to the FastAPI app
@@ -182,7 +214,11 @@ def health_check():
     """
     Health check endpoint to verify the API is running.
     """
-    return {"status": "ok", "version": "0.1.1"}
+    return {
+        "status": "ok",
+        "version": "0.1.1",
+        "autocomplete_ready": getattr(app.state, "autocomplete_ready", False),
+    }
 
 
 @app.get("/debug/routes")

--- a/backend/app/services/sandbox/autocomplete_service.py
+++ b/backend/app/services/sandbox/autocomplete_service.py
@@ -1,0 +1,441 @@
+"""
+選手名オートコンプリートサービス（Vol.1 実装）
+
+メモリ常駐の Trie + ContextFilter + PrefixCache で
+4 系統の選手検索 API を 1 本に統合する。
+
+関連ドキュメント: docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md
+
+リクエスト処理フロー:
+    Cache → Trie → ContextFilter → popularity_score 降順 → 上位 N 件
+"""
+import logging
+import math
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from backend.app.services.base import (
+    client,
+    PROJECT_ID,
+    DATASET_ID,
+    DIM_PLAYERS_MASTER_TABLE_ID,
+    BATTING_STATS_TABLE_ID,
+    PITCHING_STATS_MASTER_TABLE_ID,
+    STATCAST_MASTER_TABLE_ID,
+    MART_BATTER_SEASON_STATS_TABLE_ID,
+    MART_PITCHER_SEASON_STATS_TABLE_ID,
+)
+from backend.app.utils.structured_logger import get_logger
+
+logger = logging.getLogger(__name__)
+structured_logger = get_logger("diamond-lens")
+
+
+# =============================================================================
+# (1) PlayerEntry — Trie のリーフに格納する選手 1 人分の DTO
+# =============================================================================
+@dataclass
+class PlayerEntry:
+    mlbid: int
+    full_name: str
+    team: Optional[str]
+    primary_position: Optional[str]
+    bat_side: Optional[str]
+    pitch_hand: Optional[str]
+    active: bool
+
+    statcast_pitcher_seasons: frozenset = field(default_factory=frozenset)
+    statcast_batter_seasons: frozenset = field(default_factory=frozenset)
+    stuffplus_seasons: frozenset = field(default_factory=frozenset)
+
+    total_pa_recent3y: int = 0
+    total_ip_recent3y: float = 0.0
+
+    popularity_score: float = 0.0
+
+
+# =============================================================================
+# (2) Trie — プレフィックス木
+# =============================================================================
+class Trie:
+    """選手名のプレフィックス検索用データ構造。
+
+    name は first_name + last_name の小文字結合と
+    last_name 単独の 2 通りで insert される（呼び出し側で）。
+    検索結果に同一 mlbid が混じる可能性があるため、
+    search_prefix 内で mlbid 単位の dedup を行う。
+    """
+
+    _ENTRIES_KEY = "__entries__"
+
+    def __init__(self) -> None:
+        self._root: Dict = {}
+
+    def insert(self, name: str, entry: PlayerEntry) -> None:
+        node = self._root
+        for ch in name:
+            if ch not in node:
+                node[ch] = {}
+            node = node[ch]
+        node.setdefault(self._ENTRIES_KEY, []).append(entry)
+
+    def search_prefix(self, prefix: str) -> List[PlayerEntry]:
+        node = self._root
+        for ch in prefix:
+            if ch not in node:
+                return []
+            node = node[ch]
+
+        # 直下のサブツリーを DFS で走査し、全 PlayerEntry を mlbid 単位で dedup
+        results: List[PlayerEntry] = []
+        seen: set = set()
+        stack: List[Dict] = [node]
+        while stack:
+            cur = stack.pop()
+            for k, v in cur.items():
+                if k == self._ENTRIES_KEY:
+                    for e in v:
+                        if e.mlbid not in seen:
+                            seen.add(e.mlbid)
+                            results.append(e)
+                else:
+                    stack.append(v)
+        return results
+
+
+# =============================================================================
+# (3) ContextFilter — Trie の結果を context × season で絞り込む
+# =============================================================================
+class ContextFilter:
+    """候補リストをリクエストの context / season で絞り込む。"""
+
+    def apply(
+        self,
+        entries: List[PlayerEntry],
+        context: str,
+        season: Optional[int],
+    ) -> List[PlayerEntry]:
+        if context == "all":
+            return entries
+        if season is None:
+            # context!=all なのに season が無いのは API 層でエラーにする想定だが、
+            # 万一来た場合は安全側でフィルタ無しとする。
+            return entries
+        if context == "statcast_pitcher":
+            return [e for e in entries if season in e.statcast_pitcher_seasons]
+        if context == "statcast_batter":
+            return [e for e in entries if season in e.statcast_batter_seasons]
+        if context == "stuffplus":
+            return [e for e in entries if season in e.stuffplus_seasons]
+        return entries
+
+
+# =============================================================================
+# (4) PrefixCache — (context, season, prefix) 単位の LRU キャッシュ
+# =============================================================================
+class PrefixCache:
+    """直近の問い合わせ結果を保持する LRU。
+
+    キー: (context, season, prefix.lower())
+    値:   List[PlayerEntry]
+    最大: 4,096 entries / TTL なし（プロセス寿命と一致）。
+    """
+
+    def __init__(self, max_size: int = 4096) -> None:
+        self._max_size: int = max_size
+        self._store: "OrderedDict[Tuple[str, Optional[int], str], List[PlayerEntry]]" = OrderedDict()
+
+    def get(self, key: Tuple[str, Optional[int], str]) -> Optional[List[PlayerEntry]]:
+        if key not in self._store:
+            return None
+        self._store.move_to_end(key)
+        return self._store[key]
+
+    def put(self, key: Tuple[str, Optional[int], str], value: List[PlayerEntry]) -> None:
+        if key in self._store:
+            self._store.move_to_end(key)
+        self._store[key] = value
+        if len(self._store) > self._max_size:
+            self._store.popitem(last=False)
+
+
+# =============================================================================
+# (5) AutocompleteService — 外向きの窓口
+# =============================================================================
+class AutocompleteService:
+    """4 系統の選手検索を統合したオートコンプリート窓口。"""
+
+    # Trie に挿入する文字種を制限（plan §5 Step 5: 英字小文字 + ハイフン + アポストロフィ + スペース）
+    _ALLOWED_CHARS = set("abcdefghijklmnopqrstuvwxyz '-")
+
+    def __init__(self) -> None:
+        self.trie: Trie = Trie()
+        self.filter: ContextFilter = ContextFilter()
+        self.cache: PrefixCache = PrefixCache()
+        self.ready: bool = False
+
+    # -------------------------------------------------------------------------
+    # 起動時 1 回呼ぶ: BigQuery から全選手を取得し Trie を構築する
+    # -------------------------------------------------------------------------
+    def build(self) -> None:
+        sql = self._build_load_sql()
+        started = time.monotonic()
+        df = client.query(sql).to_dataframe()
+        elapsed_query = time.monotonic() - started
+
+        loaded = 0
+        for _, row in df.iterrows():
+            entry = self._row_to_entry(row)
+            if entry is None:
+                continue
+
+            full_name_key = self._normalize(entry.full_name)
+            last_name_key = self._normalize(self._extract_last_name(entry.full_name))
+
+            if full_name_key:
+                self.trie.insert(full_name_key, entry)
+            if last_name_key and last_name_key != full_name_key:
+                self.trie.insert(last_name_key, entry)
+            loaded += 1
+
+        elapsed_total = time.monotonic() - started
+        self.ready = True
+        structured_logger.info(
+            "autocomplete_build_completed",
+            entries_loaded=loaded,
+            elapsed_query_ms=int(elapsed_query * 1000),
+            elapsed_total_ms=int(elapsed_total * 1000),
+        )
+
+    # -------------------------------------------------------------------------
+    # クエリ時に呼ぶ: Cache → Trie → ContextFilter → 上位 N 件
+    # -------------------------------------------------------------------------
+    def query(
+        self,
+        prefix: str,
+        context: str = "all",
+        season: Optional[int] = None,
+        limit: int = 10,
+    ) -> Tuple[List[PlayerEntry], str]:
+        """検索結果と served_from（"cache" / "trie"）のタプルを返す。"""
+        normalized = self._normalize(prefix)
+        if not normalized:
+            return [], "trie"
+
+        cache_key: Tuple[str, Optional[int], str] = (context, season, normalized)
+
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            return cached[:limit], "cache"
+
+        candidates = self.trie.search_prefix(normalized)
+        filtered = self.filter.apply(candidates, context, season)
+        ranked = sorted(filtered, key=lambda e: e.popularity_score, reverse=True)
+
+        self.cache.put(cache_key, ranked)
+        return ranked[:limit], "trie"
+
+    # -------------------------------------------------------------------------
+    # ヘルパー
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _normalize(cls, text: Optional[str]) -> str:
+        """Trie 用に文字列を正規化する。許容文字以外は除去。"""
+        if not text:
+            return ""
+        lowered = text.lower()
+        return "".join(ch for ch in lowered if ch in cls._ALLOWED_CHARS).strip()
+
+    @staticmethod
+    def _extract_last_name(full_name: str) -> str:
+        if not full_name:
+            return ""
+        parts = full_name.strip().split()
+        return parts[-1] if parts else ""
+
+    @staticmethod
+    def _compute_popularity_score(pa: int, ip: float, active: bool) -> float:
+        """plan §3.4 の式: log(1 + PA + IP*3) + (active なら +1.0)"""
+        base = math.log(1.0 + float(pa) + float(ip) * 3.0)
+        return base + (1.0 if active else 0.0)
+
+    @staticmethod
+    def _safe_int(value, default: int = 0) -> int:
+        if value is None or pd.isna(value):
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _safe_float(value, default: float = 0.0) -> float:
+        if value is None or pd.isna(value):
+            return default
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _safe_bool(value, default: bool = False) -> bool:
+        if value is None or pd.isna(value):
+            return default
+        return bool(value)
+
+    @staticmethod
+    def _safe_str(value) -> Optional[str]:
+        if value is None or pd.isna(value):
+            return None
+        s = str(value).strip()
+        return s if s else None
+
+    @staticmethod
+    def _safe_seasons(value) -> frozenset:
+        """ARRAY_AGG 結果（list / numpy array / NA）を frozenset[int] に揃える。"""
+        if value is None:
+            return frozenset()
+        # pd.isna は配列に対しては配列を返すので、スカラーかどうかで分岐
+        try:
+            if pd.isna(value):
+                return frozenset()
+        except (TypeError, ValueError):
+            pass  # 配列なので isna は使えない → そのまま処理
+        try:
+            return frozenset(int(x) for x in value if x is not None and not pd.isna(x))
+        except TypeError:
+            return frozenset()
+
+    @classmethod
+    def _row_to_entry(cls, row) -> Optional[PlayerEntry]:
+        mlbid = cls._safe_int(row.get("mlbid"), default=-1)
+        if mlbid <= 0:
+            return None
+
+        pa = cls._safe_int(row.get("total_pa_recent3y"))
+        ip = cls._safe_float(row.get("total_ip_recent3y"))
+        active = cls._safe_bool(row.get("active"))
+        full_name = cls._safe_str(row.get("full_name")) or ""
+
+        return PlayerEntry(
+            mlbid=mlbid,
+            full_name=full_name,
+            team=cls._safe_str(row.get("team")),
+            primary_position=cls._safe_str(row.get("primary_position")),
+            bat_side=cls._safe_str(row.get("bat_side")),
+            pitch_hand=cls._safe_str(row.get("pitch_hand")),
+            active=active,
+            statcast_pitcher_seasons=cls._safe_seasons(row.get("statcast_pitcher_seasons")),
+            statcast_batter_seasons=cls._safe_seasons(row.get("statcast_batter_seasons")),
+            stuffplus_seasons=cls._safe_seasons(row.get("stuffplus_seasons")),
+            total_pa_recent3y=pa,
+            total_ip_recent3y=ip,
+            popularity_score=cls._compute_popularity_score(pa, ip, active),
+        )
+
+    @staticmethod
+    def _build_load_sql() -> str:
+        """起動時ロード SQL。直近 3 シーズン (2024〜2026) を対象とする。
+
+        2024〜2025: fact 層（fact_batting_stats_with_risp / fact_pitching_stats_master）
+        2026〜:     mart 層（mart_batter_season_stats / mart_pitcher_season_stats）
+        """
+        dpm = f"`{PROJECT_ID}.{DATASET_ID}.{DIM_PLAYERS_MASTER_TABLE_ID}`"
+        teams = f"`{PROJECT_ID}.{DATASET_ID}.dim_teams`"
+        statcast = f"`{PROJECT_ID}.{DATASET_ID}.{STATCAST_MASTER_TABLE_ID}`"
+        stuffplus = f"`{PROJECT_ID}.{DATASET_ID}.stuff_plus_rankings`"
+        fact_bat = f"`{PROJECT_ID}.{DATASET_ID}.{BATTING_STATS_TABLE_ID}`"
+        fact_pit = f"`{PROJECT_ID}.{DATASET_ID}.{PITCHING_STATS_MASTER_TABLE_ID}`"
+        mart_bat = f"`{PROJECT_ID}.{DATASET_ID}.{MART_BATTER_SEASON_STATS_TABLE_ID}`"
+        mart_pit = f"`{PROJECT_ID}.{DATASET_ID}.{MART_PITCHER_SEASON_STATS_TABLE_ID}`"
+
+        return f"""
+WITH
+players_base AS (
+  SELECT
+    mlbid, full_name, first_name, last_name,
+    primary_position, bat_side, pitch_hand, active,
+    current_team_id, mlb_debut_year, mlb_last_year
+  FROM {dpm}
+  WHERE (mlb_debut_year >= 2000 OR mlb_last_year >= 2000)
+    AND mlbid IS NOT NULL
+),
+teams AS (
+  SELECT team_id, abbreviation AS team_abbr FROM {teams}
+),
+statcast_pitcher_years AS (
+  SELECT pitcher AS mlbid,
+         ARRAY_AGG(DISTINCT game_year ORDER BY game_year) AS statcast_pitcher_seasons
+  FROM {statcast}
+  WHERE pitch_type IS NOT NULL
+  GROUP BY pitcher
+),
+statcast_batter_years AS (
+  SELECT batter AS mlbid,
+         ARRAY_AGG(DISTINCT game_year ORDER BY game_year) AS statcast_batter_seasons
+  FROM {statcast}
+  WHERE pitch_type IS NOT NULL
+  GROUP BY batter
+),
+stuffplus_years AS (
+  SELECT pitcher AS mlbid,
+         ARRAY_AGG(DISTINCT season ORDER BY season) AS stuffplus_seasons
+  FROM {stuffplus}
+  WHERE model_type = 'stuff_plus'
+  GROUP BY pitcher
+),
+batter_pa_recent AS (
+  SELECT mlbid, SUM(pa) AS total_pa_recent3y
+  FROM (
+    SELECT mlbId AS mlbid, pa
+    FROM {fact_bat}
+    WHERE season BETWEEN 2024 AND 2025
+    UNION ALL
+    SELECT batter AS mlbid, pa
+    FROM {mart_bat}
+    WHERE season >= 2026
+  )
+  WHERE mlbid IS NOT NULL
+  GROUP BY mlbid
+),
+pitcher_ip_recent AS (
+  SELECT mlbid, SUM(ip) AS total_ip_recent3y
+  FROM (
+    SELECT mlbid, ip
+    FROM {fact_pit}
+    WHERE season BETWEEN 2024 AND 2025
+    UNION ALL
+    SELECT pitcher AS mlbid, ip
+    FROM {mart_pit}
+    WHERE season >= 2026
+  )
+  WHERE mlbid IS NOT NULL
+  GROUP BY mlbid
+)
+SELECT
+  p.mlbid,
+  p.full_name,
+  p.first_name,
+  p.last_name,
+  p.primary_position,
+  p.bat_side,
+  p.pitch_hand,
+  p.active,
+  t.team_abbr AS team,
+  IFNULL(spy.statcast_pitcher_seasons, []) AS statcast_pitcher_seasons,
+  IFNULL(sby.statcast_batter_seasons, [])  AS statcast_batter_seasons,
+  IFNULL(sfy.stuffplus_seasons, [])        AS stuffplus_seasons,
+  IFNULL(bpa.total_pa_recent3y, 0)         AS total_pa_recent3y,
+  IFNULL(pip.total_ip_recent3y, 0)         AS total_ip_recent3y
+FROM players_base p
+LEFT JOIN teams                  t   ON p.current_team_id = t.team_id
+LEFT JOIN statcast_pitcher_years spy ON p.mlbid = spy.mlbid
+LEFT JOIN statcast_batter_years  sby ON p.mlbid = sby.mlbid
+LEFT JOIN stuffplus_years        sfy ON p.mlbid = sfy.mlbid
+LEFT JOIN batter_pa_recent       bpa ON p.mlbid = bpa.mlbid
+LEFT JOIN pitcher_ip_recent      pip ON p.mlbid = pip.mlbid
+"""

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,8 @@
 
 # Password for accessing the MLB Stats Assistant
 VITE_APP_PASSWORD=your_secure_password_here
+
+# 統合オートコンプリート API への切替フラグ（Vol.1 段階移行用）
+# true: /api/v1/players/autocomplete を使用（新）
+# false / 未設定: 既存 4 系統 (/players/search, /advanced-stats/*/search, /stuff-plus/search) を使用
+VITE_USE_AUTOCOMPLETE_API=false

--- a/frontend/src/components/AdvancedStats.jsx
+++ b/frontend/src/components/AdvancedStats.jsx
@@ -396,14 +396,35 @@ const AdvancedStats = () => {
       setTrendsSearchResults([]);
       if (val.length < 2) return;
       try {
-        const endpoint = category === 'pitching'
-          ? `/api/v1/advanced-stats/pitching/search?name=${encodeURIComponent(val)}&season=2025&limit=10`
-          : `/api/v1/advanced-stats/batting/search?name=${encodeURIComponent(val)}&season=2025&limit=10`;
+        // feature flag: VITE_USE_AUTOCOMPLETE_API=true で新統合エンドポイントへ切替
+        const useAutocomplete =
+          String(import.meta.env.VITE_USE_AUTOCOMPLETE_API).toLowerCase() === 'true';
+        const isPitching = category === 'pitching';
+        const endpoint = useAutocomplete
+          ? `/api/v1/players/autocomplete?q=${encodeURIComponent(val)}&context=${
+              isPitching ? 'statcast_pitcher' : 'statcast_batter'
+            }&season=2025&limit=10`
+          : `/api/v1/advanced-stats/${isPitching ? 'pitching' : 'batting'}/search?name=${encodeURIComponent(
+              val
+            )}&season=2025&limit=10`;
         const headers = await getAuthHeaders();
         const res = await fetch(`${BACKEND_URL}${endpoint}`, { headers });
         const data = await res.json();
         if (trendsQueryRef.current !== val) return;
-        setTrendsSearchResults(Array.isArray(data) ? data : []);
+
+        let results;
+        if (useAutocomplete) {
+          // 新 API: {results: [{mlbid, full_name, team}]} → 旧形式 (pitcher_id|batter_id, player_name, team) に揃える
+          const idKey = isPitching ? 'pitcher_id' : 'batter_id';
+          results = (data.results || []).map((item) => ({
+            [idKey]: item.mlbid,
+            player_name: item.full_name,
+            team: item.team || '',
+          }));
+        } else {
+          results = Array.isArray(data) ? data : [];
+        }
+        setTrendsSearchResults(results);
       } catch (e) {
         console.error('Search error:', e);
       }

--- a/frontend/src/components/StrategyReportPage.jsx
+++ b/frontend/src/components/StrategyReportPage.jsx
@@ -826,12 +826,30 @@ const PlayerSearchPicker = ({
       try {
         const baseURL = getBackendURL ? getBackendURL() : "";
         const headers = getAuthHeaders ? await getAuthHeaders() : {};
-        const url = `${baseURL}/api/v1/players/search?q=${encodeURIComponent(q)}`;
+        // feature flag: VITE_USE_AUTOCOMPLETE_API=true で新統合エンドポイントへ切替
+        const useAutocomplete =
+          String(import.meta.env.VITE_USE_AUTOCOMPLETE_API).toLowerCase() === "true";
+        const url = useAutocomplete
+          ? `${baseURL}/api/v1/players/autocomplete?q=${encodeURIComponent(q)}&context=all&limit=20`
+          : `${baseURL}/api/v1/players/search?q=${encodeURIComponent(q)}`;
         const res = await fetch(url, { headers });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = await res.json();
         if (cancelled) return;
-        setResults(Array.isArray(json.results) ? json.results.slice(0, 20) : []);
+
+        // 旧 API: { results: [{mlbid, player_name, team, league}] }
+        // 新 API: { results: [{mlbid, full_name, team, ...}] }
+        // 既存呼び出し側 (handleSelect) は player_name を読むので旧形式に揃える。
+        const rawResults = Array.isArray(json.results) ? json.results : [];
+        const normalized = useAutocomplete
+          ? rawResults.map((it) => ({
+              mlbid: it.mlbid,
+              player_name: it.full_name,
+              team: it.team || null,
+              league: null,
+            }))
+          : rawResults;
+        setResults(normalized.slice(0, 20));
         setError(null);
       } catch (e) {
         if (cancelled) return;

--- a/frontend/src/hooks/useBackendAPI.js
+++ b/frontend/src/hooks/useBackendAPI.js
@@ -7,6 +7,14 @@
  * @param {Function} deps.setSessionId  - セッションID更新関数
  * @param {boolean} deps.isAgentMode  - エージェントモードのON/OFF
  */
+// ===== feature flag =====
+// 新しい統合オートコンプリート API (/api/v1/players/autocomplete) を使うか。
+// 既存 4 系統 (/players/search, /advanced-stats/{pitching|batting}/search,
+// /stuff-plus/search) からの段階移行用。
+// .env で VITE_USE_AUTOCOMPLETE_API=true にすると有効。
+export const USE_AUTOCOMPLETE_API =
+  String(import.meta.env.VITE_USE_AUTOCOMPLETE_API).toLowerCase() === 'true';
+
 export const useBackendAPI = ({ getIdToken, sessionId, setSessionId, isAgentMode }) => {
 
   // ===== 環境別バックエンドURL検出 =====
@@ -44,18 +52,105 @@ export const useBackendAPI = ({ getIdToken, sessionId, setSessionId, isAgentMode
   };
 
   // ===== 選手検索 =====
+  // USE_AUTOCOMPLETE_API=true のとき新統合エンドポイントを叩き、
+  // 新形式 (mlbid, full_name, team) を旧形式 (mlbid, player_name, team, league) に
+  // マッピングして既存呼び出し側との互換を保つ。
   const searchPlayers = async (searchTerm, signal) => {
     const baseURL = getBackendURL();
-    const endpoint = `${baseURL}/api/v1/players/search?q=${encodeURIComponent(searchTerm)}`;
+    const endpoint = USE_AUTOCOMPLETE_API
+      ? `${baseURL}/api/v1/players/autocomplete?q=${encodeURIComponent(searchTerm)}&context=all&limit=10`
+      : `${baseURL}/api/v1/players/search?q=${encodeURIComponent(searchTerm)}`;
     try {
       const headers = await getAuthHeaders();
       const response = await fetch(endpoint, { headers, signal });
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       const data = await response.json();
-      return data.results || [];
+      const results = data.results || [];
+
+      if (USE_AUTOCOMPLETE_API) {
+        return results.map((item) => ({
+          mlbid: item.mlbid,
+          player_name: item.full_name,
+          team: item.team || null,
+          league: null, // 新 API は league を返さない（Vol.1 スコープ外）
+        }));
+      }
+      return results;
     } catch (error) {
       if (error.name === 'AbortError') return [];
       console.error('選手検索API呼び出しエラー:', error);
+      return [];
+    }
+  };
+
+  // ===== Statcast 投手・打者検索（AdvancedStats trends 用） =====
+  // category: 'pitching' | 'batting'
+  // 旧 API は配列を直接返す: [{pitcher_id|batter_id, player_name, team}]
+  // 新 API は {results: [{mlbid, full_name, team, ...}]} を返すので、
+  // ID 名のエイリアス (mlbid → pitcher_id / batter_id) を吸収して旧形式に揃える。
+  const searchAdvancedStatsPlayers = async (searchTerm, category, season, signal) => {
+    const baseURL = getBackendURL();
+    const isPitching = category === 'pitching';
+
+    const endpoint = USE_AUTOCOMPLETE_API
+      ? `${baseURL}/api/v1/players/autocomplete?q=${encodeURIComponent(searchTerm)}&context=${
+          isPitching ? 'statcast_pitcher' : 'statcast_batter'
+        }&season=${season}&limit=10`
+      : `${baseURL}/api/v1/advanced-stats/${
+          isPitching ? 'pitching' : 'batting'
+        }/search?name=${encodeURIComponent(searchTerm)}&season=${season}&limit=10`;
+
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch(endpoint, { headers, signal });
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const data = await response.json();
+
+      if (USE_AUTOCOMPLETE_API) {
+        const results = data.results || [];
+        const idKey = isPitching ? 'pitcher_id' : 'batter_id';
+        return results.map((item) => ({
+          [idKey]: item.mlbid,
+          player_name: item.full_name,
+          team: item.team || '',
+        }));
+      }
+      return Array.isArray(data) ? data : [];
+    } catch (error) {
+      if (error.name === 'AbortError') return [];
+      console.error('Statcast 選手検索 API 呼び出しエラー:', error);
+      return [];
+    }
+  };
+
+  // ===== Stuff+ 投手検索 =====
+  // 旧 API: [{pitcher_id, player_name, team, hand}]
+  // 新 API: {results: [...]} → pitcher_id にエイリアス
+  const searchStuffPlusPitchers = async (searchTerm, season, signal) => {
+    const baseURL = getBackendURL();
+    const endpoint = USE_AUTOCOMPLETE_API
+      ? `${baseURL}/api/v1/players/autocomplete?q=${encodeURIComponent(searchTerm)}&context=stuffplus&season=${season}&limit=10`
+      : `${baseURL}/api/v1/stuff-plus/search?name=${encodeURIComponent(searchTerm)}&season=${season}&limit=10`;
+
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch(endpoint, { headers, signal });
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const data = await response.json();
+
+      if (USE_AUTOCOMPLETE_API) {
+        const results = data.results || [];
+        return results.map((item) => ({
+          pitcher_id: item.mlbid,
+          player_name: item.full_name,
+          team: item.team || '',
+          hand: item.pitch_hand || '',
+        }));
+      }
+      return Array.isArray(data) ? data : [];
+    } catch (error) {
+      if (error.name === 'AbortError') return [];
+      console.error('Stuff+ 選手検索 API 呼び出しエラー:', error);
       return [];
     }
   };
@@ -188,5 +283,12 @@ export const useBackendAPI = ({ getIdToken, sessionId, setSessionId, isAgentMode
     }
   };
 
-  return { getBackendURL, getAuthHeaders, callBackendAPI, searchPlayers };
+  return {
+    getBackendURL,
+    getAuthHeaders,
+    callBackendAPI,
+    searchPlayers,
+    searchAdvancedStatsPlayers,
+    searchStuffPlusPitchers,
+  };
 };


### PR DESCRIPTION
Replaces 4 scattered LIKE-based search endpoints
(/players/search, /advanced-stats/{pitching|batting}/search, /stuff-plus/search) with a single in-memory Trie + popularity-ranked autocomplete service loaded once at Cloud Run startup.

- backend: AutocompleteService (Trie + ContextFilter + LRU PrefixCache) loaded via FastAPI lifespan, exposed at /api/v1/players/autocomplete
- popularity_score precomputed from recent 3 seasons (fact <=2025
  + mart >=2026 via UNION ALL), context-aware tag filtering
- frontend: VITE_USE_AUTOCOMPLETE_API flag switches 4 search call sites, with mlbid -> pitcher_id/batter_id alias mapping for legacy contracts
- structured logging (autocomplete_build_completed / autocomplete_request) with Snowflake trace_id auto-tagging