### PR TITLE
feat: LLM usage cost tracking + dedicated dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,18 @@ PrefixCache.put(...)
 
 ---
 
+### 24. LLM Usage Cost Dashboard (Full Stack, NEW 2026-05)
+
+Tracks every LLM invocation across the application and exposes cost / token / latency analytics via a dedicated dashboard.
+
+**Gateway pattern**: All LLM calls route through `llm_gateway_service.py` — REST callers via `call_gemini()`, LangChain via `LangchainUsageCallback(BaseCallbackHandler)` attached to `ChatGoogleGenerativeAI`. Every call records model, tokens, cost, latency, and feature tag to `llm_interaction_logs`. Per-model `PRICING` table calculates USD cost from `usage_metadata`.
+
+**Dashboard**: `GET /api/v1/usage/dashboard` returns 6 aggregations (current/prev month summary, by-model, by-feature, 30-day trend with zero-fill, recent N) in a **single BQ query** (CTE + `ARRAY<STRUCT>`) with 60s in-memory TTL cache. Frontend `UsageDashboard.jsx` renders KPI cards, monthly budget tracker, efficiency metrics, by-feature panel, models donut, daily trend SVG, and recent invocations table — styled with diamond-lens design tokens.
+
+**Technologies**: FastAPI, BigQuery, `google-genai`, `langchain-google-genai` + `langgraph`, React.
+
+---
+
 ### Technical Features
 - **AI-Powered Processing**: Uses Gemini 2.5 Flash for query parsing and response generation
 - **Real-time Interface**: Interactive experience with loading states and live updates

--- a/README_JP.md
+++ b/README_JP.md
@@ -606,6 +606,18 @@ PrefixCache.put(...)
 
 ---
 
+### 24. LLM 使用量・コストダッシュボード（フルスタック、NEW 2026-05）
+
+アプリ全体の LLM 呼び出しを全件トラッキングし、コスト・トークン・レイテンシを専用ダッシュボードで可視化する。
+
+**Gateway パターン**: 全 LLM 呼び出しを `llm_gateway_service.py` に集約 — REST 呼び出しは `call_gemini()`、LangChain (`ChatGoogleGenerativeAI`) は `LangchainUsageCallback(BaseCallbackHandler)` を attach。各呼び出しで model / tokens / cost / latency / feature タグを `llm_interaction_logs` に記録。モデル別 `PRICING` テーブルが `usage_metadata` から USD コストを算出する。
+
+**ダッシュボード**: `GET /api/v1/usage/dashboard` が 6 種類の集計（当月/前月サマリ、モデル別、feature 別、直近 30 日トレンド（欠損日 0 埋め）、直近 N 件履歴）を**単一 BQ クエリ**（CTE + `ARRAY<STRUCT>`）で返却、60 秒インメモリ TTL キャッシュ付き。フロントエンド `UsageDashboard.jsx` は KPI カード、月次予算トラッカー、効率指標、feature 別パネル、モデル別ドーナツ、日次トレンド SVG、直近呼び出しテーブルを diamond-lens のデザイントークンで描画。
+
+**技術**: FastAPI、BigQuery、`google-genai`、`langchain-google-genai` + `langgraph`、React
+
+---
+
 ### 技術機能
 - **AI搭載処理**: Gemini 2.5 Flashを使用したクエリ解析とレスポンス生成
 - **リアルタイムインターフェース**: ローディング状態とライブ更新付きのインタラクティブ体験

--- a/README_architecture.md
+++ b/README_architecture.md
@@ -846,6 +846,26 @@ python scripts/train_stuff_plus.py --season 2025 --min-pitches 100
 | **Observability** | `autocomplete_build_completed` (entries_loaded / elapsed_query_ms / elapsed_total_ms) and `autocomplete_request` (prefix / context / season / served_from / latency_ms / result_count) via `StructuredLogger`, auto-tagged with Snowflake `trace_id` |
 | **Design Doc** | `docs/plan_docs/SEARCH_AUTOCOMPLETE_PLAN_VOL1.md` |
 
+### 8q. LLM Usage Cost Dashboard
+
+| Property | Value |
+|----------|-------|
+| **Status** | NEW 2026-05, production-ready |
+| **Gateway** | `backend/app/services/llm_gateway_service.py` — `call_gemini()` (sync, REST drop-in) + `LangchainUsageCallback(BaseCallbackHandler)` (LangChain/LangGraph integration) |
+| **BQ Table** | `tksm-dash-test-25.mlb_analytics_dash_25.llm_interaction_logs` extended with `model`, `input_tokens`, `output_tokens`, `cached_tokens`, `estimated_cost_usd`, `feature` |
+| **Row Discrimination** | `WHERE model IS NOT NULL` selects gateway-written rows only |
+| **Pricing** | gemini-2.5-flash ($0.30 / $2.50 / $0.03 per 1M input/output/cached); gemini-2.0-flash ($0.10 / $0.40 / $0.025). Verified at ai.google.dev/gemini-api/docs/pricing |
+| **Endpoint** | `GET /api/v1/usage/dashboard?year=&month=&trend_days=&recent_limit=&force=` |
+| **Service** | `usage_stats_service.py:get_dashboard_all()` — 6 aggregations in a single BQ query via CTE + `ARRAY<STRUCT>`, scan-limited to 90 days |
+| **Cache** | 60s in-memory TTL keyed by `(year, month, trend_days, recent_limit)`; `force=true` bypasses |
+| **Daily Zero-Fill** | `GENERATE_ARRAY` left-joined with aggregated rows for stable N-day chart |
+| **Feature Tags** | `parse_query`, `conversation`, `mlb_data_engine`, `analytics_{base,pitcher,batter}`, `routing_judge`, `reflection_judge`, `synthesizer_judge`, `llm_judge`, `drift_alert_judge`, `supervisor_agent`, `agent_{stream_}?{batter,pitcher,matchup,stats,strategy}`, `strategy_report`, `strategy_tactics`, `game_summary` |
+| **REST Callers Migrated** | 11 services: `ai_service`, `conversation_service`, `mlb_data_engine`, `analytics/{base,pitcher,batter}_*`, `{routing,reflection,synthesizer,llm,drift_alert}_judge_service` |
+| **LangChain Callers Attached** | 6 sites: `supervisor_agent.py`, `ai_agent_service.py` (×2), `game_summary_service.py`, `strategy_report_endpoints.py` (×2) |
+| **Frontend** | `frontend/src/components/UsageDashboard.jsx` (sidebar entry `id="usage"`, icon=`sparkle`). KPI cards + Monthly Budget + Efficiency + Cost-by-Feature + Models Donut + Daily Trend SVG + Recent Invocations |
+| **Design Tokens** | `--ink-*`, `--bg-*`, `--amber`, `--pos`, `--info` from `frontend/src/index.css` (Bloomberg Terminal × ESPN Statcast aesthetic, sharp edges, JetBrains Mono) |
+| **Branch** | `feature/llm-usage-cost-tracker` |
+
 ---
 
 ### 8. Orchestration

--- a/backend/app/api/endpoints/router.py
+++ b/backend/app/api/endpoints/router.py
@@ -18,6 +18,7 @@ from .live_game_endpoints import router as live_game_router
 from .summary_endpoints import router as summary_router
 from .hot_slump_endpoints import router as hot_slump_router
 from .strategy_report_endpoints import router as strategy_report_router
+from .usage_endpoints import router as usage_router
 # RAG機能は一時無効化（イメージサイズ削減のため）
 # from .rag_endpoints import router as rag_router
 
@@ -42,5 +43,6 @@ api_router.include_router(live_game_router)
 api_router.include_router(summary_router)
 api_router.include_router(hot_slump_router)
 api_router.include_router(strategy_report_router)
+api_router.include_router(usage_router)
 # api_router.include_router(rag_router)
 # api_router.include_router(pitcher_prediction_router)

--- a/backend/app/api/endpoints/strategy_report_endpoints.py
+++ b/backend/app/api/endpoints/strategy_report_endpoints.py
@@ -75,11 +75,13 @@ async def generate_strategy_report_endpoint(
         import os
 
         from backend.app.services.agents.strategy_agent import StrategyAgent
+        from backend.app.services.llm_gateway_service import LangchainUsageCallback
 
         model = ChatGoogleGenerativeAI(
             model="gemini-2.5-flash",
             google_api_key=os.getenv("GEMINI_API_KEY_V2"),
             temperature=0,
+            callbacks=[LangchainUsageCallback(feature="strategy_report", model="gemini-2.5-flash")],
         )
         agent = StrategyAgent(model=model)
         result = agent.run_structured(
@@ -1531,10 +1533,12 @@ target, alert, users, bolt, shield, crosshair
         api_key = os.getenv("GEMINI_API_KEY_V2")
         if not api_key:
             raise RuntimeError("GEMINI_API_KEY_V2 が設定されていません")
+        from backend.app.services.llm_gateway_service import LangchainUsageCallback
         llm = ChatGoogleGenerativeAI(
             model="gemini-2.5-flash",
             google_api_key=api_key,
             temperature=0,
+            callbacks=[LangchainUsageCallback(feature="strategy_tactics", model="gemini-2.5-flash")],
         )
         structured_llm = llm.with_structured_output(TacticsResponse)
 

--- a/backend/app/api/endpoints/usage_endpoints.py
+++ b/backend/app/api/endpoints/usage_endpoints.py
@@ -1,0 +1,74 @@
+"""
+LLM Usage Cost Dashboard API Endpoints
+GET /usage/dashboard で月次サマリ・モデル別・feature別・日次トレンド・直近N件を返す。
+"""
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, Optional, Tuple
+
+from fastapi import APIRouter, HTTPException, Query
+
+from backend.app.services.usage_stats_service import get_dashboard_all
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/usage", tags=["LLM Usage Dashboard"])
+
+# 60 秒の TTL キャッシュ（同一パラメータの連打を BQ に投げ直さない）
+_CACHE_TTL_SEC = 60.0
+_cache: Dict[Tuple, Tuple[float, Dict[str, Any]]] = {}
+_cache_lock = threading.Lock()
+
+
+@router.get("/dashboard")
+def get_usage_dashboard(
+    year: Optional[int] = Query(None, ge=2024, le=2100, description="対象年 (省略時は当月)"),
+    month: Optional[int] = Query(None, ge=1, le=12, description="対象月 (省略時は当月)"),
+    trend_days: int = Query(30, ge=1, le=365, description="日次トレンドの対象日数"),
+    recent_limit: int = Query(20, ge=1, le=100, description="直近呼び出しの件数"),
+    force: bool = Query(False, description="True なら 60s キャッシュを無視して再取得"),
+):
+    """LLM コストダッシュボードに必要な集計データを **1 本の BQ クエリ** で取得する。
+
+    高速化策:
+    - BQ クエリ 6 本 → 1 本 (round-trip コスト削減、テーブル scan も 1 回)
+    - 60 秒インメモリ TTL キャッシュ (Refresh 連打を BQ に流さない)
+    - force=true で明示的にキャッシュバイパス可
+    """
+    try:
+        now_jst = datetime.now(timezone.utc) + timedelta(hours=9)
+        target_year = year or now_jst.year
+        target_month = month or now_jst.month
+        if target_month == 1:
+            prev_year, prev_month = target_year - 1, 12
+        else:
+            prev_year, prev_month = target_year, target_month - 1
+
+        cache_key = (target_year, target_month, trend_days, recent_limit)
+
+        if not force:
+            with _cache_lock:
+                hit = _cache.get(cache_key)
+                if hit and (time.time() - hit[0]) < _CACHE_TTL_SEC:
+                    return {"success": True, "data": hit[1], "cached": True}
+
+        data = get_dashboard_all(
+            target_year=target_year,
+            target_month=target_month,
+            prev_year=prev_year,
+            prev_month=prev_month,
+            trend_days=trend_days,
+            recent_limit=recent_limit,
+        )
+
+        with _cache_lock:
+            _cache[cache_key] = (time.time(), data)
+
+        return {"success": True, "data": data, "cached": False}
+
+    except Exception as e:
+        logger.error(f"Usage dashboard query failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/services/agents/supervisor_agent.py
+++ b/backend/app/services/agents/supervisor_agent.py
@@ -2,6 +2,7 @@ import os
 from langchain_google_genai import ChatGoogleGenerativeAI
 from typing import Literal
 from backend.app.config.prompt_registry import get_prompt, get_prompt_version
+from backend.app.services.llm_gateway_service import LangchainUsageCallback
 from backend.app.utils.structured_logger import get_logger
 
 logger = get_logger("supervisor-agent")
@@ -16,7 +17,8 @@ class SupervisorAgent:
         self.model = ChatGoogleGenerativeAI(
             model="gemini-2.5-flash",
             google_api_key=os.getenv("GEMINI_API_KEY_V2"),
-            temperature=0.0 # Deterministic routing
+            temperature=0.0, # Deterministic routing
+            callbacks=[LangchainUsageCallback(feature="supervisor_agent", model="gemini-2.5-flash")],
         )
     
 

--- a/backend/app/services/ai_agent_service.py
+++ b/backend/app/services/ai_agent_service.py
@@ -9,6 +9,7 @@ from typing import Annotated, TypedDict, List, Dict, Any, Union, Optional, Async
 from operator import add
 import pandas as pd
 from .simple_chart_service import enhance_response_with_simple_chart
+from .llm_gateway_service import LangchainUsageCallback
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage, ToolMessage
@@ -1248,7 +1249,8 @@ def run_mlb_agent(query: str) -> dict:
     model = ChatGoogleGenerativeAI(
         model="gemini-2.5-flash",
         google_api_key=os.getenv("GEMINI_API_KEY_V2"),
-        temperature=0 # 分析精度を高めるため、ランダム性を排除
+        temperature=0, # 分析精度を高めるため、ランダム性を排除
+        callbacks=[LangchainUsageCallback(feature=f"agent_{agent_type}", model="gemini-2.5-flash")],
     )
 
     # Step 4: Select and initialize agent
@@ -1361,7 +1363,8 @@ async def run_mlb_agent_stream(
     model = ChatGoogleGenerativeAI(
         model="gemini-2.5-flash",
         google_api_key=os.getenv("GEMINI_API_KEY_V2"),
-        temperature=0
+        temperature=0,
+        callbacks=[LangchainUsageCallback(feature=f"agent_stream_{agent_type}", model="gemini-2.5-flash")],
     )
 
     # Step 4: Select and initialize agent

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -5,7 +5,6 @@ from google.cloud.exceptions import GoogleCloudError
 import pandas as pd
 import os
 import json
-import requests
 import re
 from dotenv import load_dotenv
 # from functools import lru_cache
@@ -14,6 +13,7 @@ from .bigquery_service import client
 import logging
 from .conversation_service import get_conversation_service
 from .analytics.base_engine import BaseEngine
+from .llm_gateway_service import call_gemini
 from backend.app.config.prompt_registry import get_prompt, get_prompt_version
 
 # インポート: テスト実行時と本番実行時の両方に対応
@@ -88,29 +88,24 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
     prompt_version = get_prompt_version("parse_query")
     logger.info(f"Using parse_query prompt version: {prompt_version}")
 
-    GEMINI_API_URL=f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={GEMINI_API_KEY}"
-    headers = {"Content-Type": "application/json"}
-    payload = {
-        "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"responseMimeType": "application/json"}
-    }
-
-    try:
-        response = requests.post(GEMINI_API_URL, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            params = json.loads(json_string)
-
-            logger.info(f"Parsed parameters: {params}")
-
-            if season and 'season' not in params:
-                params['season'] = season
-            return params
+    text = call_gemini(
+        prompt=prompt,
+        model="gemini-2.5-flash",
+        response_mime_type="application/json",
+        feature="parse_query",
+        user_id="",
+        prompt_version=prompt_version,
+    )
+    if not text:
         return None
-    except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
-        logger.error(f"Error during LLM query parsing: {e}", exc_info=True)
+    try:
+        params = json.loads(text)
+        logger.info(f"Parsed parameters: {params}")
+        if season and 'season' not in params:
+            params['season'] = season
+        return params
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing LLM JSON output: {e}", exc_info=True)
         return None
 
 

--- a/backend/app/services/analytics/base_engine.py
+++ b/backend/app/services/analytics/base_engine.py
@@ -4,8 +4,6 @@ from typing import Optional, List, Dict, Any
 from google.cloud.exceptions import GoogleCloudError
 import pandas as pd
 import os
-import json
-import requests
 import re
 from dotenv import load_dotenv
 # from functools import lru_cache
@@ -27,6 +25,7 @@ try:
         MAIN_BATTING_BY_GAME_SCORE_SITUATIONS_STATS
     )
     from app.config.statcast_query import KEY_METRICS_QUERY_SELECT
+    from app.services.llm_gateway_service import call_gemini
 except ImportError:
     # 本番実行時の絶対インポート
     from backend.app.config.query_maps import (
@@ -41,6 +40,7 @@ except ImportError:
         MAIN_BATTING_BY_GAME_SCORE_SITUATIONS_STATS
     )
     from backend.app.config.statcast_query import KEY_METRICS_QUERY_SELECT
+    from backend.app.services.llm_gateway_service import call_gemini
 # from .simple_chart_service import enhance_response_with_simple_chart, should_show_simple_chart # For Development, add backend. path
 
 # ロガーの設定
@@ -623,18 +623,13 @@ class BaseEngine:
         ---
         回答:
         """
-        GEMINI_API_URL = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={GEMINI_API_KEY}"
-        headers = {"Content-Type": "application/json"}
-        payload = {"contents": [{"parts": [{"text": prompt}]}]}
-
-        try:
-            response = requests.post(GEMINI_API_URL, headers=headers, data=json.dumps(payload))
-            response.raise_for_status()
-            result = response.json()
-            if result.get("candidates"):
-                generated_text = result["candidates"][0]["content"]["parts"][0]["text"]
-                return generated_text.replace('\n', '<br>')
+        text = call_gemini(
+            prompt=prompt,
+            model="gemini-2.5-flash",
+            response_mime_type="text/plain",
+            feature="analytics_base",
+            user_id="",
+        )
+        if not text:
             return "AIによる回答を生成できませんでした。"
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error calling Gemini API for final response: {e}", exc_info=True)
-            return "AIによる回答生成中にエラーが発生しました。"
+        return text.replace('\n', '<br>')

--- a/backend/app/services/analytics/batter_services.py
+++ b/backend/app/services/analytics/batter_services.py
@@ -5,12 +5,12 @@ from google.cloud.exceptions import GoogleCloudError
 import pandas as pd
 import os
 import json
-import requests
 import re
 from dotenv import load_dotenv
 # from functools import lru_cache
 from datetime import datetime
 from ..bigquery_service import client
+from ..llm_gateway_service import call_gemini
 import logging
 from ..conversation_service import get_conversation_service
 from .base_engine import BaseEngine
@@ -108,33 +108,28 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
         prev_year=current_year - 1
     )
 
-    GEMINI_API_URL=f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={GEMINI_API_KEY}"
-    headers = {"Content-Type": "application/json"}
-    payload = {
-        "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"responseMimeType": "application/json"}
-    }
-
-    try:
-        response = requests.post(GEMINI_API_URL, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            logger.info(f"LLM raw response: {json_string}")
-
-            params = json.loads(json_string)
-            logger.info(f"Parsed parameters: {params}")
-
-            # seasonパラメータが渡されており、かつLLMがseasonを設定していない場合、強制的に設定
-            if season and (not params.get('season') or params.get('season') is None):
-                logger.info(f"Overriding season from context: {season}")
-                params['season'] = season
-
-            return params
+    text = call_gemini(
+        prompt=prompt,
+        model="gemini-2.5-flash",
+        response_mime_type="application/json",
+        feature="analytics_batter",
+        user_id="",
+    )
+    if not text:
         return None
-    except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
-        logger.error(f"Error during LLM query parsing: {e}", exc_info=True)
+    try:
+        logger.info(f"LLM raw response: {text}")
+        params = json.loads(text)
+        logger.info(f"Parsed parameters: {params}")
+
+        # seasonパラメータが渡されており、かつLLMがseasonを設定していない場合、強制的に設定
+        if season and (not params.get('season') or params.get('season') is None):
+            logger.info(f"Overriding season from context: {season}")
+            params['season'] = season
+
+        return params
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing LLM JSON output: {e}", exc_info=True)
         return None
 
 

--- a/backend/app/services/analytics/pitcher_services.py
+++ b/backend/app/services/analytics/pitcher_services.py
@@ -5,12 +5,12 @@ from google.cloud.exceptions import GoogleCloudError
 import pandas as pd
 import os
 import json
-import requests
 import re
 from dotenv import load_dotenv
 # from functools import lru_cache
 from datetime import datetime
 from ..bigquery_service import client
+from ..llm_gateway_service import call_gemini
 import logging
 from ..conversation_service import get_conversation_service
 from .base_engine import BaseEngine
@@ -125,29 +125,23 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
     JSON:
     """
 
-    GEMINI_API_URL=f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={GEMINI_API_KEY}"
-    headers = {"Content-Type": "application/json"}
-    payload = {
-        "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"responseMimeType": "application/json"}
-    }
-
-    try:
-        response = requests.post(GEMINI_API_URL, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            params = json.loads(json_string)
-
-            logger.info(f"Parsed parameters: {params}")
-
-            if season and 'season' not in params:
-                params['season'] = season
-            return params
+    text = call_gemini(
+        prompt=prompt,
+        model="gemini-2.5-flash",
+        response_mime_type="application/json",
+        feature="analytics_pitcher",
+        user_id="",
+    )
+    if not text:
         return None
-    except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
-        logger.error(f"Error during LLM query parsing: {e}", exc_info=True)
+    try:
+        params = json.loads(text)
+        logger.info(f"Parsed parameters: {params}")
+        if season and 'season' not in params:
+            params['season'] = season
+        return params
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing LLM JSON output: {e}", exc_info=True)
         return None
 
 

--- a/backend/app/services/conversation_service.py
+++ b/backend/app/services/conversation_service.py
@@ -6,7 +6,8 @@ import json
 import logging
 from datetime import datetime
 import os
-import requests
+
+from backend.app.services.llm_gateway_service import call_gemini
 
 logger = logging.getLogger(__name__)
 
@@ -173,31 +174,19 @@ class ConversationService:
         """
 
         try:
-            # Call Gemini API (requests方式)
-            GEMINI_API_URL = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={self.gemini_api_key}"
-            headers = {"Content-Type": "application/json"}
-            payload = {
-                "contents": [{"parts": [{"text": prompt}]}],
-                "generationConfig": {"responseMimeType": "application/json"}
-            }
+            text = call_gemini(
+                prompt=prompt,
+                model="gemini-2.5-flash",
+                response_mime_type="application/json",
+                feature="conversation",
+                user_id="",
+            )
+            if not text:
+                return {"resolved_query": current_query, "context_used": False}
 
-            response = requests.post(GEMINI_API_URL, headers=headers, data=json.dumps(payload))
-            response.raise_for_status()
-            result_json = response.json()
-
-            if result_json.get("candidates"):
-                json_string = result_json["candidates"][0]["content"]["parts"][0]["text"]
-                result = json.loads(json_string)
-                logger.info(f"✅ Context resolved: '{current_query}' → '{result['resolved_query']}'")
-                return result
-
-            return {"resolved_query": current_query, "context_used": False}
-
-            # LlamaIndex版（将来使用する可能性あり）
-            # response = self.llm.complete(prompt)
-            # result = json.loads(response.text)
-            # logger.info(f"Context resolved: '{current_query}' → '{result['resolved_query']}'")
-            # return result
+            result = json.loads(text)
+            logger.info(f"✅ Context resolved: '{current_query}' → '{result['resolved_query']}'")
+            return result
 
         except Exception as e:
             logger.error(f"❌ Context resolution failed: {e}")

--- a/backend/app/services/drift_alert_judge_service.py
+++ b/backend/app/services/drift_alert_judge_service.py
@@ -8,10 +8,11 @@ LLM as a Judge #5 - Data Drift アラート品質評価サービス
 import os
 import json
 import logging
-import requests
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
+
+from backend.app.services.llm_gateway_service import call_gemini
 
 logger = logging.getLogger(__name__)
 
@@ -225,23 +226,17 @@ MLBの文脈で、このドリフトに意味があるか。
         return contexts.get(model_type, "ドメインコンテキスト情報なし")
 
     def _call_gemini(self, prompt: str) -> Dict[str, Any]:
-        """Gemini API を呼び出す"""
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_name}:generateContent?key={self.api_key}"
-        headers = {"Content-Type": "application/json"}
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"responseMimeType": "application/json"},
-        }
-
-        response = requests.post(url, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            return json.loads(json_string)
-
-        raise ValueError("No candidates in Gemini response")
+        """Gemini API を Gateway 経由で呼び出す"""
+        text = call_gemini(
+            prompt=prompt,
+            model=self.model_name,
+            response_mime_type="application/json",
+            feature="drift_alert_judge",
+            user_id="",  # system-initiated batch job
+        )
+        if not text:
+            raise ValueError("Gateway returned no text from Gemini")
+        return json.loads(text)
 
     def _parse_judge_response(
         self,

--- a/backend/app/services/game_summary_service.py
+++ b/backend/app/services/game_summary_service.py
@@ -18,6 +18,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 
 from backend.app.config.settings import get_settings
 from backend.app.services.live_game_service import LiveGameService
+from backend.app.services.llm_gateway_service import LangchainUsageCallback
 
 settings = get_settings()
 
@@ -32,6 +33,7 @@ class GameSummaryService:
             model=settings.gemini_model,
             google_api_key=settings.gemini_api_key,
             temperature=0.7,
+            callbacks=[LangchainUsageCallback(feature="game_summary", model=settings.gemini_model)],
         )
         self.gcs_client = storage.Client()
         self.bucket = self.gcs_client.bucket(settings.gcs_bucket_name)

--- a/backend/app/services/llm_gateway_service.py
+++ b/backend/app/services/llm_gateway_service.py
@@ -1,0 +1,291 @@
+"""
+LLM Gateway Service
+全 LLM 呼び出しの単一窓口。google-genai SDK 経由で Gemini を呼び出し、
+トークン抽出・コスト計算・BQロギングを集約する。
+
+設計原則:
+- 「LLMを呼ぶ＝gatewayを通す＝コストログが必ず書かれる」を構造的に担保
+- try-finally で成功/失敗・例外時も必ず log を書く
+- 戻り値は既存 _make_request と互換 (テキストまたは None)、Phase3 の機械的移行を担保
+- 例外は内部で握り、None を返す (既存 Caller の None 判定パターンを維持)
+"""
+
+import os
+import time
+import logging
+from pathlib import Path
+from typing import Optional, Dict
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+
+from backend.app.services.llm_logger_service import LLMLogEntry, get_llm_logger
+
+logger = logging.getLogger(__name__)
+
+# .env を明示的にロード（ai_service.py 等と同じパターン）
+_env_path = Path(__file__).parent.parent.parent.parent / ".env"
+load_dotenv(dotenv_path=_env_path)
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY_V2", "")
+DEFAULT_MODEL = "gemini-2.5-flash"
+
+# ==================================
+# PRICING Map
+# ==================================
+# Source: https://ai.google.dev/gemini-api/docs/pricing (Paid tier, verified 2026-05-16)
+PRICING: Dict[str, Dict[str, float]] = {
+    "gemini-2.5-flash": {
+        "input_per_1m_usd": 0.30,
+        "output_per_1m_usd": 2.50,
+        "cached_per_1m_usd": 0.03,
+    },
+    "gemini-2.0-flash": {
+        "input_per_1m_usd": 0.10,
+        "output_per_1m_usd": 0.40,
+        "cached_per_1m_usd": 0.025,
+    },
+}
+
+
+def _calc_cost_usd(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cached_tokens: int = 0,
+) -> float:
+    """モデル別価格表からUSDコストを算出。未登録モデルは0を返す。"""
+    p = PRICING.get(model)
+    if not p:
+        logger.warning(f"PRICING not defined for model: {model}")
+        return 0.0
+    non_cached_input = max(0, input_tokens - cached_tokens)
+    return (
+        non_cached_input * p["input_per_1m_usd"] / 1_000_000
+        + cached_tokens * p["cached_per_1m_usd"] / 1_000_000
+        + output_tokens * p["output_per_1m_usd"] / 1_000_000
+    )
+
+
+# ==================================
+# Lazy genai client
+# ==================================
+_genai_client: Optional[genai.Client] = None
+
+
+def _get_genai_client() -> genai.Client:
+    """genai SDK クライアントを lazy 初期化 (起動時に API key 未設定でも import を許容)"""
+    global _genai_client
+    if _genai_client is None:
+        if not GEMINI_API_KEY:
+            raise RuntimeError("GEMINI_API_KEY is not configured")
+        _genai_client = genai.Client(api_key=GEMINI_API_KEY)
+    return _genai_client
+
+
+# ==================================
+# Gateway 本体
+# ==================================
+def call_gemini(
+    prompt: str,
+    *,
+    model: str = DEFAULT_MODEL,
+    response_mime_type: str = "text/plain",
+    feature: Optional[str] = None,
+    user_id: str = "",
+    endpoint: Optional[str] = None,
+    request_id: Optional[str] = None,
+    prompt_version: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Gemini テキスト生成の単一窓口。
+
+    Args:
+        prompt: LLM へのプロンプト
+        model: gemini-2.5-flash / gemini-2.0-flash 等
+        response_mime_type: "text/plain" or "application/json"
+        feature: ダッシュボード集計用タグ (例 "ai_summary", "routing_judge")
+        user_id: Firebase UID 等 (集計用に caller から伝搬)
+        endpoint: 呼び出し元 API パス (任意)
+        request_id: HTTP リクエスト ID (任意)
+        prompt_version: prompt registry から取得した version (任意)
+
+    Returns:
+        生成テキスト、または失敗時 None (既存 _make_request と互換)
+    """
+    entry = LLMLogEntry()
+    entry.user_id = user_id
+    entry.model = model
+    entry.endpoint = endpoint
+    entry.request_id = request_id
+    entry.feature = feature
+    entry.prompt_version = prompt_version
+    entry.user_query = prompt[:500]  # プロンプト先頭500文字（全文は冗長）
+
+    text: Optional[str] = None
+    t0 = time.time()
+    try:
+        client = _get_genai_client()
+        config = types.GenerateContentConfig(response_mime_type=response_mime_type)
+
+        response = client.models.generate_content(
+            model=model,
+            contents=prompt,
+            config=config,
+        )
+
+        # usage_metadata 抽出
+        um = response.usage_metadata
+        entry.input_tokens = (um.prompt_token_count if um else None) or 0
+        entry.output_tokens = (um.candidates_token_count if um else None) or 0
+        entry.cached_tokens = (
+            getattr(um, "cached_content_token_count", None) if um else None
+        )
+
+        # コスト計算
+        entry.estimated_cost_usd = _calc_cost_usd(
+            model=model,
+            input_tokens=entry.input_tokens or 0,
+            output_tokens=entry.output_tokens or 0,
+            cached_tokens=entry.cached_tokens or 0,
+        )
+
+        text = response.text
+        if text is None:
+            entry.success = False
+            entry.error_type = "no_text"
+            entry.error_message = "SDK returned response with text=None"
+            logger.warning("Gemini SDK returned no text")
+        else:
+            entry.success = True
+
+    except Exception as e:
+        entry.success = False
+        entry.error_type = type(e).__name__
+        entry.error_message = str(e)[:500]
+        logger.error(f"Gemini gateway call failed: {e}", exc_info=True)
+        text = None
+
+    finally:
+        entry.llm_latency_ms = (time.time() - t0) * 1000.0
+        try:
+            get_llm_logger().log(entry)
+        except Exception as e:
+            # ロギング失敗はアプリ機能に影響させない
+            logger.error(f"Failed to log gateway entry: {e}")
+
+    return text
+
+
+# ==================================
+# LangChain Usage Callback
+# ==================================
+# ChatGoogleGenerativeAI など LangChain LLM ラッパーは call_gemini() を経由しない。
+# 同等の BQ ログを実現するため、LangChain callback 機構で on_llm_end を捕まえる。
+
+try:
+    from langchain_core.callbacks import BaseCallbackHandler
+    _LANGCHAIN_AVAILABLE = True
+except ImportError:
+    BaseCallbackHandler = object  # type: ignore
+    _LANGCHAIN_AVAILABLE = False
+
+
+class LangchainUsageCallback(BaseCallbackHandler):
+    """LangChain ChatGoogleGenerativeAI 用のコスト・トークン計測 callback。
+    各 LLM 呼び出しの終了時 (on_llm_end) に LLMLogEntry を組み立てて BQ に書く。
+
+    Usage:
+        cb = LangchainUsageCallback(feature="strategy_report", model="gemini-2.5-flash")
+        llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", callbacks=[cb], ...)
+    """
+
+    def __init__(
+        self,
+        feature: str,
+        model: str,
+        user_id: str = "",
+        endpoint: Optional[str] = None,
+    ):
+        super().__init__() if _LANGCHAIN_AVAILABLE else None
+        self.feature = feature
+        self.model = model
+        self.user_id = user_id
+        self.endpoint = endpoint
+        self._start_time: Optional[float] = None
+
+    # LangChain は chat-style では on_chat_model_start を呼ぶ
+    def on_chat_model_start(self, serialized, messages, **kwargs):
+        self._start_time = time.time()
+
+    def on_llm_start(self, serialized, prompts, **kwargs):
+        self._start_time = time.time()
+
+    def _extract_usage(self, response) -> Dict[str, int]:
+        """LangChain LLMResult から (input, output) トークン数を抽出。複数 path に対応。"""
+        in_t, out_t = 0, 0
+        try:
+            # Path 1: response.llm_output["token_usage"] (OpenAI 互換 path)
+            if getattr(response, "llm_output", None):
+                tu = (response.llm_output or {}).get("token_usage") or {}
+                in_t = tu.get("prompt_token_count") or tu.get("input_tokens") or in_t
+                out_t = tu.get("candidates_token_count") or tu.get("output_tokens") or out_t
+
+            # Path 2: response.generations[0][0].message.usage_metadata (Gemini 経路の主流)
+            gens = getattr(response, "generations", None) or []
+            if gens and gens[0]:
+                first = gens[0][0]
+                msg = getattr(first, "message", None)
+                um = getattr(msg, "usage_metadata", None) if msg else None
+                if um:
+                    in_t = in_t or um.get("input_tokens") or 0
+                    out_t = out_t or um.get("output_tokens") or 0
+                # Path 3: generation_info
+                gi = getattr(first, "generation_info", None) or {}
+                um2 = gi.get("usage_metadata") or {}
+                in_t = in_t or um2.get("prompt_token_count") or 0
+                out_t = out_t or um2.get("candidates_token_count") or 0
+        except Exception as e:
+            logger.warning(f"LangchainUsageCallback: failed to extract usage: {e}")
+        return {"input_tokens": int(in_t or 0), "output_tokens": int(out_t or 0)}
+
+    def on_llm_end(self, response, **kwargs):
+        entry = LLMLogEntry()
+        entry.user_id = self.user_id
+        entry.feature = self.feature
+        entry.endpoint = self.endpoint
+        entry.model = self.model
+
+        usage = self._extract_usage(response)
+        entry.input_tokens = usage["input_tokens"]
+        entry.output_tokens = usage["output_tokens"]
+        entry.estimated_cost_usd = _calc_cost_usd(
+            model=self.model,
+            input_tokens=entry.input_tokens or 0,
+            output_tokens=entry.output_tokens or 0,
+        )
+        if self._start_time:
+            entry.llm_latency_ms = (time.time() - self._start_time) * 1000.0
+        entry.success = True
+
+        try:
+            get_llm_logger().log(entry)
+        except Exception as e:
+            logger.error(f"LangchainUsageCallback: log failed: {e}")
+
+    def on_llm_error(self, error, **kwargs):
+        entry = LLMLogEntry()
+        entry.user_id = self.user_id
+        entry.feature = self.feature
+        entry.endpoint = self.endpoint
+        entry.model = self.model
+        entry.success = False
+        entry.error_type = type(error).__name__
+        entry.error_message = str(error)[:500]
+        if self._start_time:
+            entry.llm_latency_ms = (time.time() - self._start_time) * 1000.0
+        try:
+            get_llm_logger().log(entry)
+        except Exception as e:
+            logger.error(f"LangchainUsageCallback: error-log failed: {e}")

--- a/backend/app/services/llm_judge_service.py
+++ b/backend/app/services/llm_judge_service.py
@@ -6,10 +6,11 @@ LLMを「審判」として使い、パース結果を多次元で意味的に�
 import os
 import json
 import logging
-import requests
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
+
+from backend.app.services.llm_gateway_service import call_gemini
 
 logger = logging.getLogger(__name__)
 
@@ -191,23 +192,17 @@ season, limit, order_by, output_format, split_type などの補助パラメー�
             ])
     
     def _call_gemini(self, prompt: str) -> Dict[str, Any]:
-        """Gemini API を呼び出す"""
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_name}:generateContent?key={self.api_key}"
-        headers = {"Content-Type": "application/json"}
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"responseMimeType": "application/json"},
-        }
-
-        response = requests.post(url, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            return json.loads(json_string)
-        
-        raise ValueError("No candidates in Gemini response")
+        """Gemini API を Gateway 経由で呼び出す"""
+        text = call_gemini(
+            prompt=prompt,
+            model=self.model_name,
+            response_mime_type="application/json",
+            feature="llm_judge",
+            user_id="",  # system-initiated batch job
+        )
+        if not text:
+            raise ValueError("Gateway returned no text from Gemini")
+        return json.loads(text)
         
     def _parse_judge_response(
         self,

--- a/backend/app/services/llm_logger_service.py
+++ b/backend/app/services/llm_logger_service.py
@@ -64,6 +64,13 @@ class LLMLogEntry:
         self.reflection_post_query: Optional[str] = None
         # Synthesizer fields
         self.synthesizer_source_data: Optional[str] = None
+        # LLM Usage / Cost tracking
+        self.model: Optional[str] = None
+        self.input_tokens: Optional[int] = None
+        self.output_tokens: Optional[int] = None
+        self.cached_tokens: Optional[int] = None
+        self.estimated_cost_usd: Optional[float] = None
+        self.feature: Optional[str] = None  # アプリ機能区分（gateway 由来。prompt_name とは別概念）
     
     def _resolve_response_answer(self) -> Optional[str]:
         """
@@ -122,6 +129,13 @@ class LLMLogEntry:
             "reflection_post_query": self.reflection_post_query,
             # Synthesizer fields
             "synthesizer_source_data": self.synthesizer_source_data,
+            # LLM Usage / Cost tracking
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cached_tokens": self.cached_tokens,
+            "estimated_cost_usd": self.estimated_cost_usd,
+            "feature": self.feature,
         }
 
 

--- a/backend/app/services/mlb_data_engine.py
+++ b/backend/app/services/mlb_data_engine.py
@@ -2,7 +2,6 @@ import os
 import json
 import re
 import logging
-import requests
 import pandas as pd
 from typing import Optional, List, Dict, Any
 from datetime import datetime
@@ -10,10 +9,11 @@ from google.cloud.exceptions import GoogleCloudError
 from google.cloud.bigquery import QueryJobConfig, ScalarQueryParameter, ArrayQueryParameter
 
 from .bigquery_service import client
+from .llm_gateway_service import call_gemini
 from ..config.query_maps import (
     QUERY_TYPE_CONFIG, METRIC_MAP, DECIMAL_FORMAT_COLUMNS,
     MAIN_BATTING_STATS, MAIN_PITCHING_STATS, MAIN_CAREER_BATTING_STATS,
-    MAIN_RISP_BATTING_STATS, MAIN_BASES_LOADED_BATTING_STATS, 
+    MAIN_RISP_BATTING_STATS, MAIN_BASES_LOADED_BATTING_STATS,
     MAIN_RUNNER_ON_1B_BATTING_STATS, MAIN_INNING_BATTING_STATS,
     MAIN_BATTING_BY_PITCHING_THROWS_STATS, MAIN_BATTING_BY_PITCH_TYPE_STATS,
     MAIN_BATTING_BY_GAME_SCORE_SITUATIONS_STATS
@@ -126,29 +126,23 @@ class MLBDataEngine:
         JSON:
         """
 
-        GEMINI_API_URL=f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={GEMINI_API_KEY}"
-        headers = {"Content-Type": "application/json"}
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"responseMimeType": "application/json"}
-        }
-
-        try:
-            response = requests.post(GEMINI_API_URL, headers=headers, data=json.dumps(payload))
-            response.raise_for_status()
-            result = response.json()
-            if result.get("candidates"):
-                json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-                params = json.loads(json_string)
-
-                logger.info(f"Parsed parameters: {params}")
-
-                if season and 'season' not in params:
-                    params['season'] = season
-                return params
+        text = call_gemini(
+            prompt=prompt,
+            model="gemini-2.0-flash",
+            response_mime_type="application/json",
+            feature="mlb_data_engine",
+            user_id="",
+        )
+        if not text:
             return None
-        except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
-            logger.error(f"Error during LLM query parsing: {e}", exc_info=True)
+        try:
+            params = json.loads(text)
+            logger.info(f"Parsed parameters: {params}")
+            if season and 'season' not in params:
+                params['season'] = season
+            return params
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing LLM JSON output: {e}", exc_info=True)
             return None
     
     def _validate_query_params(self, params: Dict[str, Any]) -> bool:

--- a/backend/app/services/reflection_judge_service.py
+++ b/backend/app/services/reflection_judge_service.py
@@ -10,10 +10,11 @@ Reflection Loop（自己修正）の判断と修正結果を多次元で評価�
 import os
 import json
 import logging
-import requests
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
+
+from backend.app.services.llm_gateway_service import call_gemini
 
 logger = logging.getLogger(__name__)
 
@@ -213,23 +214,17 @@ Reflectionを発動すべき状況だったか。
 }}"""
 
     def _call_gemini(self, prompt: str) -> Dict[str, Any]:
-        """Gemini API を呼び出す"""
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_name}:generateContent?key={self.api_key}"
-        headers = {"Content-Type": "application/json"}
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"responseMimeType": "application/json"},
-        }
-
-        response = requests.post(url, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            return json.loads(json_string)
-
-        raise ValueError("No candidates in Gemini response")
+        """Gemini API を Gateway 経由で呼び出す"""
+        text = call_gemini(
+            prompt=prompt,
+            model=self.model_name,
+            response_mime_type="application/json",
+            feature="reflection_judge",
+            user_id="",  # system-initiated batch job
+        )
+        if not text:
+            raise ValueError("Gateway returned no text from Gemini")
+        return json.loads(text)
 
     def _parse_judge_response(
         self,

--- a/backend/app/services/routing_judge_service.py
+++ b/backend/app/services/routing_judge_service.py
@@ -14,10 +14,11 @@ LLM Judge が多次元で評価します。
 import os
 import json
 import logging
-import requests
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
+
+from backend.app.services.llm_gateway_service import call_gemini
 
 logger = logging.getLogger(__name__)
 
@@ -194,23 +195,17 @@ class RoutingJudgeService:
 }}"""
 
     def _call_gemini(self, prompt: str) -> Dict[str, Any]:
-        """Gemini API を呼び出す"""
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_name}:generateContent?key={self.api_key}"
-        headers = {"Content-Type": "application/json"}
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"responseMimeType": "application/json"},
-        }
-
-        response = requests.post(url, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            return json.loads(json_string)
-
-        raise ValueError("No candidates in Gemini response")
+        """Gemini API を Gateway 経由で呼び出す"""
+        text = call_gemini(
+            prompt=prompt,
+            model=self.model_name,
+            response_mime_type="application/json",
+            feature="routing_judge",
+            user_id="",  # system-initiated batch job
+        )
+        if not text:
+            raise ValueError("Gateway returned no text from Gemini")
+        return json.loads(text)
 
     def _parse_judge_response(
         self,

--- a/backend/app/services/synthesizer_judge_service.py
+++ b/backend/app/services/synthesizer_judge_service.py
@@ -8,10 +8,11 @@ Synthesizer が生成した分析レポートや回答の品質を多次元で�
 import os
 import json
 import logging
-import requests
 from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
+
+from backend.app.services.llm_gateway_service import call_gemini
 
 logger = logging.getLogger(__name__)
 
@@ -206,22 +207,17 @@ class SynthesizerJudgeService:
 }}"""
 
     def _call_gemini(self, prompt: str) -> Dict[str, Any]:
-        """Gemini API を呼び出す"""
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_name}:generateContent?key={self.api_key}"
-        headers = {"Content-Type": "application/json"}
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"responseMimeType": "application/json"},
-        }
-        response = requests.post(url, headers=headers, data=json.dumps(payload))
-        response.raise_for_status()
-        result = response.json()
-
-        if result.get("candidates"):
-            json_string = result["candidates"][0]["content"]["parts"][0]["text"]
-            return json.loads(json_string)
-
-        raise ValueError("No candidates in Gemini response")
+        """Gemini API を Gateway 経由で呼び出す"""
+        text = call_gemini(
+            prompt=prompt,
+            model=self.model_name,
+            response_mime_type="application/json",
+            feature="synthesizer_judge",
+            user_id="",  # system-initiated batch job
+        )
+        if not text:
+            raise ValueError("Gateway returned no text from Gemini")
+        return json.loads(text)
 
     def _parse_judge_response(
         self,

--- a/backend/app/services/usage_stats_service.py
+++ b/backend/app/services/usage_stats_service.py
@@ -1,0 +1,463 @@
+"""
+Usage Stats Service
+LLM usage / cost ダッシュボード向けの集計クエリを提供する。
+
+ソーステーブル: llm_interaction_logs
+判別: WHERE model IS NOT NULL  ← gateway 由来の LLM 呼び出し行のみを対象
+(model IS NULL は request-level / feedback 行で別概念)
+
+タイムゾーン: BQ の timestamp は UTC。日次集計のみ Asia/Tokyo に変換。
+"""
+
+import os
+import logging
+from typing import Any, Dict, List
+
+from google.cloud import bigquery
+
+from backend.app.services.bigquery_service import client
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "tksm-dash-test-25")
+DATASET_ID = os.getenv("BIGQUERY_DATASET_ID", "mlb_analytics_dash_25")
+TABLE_ID = "llm_interaction_logs"
+FULL_TABLE_ID = f"`{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`"
+
+DEFAULT_TZ = "Asia/Tokyo"
+
+
+def get_dashboard_all(
+    target_year: int,
+    target_month: int,
+    prev_year: int,
+    prev_month: int,
+    trend_days: int,
+    recent_limit: int,
+) -> Dict[str, Any]:
+    """ダッシュボードに必要な全集計を **単一の BQ クエリ** で取得する。
+
+    実装方針:
+      - 1回の round-trip で 6 種類の集計を ARRAY<STRUCT> でネスト返却
+      - 直近 90 日に scan を限定（month + prev_month + trend_days を最大カバー）
+      - target_month / prev_month / 直近 trend_days のいずれかに該当する行のみ base に残す
+    """
+    sql = f"""
+    WITH base AS (
+      SELECT
+        log_id,
+        timestamp,
+        DATE(timestamp, @tz) AS d_jst,
+        EXTRACT(YEAR FROM timestamp AT TIME ZONE @tz) AS yr,
+        EXTRACT(MONTH FROM timestamp AT TIME ZONE @tz) AS mo,
+        feature,
+        model,
+        IFNULL(input_tokens, 0) AS input_tokens,
+        IFNULL(output_tokens, 0) AS output_tokens,
+        IFNULL(estimated_cost_usd, 0.0) AS estimated_cost_usd,
+        llm_latency_ms,
+        success,
+        error_type,
+        endpoint
+      FROM {FULL_TABLE_ID}
+      WHERE model IS NOT NULL
+        AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+    ),
+    target_rows AS (
+      SELECT * FROM base WHERE yr = @target_year AND mo = @target_month
+    ),
+    prev_rows AS (
+      SELECT * FROM base WHERE yr = @prev_year AND mo = @prev_month
+    ),
+    date_range AS (
+      SELECT DATE_SUB(CURRENT_DATE(@tz), INTERVAL n DAY) AS date
+      FROM UNNEST(GENERATE_ARRAY(0, @days - 1)) AS n
+    ),
+    daily_agg AS (
+      SELECT d_jst AS date,
+             COUNT(*) AS invocations,
+             SUM(estimated_cost_usd) AS cost_usd,
+             SUM(input_tokens + output_tokens) AS tokens
+      FROM base
+      WHERE d_jst >= DATE_SUB(CURRENT_DATE(@tz), INTERVAL @days - 1 DAY)
+      GROUP BY d_jst
+    )
+    SELECT
+      STRUCT(
+        @target_year AS year,
+        @target_month AS month,
+        (SELECT COUNT(*) FROM target_rows) AS total_invocations,
+        (SELECT COUNTIF(success = TRUE) FROM target_rows) AS success_count,
+        (SELECT IFNULL(SUM(estimated_cost_usd), 0) FROM target_rows) AS total_cost_usd,
+        (SELECT IFNULL(SUM(input_tokens), 0) FROM target_rows) AS total_input_tokens,
+        (SELECT IFNULL(SUM(output_tokens), 0) FROM target_rows) AS total_output_tokens,
+        (SELECT IFNULL(AVG(llm_latency_ms), 0) FROM target_rows) AS avg_latency_ms,
+        (SELECT IFNULL(APPROX_QUANTILES(llm_latency_ms, 100)[OFFSET(95)], 0) FROM target_rows) AS p95_latency_ms
+      ) AS summary,
+      STRUCT(
+        @prev_year AS year,
+        @prev_month AS month,
+        (SELECT COUNT(*) FROM prev_rows) AS total_invocations,
+        (SELECT COUNTIF(success = TRUE) FROM prev_rows) AS success_count,
+        (SELECT IFNULL(SUM(estimated_cost_usd), 0) FROM prev_rows) AS total_cost_usd,
+        (SELECT IFNULL(SUM(input_tokens), 0) FROM prev_rows) AS total_input_tokens,
+        (SELECT IFNULL(SUM(output_tokens), 0) FROM prev_rows) AS total_output_tokens,
+        (SELECT IFNULL(AVG(llm_latency_ms), 0) FROM prev_rows) AS avg_latency_ms,
+        (SELECT IFNULL(APPROX_QUANTILES(llm_latency_ms, 100)[OFFSET(95)], 0) FROM prev_rows) AS p95_latency_ms
+      ) AS prev_summary,
+      ARRAY(
+        SELECT AS STRUCT
+          model,
+          COUNT(*) AS invocations,
+          SUM(estimated_cost_usd) AS cost_usd,
+          SUM(input_tokens) AS input_tokens,
+          SUM(output_tokens) AS output_tokens
+        FROM target_rows
+        GROUP BY model
+        ORDER BY cost_usd DESC
+      ) AS by_model,
+      ARRAY(
+        SELECT AS STRUCT
+          IFNULL(feature, '(unknown)') AS feature,
+          COUNT(*) AS invocations,
+          SUM(estimated_cost_usd) AS cost_usd,
+          SUM(input_tokens) AS input_tokens,
+          SUM(output_tokens) AS output_tokens,
+          AVG(llm_latency_ms) AS avg_latency_ms
+        FROM target_rows
+        GROUP BY feature
+        ORDER BY cost_usd DESC
+      ) AS by_feature,
+      ARRAY(
+        SELECT AS STRUCT
+          r.date AS date,
+          IFNULL(a.invocations, 0) AS invocations,
+          IFNULL(a.cost_usd, 0.0) AS cost_usd,
+          IFNULL(a.tokens, 0) AS tokens
+        FROM date_range r
+        LEFT JOIN daily_agg a USING (date)
+        ORDER BY r.date ASC
+      ) AS daily,
+      ARRAY(
+        SELECT AS STRUCT
+          log_id,
+          timestamp,
+          IFNULL(feature, '(unknown)') AS feature,
+          model,
+          input_tokens,
+          output_tokens,
+          estimated_cost_usd,
+          llm_latency_ms,
+          success,
+          error_type,
+          endpoint
+        FROM base
+        ORDER BY timestamp DESC
+        LIMIT @recent_limit
+      ) AS recent
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("target_year", "INT64", target_year),
+            bigquery.ScalarQueryParameter("target_month", "INT64", target_month),
+            bigquery.ScalarQueryParameter("prev_year", "INT64", prev_year),
+            bigquery.ScalarQueryParameter("prev_month", "INT64", prev_month),
+            bigquery.ScalarQueryParameter("days", "INT64", trend_days),
+            bigquery.ScalarQueryParameter("recent_limit", "INT64", recent_limit),
+            bigquery.ScalarQueryParameter("tz", "STRING", DEFAULT_TZ),
+        ]
+    )
+    rows = list(client.query(sql, job_config=job_config).result())
+    if not rows:
+        return _empty_dashboard(target_year, target_month, prev_year, prev_month)
+    r = rows[0]
+
+    def _summary_to_dict(s):
+        return {
+            "year": int(s["year"]),
+            "month": int(s["month"]),
+            "total_invocations": int(s["total_invocations"] or 0),
+            "success_count": int(s["success_count"] or 0),
+            "total_cost_usd": float(s["total_cost_usd"] or 0),
+            "total_input_tokens": int(s["total_input_tokens"] or 0),
+            "total_output_tokens": int(s["total_output_tokens"] or 0),
+            "avg_latency_ms": float(s["avg_latency_ms"] or 0),
+            "p95_latency_ms": float(s["p95_latency_ms"] or 0),
+        }
+
+    return {
+        "summary": _summary_to_dict(r["summary"]),
+        "prev_summary": _summary_to_dict(r["prev_summary"]),
+        "by_model": [
+            {
+                "model": m["model"],
+                "invocations": int(m["invocations"] or 0),
+                "cost_usd": float(m["cost_usd"] or 0),
+                "input_tokens": int(m["input_tokens"] or 0),
+                "output_tokens": int(m["output_tokens"] or 0),
+            }
+            for m in (r["by_model"] or [])
+        ],
+        "by_feature": [
+            {
+                "feature": f["feature"],
+                "invocations": int(f["invocations"] or 0),
+                "cost_usd": float(f["cost_usd"] or 0),
+                "input_tokens": int(f["input_tokens"] or 0),
+                "output_tokens": int(f["output_tokens"] or 0),
+                "avg_latency_ms": float(f["avg_latency_ms"] or 0),
+            }
+            for f in (r["by_feature"] or [])
+        ],
+        "daily": [
+            {
+                "date": d["date"].isoformat(),
+                "invocations": int(d["invocations"] or 0),
+                "cost_usd": float(d["cost_usd"] or 0),
+                "tokens": int(d["tokens"] or 0),
+            }
+            for d in (r["daily"] or [])
+        ],
+        "recent": [
+            {
+                "log_id": rec["log_id"],
+                "timestamp": rec["timestamp"].isoformat() if rec["timestamp"] else None,
+                "feature": rec["feature"],
+                "model": rec["model"],
+                "input_tokens": int(rec["input_tokens"] or 0),
+                "output_tokens": int(rec["output_tokens"] or 0),
+                "estimated_cost_usd": float(rec["estimated_cost_usd"] or 0),
+                "llm_latency_ms": float(rec["llm_latency_ms"] or 0),
+                "success": bool(rec["success"]) if rec["success"] is not None else None,
+                "error_type": rec["error_type"],
+                "endpoint": rec["endpoint"],
+            }
+            for rec in (r["recent"] or [])
+        ],
+    }
+
+
+def _empty_dashboard(ty, tm, py, pm):
+    empty = lambda y, m: {
+        "year": y, "month": m,
+        "total_invocations": 0, "success_count": 0,
+        "total_cost_usd": 0.0, "total_input_tokens": 0, "total_output_tokens": 0,
+        "avg_latency_ms": 0.0, "p95_latency_ms": 0.0,
+    }
+    return {
+        "summary": empty(ty, tm), "prev_summary": empty(py, pm),
+        "by_model": [], "by_feature": [], "daily": [], "recent": [],
+    }
+
+
+def get_monthly_summary(year: int, month: int) -> Dict[str, Any]:
+    """指定月のサマリ (cost / invocations / tokens / latency)"""
+    sql = f"""
+    SELECT
+      COUNT(*) AS total_invocations,
+      COUNTIF(success = TRUE) AS success_count,
+      COALESCE(SUM(estimated_cost_usd), 0) AS total_cost_usd,
+      COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
+      COALESCE(AVG(llm_latency_ms), 0) AS avg_latency_ms,
+      COALESCE(APPROX_QUANTILES(llm_latency_ms, 100)[OFFSET(95)], 0) AS p95_latency_ms
+    FROM {FULL_TABLE_ID}
+    WHERE model IS NOT NULL
+      AND EXTRACT(YEAR FROM timestamp AT TIME ZONE @tz) = @year
+      AND EXTRACT(MONTH FROM timestamp AT TIME ZONE @tz) = @month
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("year", "INT64", year),
+            bigquery.ScalarQueryParameter("month", "INT64", month),
+            bigquery.ScalarQueryParameter("tz", "STRING", DEFAULT_TZ),
+        ]
+    )
+    rows = list(client.query(sql, job_config=job_config).result())
+    if not rows:
+        return _empty_summary(year, month)
+    r = rows[0]
+    return {
+        "year": year,
+        "month": month,
+        "total_invocations": int(r["total_invocations"] or 0),
+        "success_count": int(r["success_count"] or 0),
+        "total_cost_usd": float(r["total_cost_usd"] or 0),
+        "total_input_tokens": int(r["total_input_tokens"] or 0),
+        "total_output_tokens": int(r["total_output_tokens"] or 0),
+        "avg_latency_ms": float(r["avg_latency_ms"] or 0),
+        "p95_latency_ms": float(r["p95_latency_ms"] or 0),
+    }
+
+
+def get_monthly_by_model(year: int, month: int) -> List[Dict[str, Any]]:
+    """指定月のモデル別集計"""
+    sql = f"""
+    SELECT
+      model,
+      COUNT(*) AS invocations,
+      COALESCE(SUM(estimated_cost_usd), 0) AS cost_usd,
+      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS output_tokens
+    FROM {FULL_TABLE_ID}
+    WHERE model IS NOT NULL
+      AND EXTRACT(YEAR FROM timestamp AT TIME ZONE @tz) = @year
+      AND EXTRACT(MONTH FROM timestamp AT TIME ZONE @tz) = @month
+    GROUP BY model
+    ORDER BY cost_usd DESC
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("year", "INT64", year),
+            bigquery.ScalarQueryParameter("month", "INT64", month),
+            bigquery.ScalarQueryParameter("tz", "STRING", DEFAULT_TZ),
+        ]
+    )
+    return [
+        {
+            "model": r["model"],
+            "invocations": int(r["invocations"] or 0),
+            "cost_usd": float(r["cost_usd"] or 0),
+            "input_tokens": int(r["input_tokens"] or 0),
+            "output_tokens": int(r["output_tokens"] or 0),
+        }
+        for r in client.query(sql, job_config=job_config).result()
+    ]
+
+
+def get_monthly_by_feature(year: int, month: int) -> List[Dict[str, Any]]:
+    """指定月の feature (prompt_name) 別集計"""
+    sql = f"""
+    SELECT
+      COALESCE(feature, '(unknown)') AS feature,
+      COUNT(*) AS invocations,
+      COALESCE(SUM(estimated_cost_usd), 0) AS cost_usd,
+      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS output_tokens,
+      COALESCE(AVG(llm_latency_ms), 0) AS avg_latency_ms
+    FROM {FULL_TABLE_ID}
+    WHERE model IS NOT NULL
+      AND EXTRACT(YEAR FROM timestamp AT TIME ZONE @tz) = @year
+      AND EXTRACT(MONTH FROM timestamp AT TIME ZONE @tz) = @month
+    GROUP BY feature
+    ORDER BY cost_usd DESC
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("year", "INT64", year),
+            bigquery.ScalarQueryParameter("month", "INT64", month),
+            bigquery.ScalarQueryParameter("tz", "STRING", DEFAULT_TZ),
+        ]
+    )
+    return [
+        {
+            "feature": r["feature"],
+            "invocations": int(r["invocations"] or 0),
+            "cost_usd": float(r["cost_usd"] or 0),
+            "input_tokens": int(r["input_tokens"] or 0),
+            "output_tokens": int(r["output_tokens"] or 0),
+            "avg_latency_ms": float(r["avg_latency_ms"] or 0),
+        }
+        for r in client.query(sql, job_config=job_config).result()
+    ]
+
+
+def get_daily_trend(trend_days: int = 30) -> List[Dict[str, Any]]:
+    """直近 N 日間の日次トレンド (cost / invocations / tokens)。欠損日は 0 埋め。"""
+    sql = f"""
+    WITH date_range AS (
+      SELECT DATE_SUB(CURRENT_DATE(@tz), INTERVAL n DAY) AS date
+      FROM UNNEST(GENERATE_ARRAY(0, @days - 1)) AS n
+    ),
+    agg AS (
+      SELECT
+        DATE(timestamp, @tz) AS date,
+        COUNT(*) AS invocations,
+        SUM(estimated_cost_usd) AS cost_usd,
+        SUM(IFNULL(input_tokens, 0) + IFNULL(output_tokens, 0)) AS tokens
+      FROM {FULL_TABLE_ID}
+      WHERE model IS NOT NULL
+        AND DATE(timestamp, @tz) >= DATE_SUB(CURRENT_DATE(@tz), INTERVAL @days - 1 DAY)
+      GROUP BY date
+    )
+    SELECT
+      r.date,
+      IFNULL(a.invocations, 0) AS invocations,
+      IFNULL(a.cost_usd, 0) AS cost_usd,
+      IFNULL(a.tokens, 0) AS tokens
+    FROM date_range r
+    LEFT JOIN agg a USING (date)
+    ORDER BY r.date ASC
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("days", "INT64", trend_days),
+            bigquery.ScalarQueryParameter("tz", "STRING", DEFAULT_TZ),
+        ]
+    )
+    return [
+        {
+            "date": r["date"].isoformat(),
+            "invocations": int(r["invocations"] or 0),
+            "cost_usd": float(r["cost_usd"] or 0),
+            "tokens": int(r["tokens"] or 0),
+        }
+        for r in client.query(sql, job_config=job_config).result()
+    ]
+
+
+def get_recent_invocations(limit: int = 10) -> List[Dict[str, Any]]:
+    """直近 N 件の LLM 呼び出し"""
+    sql = f"""
+    SELECT
+      log_id,
+      timestamp,
+      COALESCE(feature, '(unknown)') AS feature,
+      model,
+      input_tokens,
+      output_tokens,
+      estimated_cost_usd,
+      llm_latency_ms,
+      success,
+      error_type,
+      endpoint
+    FROM {FULL_TABLE_ID}
+    WHERE model IS NOT NULL
+    ORDER BY timestamp DESC
+    LIMIT @limit
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("limit", "INT64", limit),
+        ]
+    )
+    return [
+        {
+            "log_id": r["log_id"],
+            "timestamp": r["timestamp"].isoformat() if r["timestamp"] else None,
+            "feature": r["feature"],
+            "model": r["model"],
+            "input_tokens": int(r["input_tokens"] or 0),
+            "output_tokens": int(r["output_tokens"] or 0),
+            "estimated_cost_usd": float(r["estimated_cost_usd"] or 0),
+            "llm_latency_ms": float(r["llm_latency_ms"] or 0),
+            "success": bool(r["success"]) if r["success"] is not None else None,
+            "error_type": r["error_type"],
+            "endpoint": r["endpoint"],
+        }
+        for r in client.query(sql, job_config=job_config).result()
+    ]
+
+
+def _empty_summary(year: int, month: int) -> Dict[str, Any]:
+    return {
+        "year": year,
+        "month": month,
+        "total_invocations": 0,
+        "success_count": 0,
+        "total_cost_usd": 0.0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "avg_latency_ms": 0.0,
+        "p95_latency_ms": 0.0,
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ google-cloud-bigquery
 google-cloud-bigquery-storage # BigQuery Storage API for fast to_dataframe()
 google-cloud-storage
 google-cloud-monitoring
+google-genai
 google-cloud-speech # For speech to text
 google-cloud-aiplatform # For Vertex AI Endpoint
 scikit-learn

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Leaderboard from './components/Leaderboard.jsx';
 import HotSlumpDashboard from './components/HotSlumpDashboard.jsx';
 import PlayerProfile from './components/PlayerProfile.jsx';
 import StrategyReportPage from './components/StrategyReportPage.jsx';
+import UsageDashboard from './components/UsageDashboard.jsx';
 import { useAuth } from './hooks/useAuth';
 import { useSession } from './hooks/useSession.js';
 import { useBackendAPI } from './hooks/useBackendAPI.js';
@@ -187,6 +188,13 @@ const MLBChatApp = () => {
             getBackendURL={getBackendURL}
             getAuthHeaders={getAuthHeaders}
             onSearchPlayers={searchPlayers}
+          />
+        );
+      case "usage":
+        return (
+          <UsageDashboard
+            getBackendURL={getBackendURL}
+            getAuthHeaders={getAuthHeaders}
           />
         );
       default:

--- a/frontend/src/components/UsageDashboard.jsx
+++ b/frontend/src/components/UsageDashboard.jsx
@@ -1,0 +1,750 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * LLM Usage Dashboard - Diamond Lens edition
+ * Bloomberg Terminal x ESPN Statcast aesthetic.
+ * 構造は project-2b-cbs ベース、視覚は diamond-lens の既存トークンに統一。
+ */
+
+// ─── Configurable ───────────────────────────────────────────
+const MONTHLY_BUDGET_CAP_USD = 7.0;
+
+// Feature / model color palette — diamond-lens の既存アクセント色のみ使用
+const FEATURE_COLOR = {
+  parse_query:        'var(--amber)',
+  conversation:       'var(--info)',
+  routing_judge:      'var(--pos)',
+  reflection_judge:   'var(--purp)',
+  synthesizer_judge:  'var(--amber-hi)',
+  llm_judge:          'var(--amber-dim)',
+  drift_alert_judge:  'var(--neg)',
+  mlb_data_engine:    'var(--info)',
+  analytics_base:     'var(--pos-dim)',
+  analytics_pitcher:  'var(--amber)',
+  analytics_batter:   'var(--purp)',
+};
+const featureColor = (id) => FEATURE_COLOR[id] ?? 'var(--ink-3)';
+
+const MODEL_COLOR = {
+  'gemini-2.5-flash':     'var(--amber)',
+  'gemini-2.0-flash':     'var(--info)',
+  'gemini-embedding-001': 'var(--purp)',
+};
+const modelColor = (id) => MODEL_COLOR[id] ?? 'var(--ink-3)';
+
+// ─── Formatters ─────────────────────────────────────────────
+const fmtUsd = (v) => {
+  if (v === 0) return '$0.00';
+  if (v < 0.01) return `$${v.toFixed(5)}`;
+  if (v < 1) return `$${v.toFixed(4)}`;
+  return `$${v.toFixed(2)}`;
+};
+const fmtInt = (v) => Math.round(v).toLocaleString();
+const fmtMs = (ms) => {
+  if (ms >= 10000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+};
+const fmtMd = (iso) => {
+  const [, m, d] = iso.split('-');
+  return `${parseInt(m, 10)}/${parseInt(d, 10)}`;
+};
+const fmtTimeShort = (iso) => {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    const pad = (n) => String(n).padStart(2, '0');
+    return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  } catch { return iso; }
+};
+
+const MONTH_NAMES = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
+
+function shiftMonth(year, month, delta) {
+  const m0 = (month - 1) + delta;
+  const dy = Math.floor(m0 / 12);
+  const dm = ((m0 % 12) + 12) % 12;
+  return { year: year + dy, month: dm + 1 };
+}
+function daysInMonth(year, month) { return new Date(year, month, 0).getDate(); }
+
+// ─── Inline SVG icons (currentColor) ────────────────────────
+const Icon = ({ size = 12, stroke = 2, children }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth={stroke} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'inline-block' }}>
+    {children}
+  </svg>
+);
+const IconL  = (p) => <Icon {...p}><polyline points="15 18 9 12 15 6" /></Icon>;
+const IconR  = (p) => <Icon {...p}><polyline points="9 18 15 12 9 6" /></Icon>;
+const IconU  = (p) => <Icon {...p}><polyline points="18 15 12 9 6 15" /></Icon>;
+const IconD  = (p) => <Icon {...p}><polyline points="6 9 12 15 18 9" /></Icon>;
+const IconRefresh = (p) => <Icon {...p}><polyline points="23 4 23 10 17 10" /><polyline points="1 20 1 14 7 14" /><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" /></Icon>;
+
+// ─── Card primitive (sharp, ruled) ───────────────────────────
+const Card = ({ children, style }) => (
+  <div style={{
+    background: 'var(--bg-1)',
+    border: '1px solid var(--rule)',
+    ...style,
+  }}>
+    {children}
+  </div>
+);
+
+const CardHead = ({ title, subtitle, right }) => (
+  <div className="rule-b" style={{
+    padding: '10px 14px',
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
+  }}>
+    <div>
+      <div className="h-label" style={{ fontSize: 10, letterSpacing: '0.14em', color: 'var(--ink-2)' }}>{title}</div>
+      {subtitle && (
+        <div style={{ fontSize: 10.5, color: 'var(--ink-4)', marginTop: 3, fontFamily: 'var(--ff-mono)' }}>
+          {subtitle}
+        </div>
+      )}
+    </div>
+    {right}
+  </div>
+);
+
+// ─── Month strip ────────────────────────────────────────────
+function MonthStrip({ year, month, range, onPrev, onNext, onRange, canGoNext }) {
+  const btnStyle = (active = false) => ({
+    height: 26, padding: '0 10px',
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    color: active ? 'var(--ink-0)' : 'var(--ink-2)',
+    background: active ? 'var(--bg-3)' : 'transparent',
+    fontFamily: 'var(--ff-mono)', fontSize: 10.5, letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+  });
+  const navBtn = (disabled = false) => ({
+    width: 26, height: 26,
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    color: disabled ? 'var(--ink-4)' : 'var(--ink-2)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.4 : 1,
+  });
+  return (
+    <div style={{
+      display: 'inline-flex', alignItems: 'center', gap: 4,
+      padding: 4,
+      background: 'var(--bg-1)', border: '1px solid var(--rule)',
+      marginBottom: 16,
+    }}>
+      <button onClick={onPrev} title="Previous month" style={navBtn(false)}><IconL /></button>
+      <div className="t-mono" style={{
+        padding: '0 10px', minWidth: 120, textAlign: 'center',
+        fontSize: 12.5, color: 'var(--ink-0)', letterSpacing: '0.06em',
+      }}>
+        {year} / {MONTH_NAMES[month - 1]}
+      </div>
+      <button onClick={onNext} disabled={!canGoNext} title="Next month" style={navBtn(!canGoNext)}><IconR /></button>
+      <div style={{ width: 1, height: 16, background: 'var(--rule)', margin: '0 4px' }} />
+      {['Month', '30d', 'YTD'].map(r => (
+        <button key={r} onClick={() => onRange(r)} style={btnStyle(range === r)}>
+          {r === 'Month' ? 'This month' : r === '30d' ? 'Last 30d' : 'YTD'}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── KPI cards ──────────────────────────────────────────────
+function KPICards({ data }) {
+  const s = data.summary;
+  const ps = data.prev_summary || {};
+  const tokens = (s.total_input_tokens || 0) + (s.total_output_tokens || 0);
+  const inPct = tokens === 0 ? 0 : ((s.total_input_tokens || 0) / tokens) * 100;
+
+  const deltaPct = ps.total_cost_usd > 0
+    ? Math.round(((s.total_cost_usd - ps.total_cost_usd) / ps.total_cost_usd) * 100) : 0;
+
+  const today = new Date();
+  const isCurrentMonth = s.year === today.getFullYear() && s.month === today.getMonth() + 1;
+  const daysElapsed = isCurrentMonth ? today.getDate() : daysInMonth(s.year, s.month);
+  const callsPerDay = daysElapsed > 0 ? (s.total_invocations || 0) / daysElapsed : 0;
+  const prevMonthLabel = MONTH_NAMES[shiftMonth(s.year, s.month, -1).month - 1];
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10, marginBottom: 16 }}>
+      <KpiCard
+        label="TOTAL COST"
+        dotColor="var(--amber)"
+        value={fmtUsd(s.total_cost_usd || 0)}
+        foot="USD this month"
+        delta={ps.total_cost_usd > 0 ? { sign: deltaPct, label: `${Math.abs(deltaPct)}% vs ${prevMonthLabel}` } : null}
+      />
+      <KpiCard
+        label="INVOCATIONS"
+        dotColor="var(--info)"
+        value={(s.total_invocations || 0).toLocaleString()}
+        foot={`API calls · ${callsPerDay.toFixed(2)} / day avg`}
+      />
+      <KpiCard
+        label="TOKENS"
+        dotColor="var(--amber-hi)"
+        value={fmtInt(tokens)}
+        custom={
+          <>
+            <div style={{ display: 'flex', height: 4, background: 'var(--bg-3)', marginTop: 6 }}>
+              <span style={{ width: inPct + '%', background: 'var(--amber)' }} />
+              <span style={{ width: (100 - inPct) + '%', background: 'var(--info)' }} />
+            </div>
+            <div style={{ display: 'flex', gap: 12, marginTop: 6, fontSize: 10, color: 'var(--ink-3)', fontFamily: 'var(--ff-mono)' }}>
+              <span><span style={{ display: 'inline-block', width: 7, height: 7, background: 'var(--amber)', marginRight: 5, verticalAlign: 'middle' }} />In {fmtInt(s.total_input_tokens || 0)}</span>
+              <span><span style={{ display: 'inline-block', width: 7, height: 7, background: 'var(--info)', marginRight: 5, verticalAlign: 'middle' }} />Out {fmtInt(s.total_output_tokens || 0)}</span>
+            </div>
+          </>
+        }
+      />
+      <KpiCard
+        label="LATENCY"
+        dotColor="var(--pos)"
+        value={<>{((s.avg_latency_ms || 0) / 1000).toFixed(1)}<span style={{ fontSize: 16, color: 'var(--ink-2)', fontWeight: 400, marginLeft: 2 }}>s</span></>}
+        foot={`avg · p95 ${fmtMs(s.p95_latency_ms || 0)}`}
+        statusBadge="OK"
+      />
+    </div>
+  );
+}
+
+function KpiCard({ label, dotColor, value, foot, delta, custom, statusBadge }) {
+  return (
+    <div style={{
+      background: 'var(--bg-1)', border: '1px solid var(--rule)',
+      padding: '14px 16px 12px', minHeight: 118,
+      display: 'flex', flexDirection: 'column',
+    }}>
+      <div className="h-label" style={{ fontSize: 9.5, color: 'var(--ink-3)', display: 'flex', alignItems: 'center', gap: 6, letterSpacing: '0.14em' }}>
+        <span style={{ width: 7, height: 7, background: dotColor, display: 'inline-block' }} />
+        {label}
+      </div>
+      <div className="t-digit" style={{ fontSize: 28, color: 'var(--ink-0)', letterSpacing: '-0.02em', lineHeight: 1.05, marginTop: 8 }}>
+        {value}
+      </div>
+      {custom}
+      {(foot || delta || statusBadge) && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginTop: 'auto', paddingTop: 8 }}>
+          {foot && <span style={{ fontSize: 10.5, color: 'var(--ink-3)' }}>{foot}</span>}
+          {delta != null && (
+            <span className="t-mono" style={{
+              display: 'inline-flex', alignItems: 'center', gap: 3,
+              fontSize: 10, fontWeight: 600, padding: '2px 6px',
+              color: delta.sign > 0 ? 'var(--neg)' : delta.sign < 0 ? 'var(--pos)' : 'var(--ink-3)',
+              background: 'var(--bg-2)', border: '1px solid var(--rule)',
+            }}>
+              {delta.sign > 0 ? <IconU size={9} stroke={3} /> : delta.sign < 0 ? <IconD size={9} stroke={3} /> : null}
+              {delta.label}
+            </span>
+          )}
+          {statusBadge && (
+            <span className="t-mono" style={{
+              display: 'inline-flex', alignItems: 'center', gap: 3,
+              fontSize: 10, fontWeight: 600, padding: '2px 6px',
+              color: 'var(--pos)', background: 'var(--bg-2)', border: '1px solid var(--rule)',
+            }}>
+              <IconU size={9} stroke={3} />{statusBadge}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Budget + Efficiency ────────────────────────────────────
+function BudgetAndEfficiency({ data }) {
+  const s = data.summary;
+  const cap = MONTHLY_BUDGET_CAP_USD;
+  const spent = s.total_cost_usd || 0;
+  const today = new Date();
+  const isCurrentMonth = s.year === today.getFullYear() && s.month === today.getMonth() + 1;
+  const daysElapsed = isCurrentMonth ? today.getDate() : daysInMonth(s.year, s.month);
+  const totalDays = daysInMonth(s.year, s.month);
+  const dailyAvg = daysElapsed > 0 ? spent / daysElapsed : 0;
+  const projected = dailyAvg * totalDays;
+  const pct = (spent / cap) * 100;
+  const projPct = Math.min((projected / cap) * 100, 100);
+  const { year: ny, month: nm } = shiftMonth(s.year, s.month, 1);
+  const resetISO = `${ny}-${String(nm).padStart(2, '0')}-01`;
+  const tokens = (s.total_input_tokens || 0) + (s.total_output_tokens || 0);
+  const costPerCall = s.total_invocations > 0 ? spent / s.total_invocations : 0;
+  const costPer1K = tokens > 0 ? (spent / tokens) * 1000 : 0;
+  const successRate = s.total_invocations > 0 ? (s.success_count || 0) / s.total_invocations : 1;
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 10, marginBottom: 16 }}>
+      <Card>
+        <CardHead
+          title="MONTHLY BUDGET"
+          subtitle={`Cap: $${cap.toFixed(2)} · Resets ${resetISO}`}
+          right={
+            <span className="t-mono" style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              fontSize: 10.5, color: 'var(--amber)',
+              border: '1px solid var(--amber-dim)', padding: '3px 8px',
+              background: 'var(--bg-2)',
+            }}>
+              <IconU size={9} stroke={2.4} />
+              Projected {fmtUsd(projected)} ({((projected / cap) * 100).toFixed(2)}%)
+            </span>
+          }
+        />
+        <div style={{ padding: '14px' }}>
+          <div style={{ position: 'relative', height: 10, background: 'var(--bg-3)', border: '1px solid var(--rule-dim)' }}>
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: Math.max(pct, 0.6) + '%', background: 'var(--amber)' }} />
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: projPct + '%', borderRight: '1px dashed var(--amber-hi)' }} />
+          </div>
+          <div className="t-mono" style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9.5, color: 'var(--ink-4)', marginTop: 6 }}>
+            <span>$0</span><span>${(cap * 0.25).toFixed(2)}</span><span>${(cap * 0.5).toFixed(0)}</span><span>${(cap * 0.75).toFixed(2)}</span><span>${cap.toFixed(0)}</span>
+          </div>
+          <div className="rule-t" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 10, paddingTop: 10, fontSize: 10.5, color: 'var(--ink-3)' }}>
+            <span>
+              Spent <b className="t-mono" style={{ color: 'var(--ink-0)' }}>{fmtUsd(spent)}</b> of ${cap.toFixed(2)} ({pct.toFixed(3)}%) · <span style={{ color: 'var(--pos)' }}>{fmtUsd(cap - spent)} remaining</span>
+            </span>
+            <span>Daily avg <b className="t-mono" style={{ color: 'var(--ink-0)' }}>{fmtUsd(dailyAvg)}</b></span>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHead title="EFFICIENCY" right={<span className="t-mono" style={{ fontSize: 10, color: 'var(--ink-4)' }}>{MONTH_NAMES[s.month - 1]}</span>} />
+        <div style={{ padding: 14, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <EffCell label="COST / CALL" value={fmtUsd(costPerCall)} />
+          <EffCell label="$ / 1K TOKENS" value={fmtUsd(costPer1K)} />
+          <EffCell label="CACHE HIT" value="—" muted />
+          <EffCell label="SUCCESS" value={`${Math.round(successRate * 100)}%`} color="var(--pos)" />
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function EffCell({ label, value, muted, color }) {
+  return (
+    <div>
+      <div className="h-label" style={{ fontSize: 9.5, color: 'var(--ink-3)', letterSpacing: '0.12em' }}>{label}</div>
+      <div className="t-digit" style={{ fontSize: 18, color: muted ? 'var(--ink-3)' : (color || 'var(--ink-0)'), marginTop: 3 }}>{value}</div>
+    </div>
+  );
+}
+
+// ─── Cost by feature ────────────────────────────────────────
+function FeatureCard({ features }) {
+  const total = features.reduce((sum, f) => sum + (f.cost_usd || 0), 0) || 1;
+  const maxLat = Math.max(...features.map(f => f.avg_latency_ms || 0), 1);
+  return (
+    <Card>
+      <CardHead
+        title="COST BY FEATURE"
+        subtitle="Token volume (in/out) and average latency per feature"
+        right={
+          <div style={{ display: 'flex', gap: 12, fontSize: 10, color: 'var(--ink-2)' }}>
+            <span><span style={{ display: 'inline-block', width: 8, height: 8, background: 'var(--amber)', marginRight: 5, verticalAlign: 'middle' }} />Input tokens</span>
+            <span><span style={{ display: 'inline-block', width: 8, height: 8, background: 'var(--info)', marginRight: 5, verticalAlign: 'middle' }} />Output tokens</span>
+          </div>
+        }
+      />
+      {features.length === 0 ? (
+        <div style={{ padding: 24, textAlign: 'center', fontSize: 11, color: 'var(--ink-4)', fontFamily: 'var(--ff-mono)', letterSpacing: '0.08em' }}>NO DATA THIS MONTH</div>
+      ) : (
+        <div style={{ padding: 6 }}>
+          {features.map((f, idx) => {
+            const tokensTotal = (f.input_tokens || 0) + (f.output_tokens || 0) || 1;
+            const inPct = ((f.input_tokens || 0) / tokensTotal) * 100;
+            const outPct = ((f.output_tokens || 0) / tokensTotal) * 100;
+            const sharePct = ((f.cost_usd || 0) / total) * 100;
+            const color = featureColor(f.feature);
+            return (
+              <div key={f.feature} style={{
+                display: 'grid', gridTemplateColumns: '140px 1fr 90px', gap: 14,
+                alignItems: 'center', padding: '10px 10px',
+                borderBottom: idx === features.length - 1 ? 'none' : '1px solid var(--rule-dim)',
+              }}>
+                <div className="t-mono" style={{ fontSize: 12, color: 'var(--ink-1)', display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ width: 8, height: 8, background: color, flexShrink: 0 }} />
+                  {f.feature}
+                </div>
+                <div>
+                  <div style={{ display: 'flex', height: 8, background: 'var(--bg-3)' }}>
+                    <span style={{ width: inPct + '%', background: color }} />
+                    <span style={{ width: outPct + '%', background: 'var(--info)' }} />
+                  </div>
+                  <div className="t-mono" style={{ display: 'flex', gap: 14, fontSize: 9.5, color: 'var(--ink-3)', marginTop: 5 }}>
+                    <span>{f.invocations} call{f.invocations === 1 ? '' : 's'}</span>
+                    <span>{fmtInt(f.input_tokens || 0)} in</span>
+                    <span>{fmtInt(f.output_tokens || 0)} out</span>
+                    <span>
+                      {fmtMs(f.avg_latency_ms || 0)} avg
+                      <span style={{ display: 'inline-block', width: 40, height: 3, background: 'var(--bg-3)', marginLeft: 6, verticalAlign: 'middle' }}>
+                        <span style={{ display: 'block', height: '100%', width: ((f.avg_latency_ms || 0) / maxLat * 100) + '%', background: 'var(--info)' }} />
+                      </span>
+                    </span>
+                  </div>
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                  <div className="t-digit" style={{ fontSize: 13, color: 'var(--ink-0)' }}>{fmtUsd(f.cost_usd || 0)}</div>
+                  <div className="t-mono" style={{ fontSize: 9.5, color: 'var(--ink-4)', marginTop: 2 }}>{sharePct.toFixed(1)}% of total</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <div className="rule-t" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', fontSize: 10.5, color: 'var(--ink-3)' }}>
+        <span>Active features <b className="t-mono" style={{ color: 'var(--ink-0)' }}>{features.length}</b></span>
+      </div>
+    </Card>
+  );
+}
+
+// ─── Models card (donut) ────────────────────────────────────
+function ModelDonut({ models }) {
+  const total = models.reduce((sum, m) => sum + (m.cost_usd || 0), 0);
+  const totalCalls = models.reduce((sum, m) => sum + (m.invocations || 0), 0);
+  const activeModels = models.filter(m => (m.invocations || 0) > 0).length;
+  const R = 15.915;
+  let acc = 0;
+  return (
+    <svg width="150" height="150" viewBox="0 0 42 42">
+      <circle cx="21" cy="21" r={R} fill="none" stroke="var(--bg-3)" strokeWidth="5" />
+      {models.map(m => {
+        if (!m.cost_usd) return null;
+        const pct = total > 0 ? (m.cost_usd / total) * 100 : 0;
+        const dasharray = `${pct} ${100 - pct}`;
+        const dashoffset = 25 - acc;
+        acc += pct;
+        return (
+          <circle key={m.model} cx="21" cy="21" r={R} fill="none"
+            stroke={modelColor(m.model)} strokeWidth="5"
+            strokeDasharray={dasharray} strokeDashoffset={dashoffset}
+            transform="rotate(-90 21 21)" />
+        );
+      })}
+      <text x="21" y="20" textAnchor="middle" fill="var(--ink-0)"
+        fontSize="5.5" fontWeight="600" fontFamily="JetBrains Mono, monospace">
+        {fmtUsd(total)}
+      </text>
+      <text x="21" y="25" textAnchor="middle" fill="var(--ink-4)"
+        fontSize="2.6" fontFamily="JetBrains Mono, monospace">
+        {totalCalls} call{totalCalls === 1 ? '' : 's'} · {activeModels} model{activeModels === 1 ? '' : 's'}
+      </text>
+    </svg>
+  );
+}
+
+function ModelsCard({ models }) {
+  const total = models.reduce((sum, m) => sum + (m.cost_usd || 0), 0) || 1;
+  return (
+    <Card>
+      <CardHead title="MODELS" subtitle="Cost share & call count" />
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '12px 0 16px' }}>
+        <ModelDonut models={models} />
+      </div>
+      {models.length === 0 ? (
+        <div style={{ padding: 16, textAlign: 'center', fontSize: 11, color: 'var(--ink-4)', fontFamily: 'var(--ff-mono)', letterSpacing: '0.08em' }}>NO INVOCATIONS</div>
+      ) : (
+        <div style={{ padding: '0 14px 14px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {models.map(m => {
+            const pct = total > 0 ? Math.round(((m.cost_usd || 0) / total) * 100) : 0;
+            return (
+              <div key={m.model} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ width: 9, height: 9, background: modelColor(m.model), flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div className="t-mono" style={{ fontSize: 11.5, color: 'var(--ink-1)' }}>{m.model}</div>
+                  <div className="t-mono" style={{ fontSize: 9.5, color: 'var(--ink-4)', marginTop: 2 }}>{m.invocations} call{m.invocations === 1 ? '' : 's'}</div>
+                </div>
+                <div className="t-mono" style={{ width: 40, textAlign: 'right', fontSize: 11.5, color: 'var(--ink-2)' }}>{pct}%</div>
+                <div className="t-digit" style={{ width: 76, textAlign: 'right', fontSize: 12, color: 'var(--ink-0)' }}>{fmtUsd(m.cost_usd || 0)}</div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ─── Daily trend chart ──────────────────────────────────────
+function TrendChart({ daily }) {
+  const [metric, setMetric] = useState('cost');
+  const wrapRef = useRef(null);
+  const ttRef = useRef(null);
+  const [w, setW] = useState(800);
+
+  useEffect(() => {
+    if (!wrapRef.current) return;
+    const ro = new ResizeObserver(entries => { for (const e of entries) setW(e.contentRect.width); });
+    ro.observe(wrapRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  const H = 240;
+  const pad = { l: 46, r: 14, t: 14, b: 26 };
+  const innerW = w - pad.l - pad.r;
+  const innerH = H - pad.t - pad.b;
+  const n = daily.length;
+  const values = daily.map(d => metric === 'cost' ? d.cost_usd : metric === 'tokens' ? d.tokens : d.invocations);
+  const maxV = (Math.max(...values, 0) * 1.18) || 1;
+  const xs = (i) => pad.l + (innerW * i) / Math.max(n - 1, 1);
+  const ys = (v) => pad.t + innerH - (v / maxV) * innerH;
+  const color = metric === 'cost' ? 'var(--amber)' : metric === 'tokens' ? 'var(--amber-hi)' : 'var(--info)';
+  const colorRaw = metric === 'cost' ? '#d49b3f' : metric === 'tokens' ? '#e3b35a' : '#7da4cc';
+  const gridVals = [0.25, 0.5, 0.75, 1].map(k => maxV * k);
+  const ticks = [];
+  for (let i = 0; i < n; i++) if (i === 0 || i === n - 1 || i % 2 === 0) ticks.push(i);
+
+  const fmtAxisV = (v) => {
+    if (metric === 'cost') return '$' + v.toFixed(3);
+    if (metric === 'tokens') return v >= 1000 ? (v / 1000).toFixed(1) + 'k' : String(Math.round(v));
+    return String(Math.round(v));
+  };
+
+  let dArea = `M ${xs(0)} ${ys(0)} `;
+  let dLine = `M ${xs(0)} ${ys(values[0] ?? 0)} `;
+  for (let i = 1; i < n; i++) {
+    dArea += `L ${xs(i)} ${ys(values[i])} `;
+    dLine += `L ${xs(i)} ${ys(values[i])} `;
+  }
+  dArea += `L ${xs(Math.max(n - 1, 0))} ${ys(0)} Z`;
+  const gradId = 'usage-grad-' + metric;
+
+  const onMove = (i, e) => {
+    const d = daily[i];
+    const tt = ttRef.current; if (!tt) return;
+    const cv = metric === 'cost' ? fmtUsd(d.cost_usd) : metric === 'tokens' ? fmtInt(d.tokens) : fmtInt(d.invocations);
+    tt.innerHTML = `
+      <div style="color: var(--ink-3); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 4px;">${d.date}</div>
+      <div style="display:flex;justify-content:space-between;gap:14px;"><span>${metric}</span><span style="color:var(--ink-0);font-family:var(--ff-mono);">${cv}</span></div>
+      <div style="display:flex;justify-content:space-between;gap:14px;"><span>calls</span><span style="color:var(--ink-0);font-family:var(--ff-mono);">${fmtInt(d.invocations)}</span></div>
+      <div style="display:flex;justify-content:space-between;gap:14px;"><span>tokens</span><span style="color:var(--ink-0);font-family:var(--ff-mono);">${fmtInt(d.tokens)}</span></div>
+      <div style="display:flex;justify-content:space-between;gap:14px;"><span>cost</span><span style="color:var(--ink-0);font-family:var(--ff-mono);">${fmtUsd(d.cost_usd)}</span></div>`;
+    tt.style.opacity = 1;
+    tt.style.left = e.clientX + 'px';
+    tt.style.top = (e.clientY - 8) + 'px';
+  };
+  const onLeave = () => { if (ttRef.current) ttRef.current.style.opacity = 0; };
+
+  return (
+    <Card style={{ marginBottom: 16 }}>
+      <CardHead
+        title="DAILY TREND"
+        subtitle={n > 0 ? `Last ${n} days · ${fmtMd(daily[0].date)} → ${fmtMd(daily[n - 1].date)}` : `Last ${n} days`}
+        right={
+          <div style={{ display: 'inline-flex', border: '1px solid var(--rule)', background: 'var(--bg-2)' }}>
+            {['cost', 'tokens', 'calls'].map(m => (
+              <button key={m} onClick={() => setMetric(m)} style={{
+                padding: '5px 10px', fontSize: 10.5,
+                fontFamily: 'var(--ff-mono)', letterSpacing: '0.08em',
+                color: metric === m ? 'var(--ink-0)' : 'var(--ink-2)',
+                background: metric === m ? 'var(--bg-3)' : 'transparent',
+                textTransform: 'uppercase',
+              }}>{m}</button>
+            ))}
+          </div>
+        }
+      />
+      <div ref={wrapRef} style={{ position: 'relative', width: '100%', height: H, padding: 4 }}>
+        <svg width="100%" height={H} viewBox={`0 0 ${w} ${H}`} preserveAspectRatio="none">
+          <defs>
+            <linearGradient id={gradId} x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stopColor={colorRaw} stopOpacity=".30" />
+              <stop offset="1" stopColor={colorRaw} stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          {gridVals.map((v, i) => (
+            <line key={i} x1={pad.l} x2={w - pad.r} y1={ys(v)} y2={ys(v)} stroke="var(--rule-dim)" strokeDasharray="2 4" />
+          ))}
+          <line x1={pad.l} x2={w - pad.r} y1={ys(0)} y2={ys(0)} stroke="var(--rule)" />
+          {gridVals.map((v, i) => (
+            <text key={i} x={pad.l - 8} y={ys(v) + 3} textAnchor="end" fill="var(--ink-4)" fontSize="9" fontFamily="JetBrains Mono, monospace">{fmtAxisV(v)}</text>
+          ))}
+          {ticks.map(i => (
+            <text key={i} x={xs(i)} y={H - pad.b + 14} textAnchor="middle" fill="var(--ink-4)" fontSize="9" fontFamily="JetBrains Mono, monospace">{fmtMd(daily[i].date)}</text>
+          ))}
+          <path d={dArea} fill={`url(#${gradId})`} />
+          <path d={dLine} stroke={color} strokeWidth="1.6" fill="none" strokeLinejoin="round" />
+          {values.map((v, i) => v > 0 ? (
+            <g key={i}>
+              <circle cx={xs(i)} cy={ys(v)} r="7" fill={color} opacity=".18" />
+              <circle cx={xs(i)} cy={ys(v)} r="3" fill={color} stroke="var(--bg-0)" strokeWidth="1.6" />
+            </g>
+          ) : null)}
+          {daily.map((_, i) => (
+            <rect key={i}
+              x={xs(i) - innerW / Math.max(n - 1, 1) / 2} y={pad.t}
+              width={innerW / Math.max(n - 1, 1)} height={innerH}
+              fill="transparent" style={{ cursor: 'crosshair' }}
+              onMouseMove={(e) => onMove(i, e)} onMouseLeave={onLeave} />
+          ))}
+        </svg>
+        <div ref={ttRef} style={{
+          position: 'fixed', pointerEvents: 'none',
+          background: 'var(--bg-2)', border: '1px solid var(--rule-hi)',
+          padding: '8px 10px', fontSize: 11, color: 'var(--ink-1)',
+          opacity: 0, transition: 'opacity 80ms',
+          transform: 'translate(-50%, -100%)', zIndex: 100, whiteSpace: 'nowrap',
+        }} />
+      </div>
+    </Card>
+  );
+}
+
+// ─── Recent invocations table ───────────────────────────────
+function RecentTable({ rows }) {
+  return (
+    <Card>
+      <CardHead title="RECENT INVOCATIONS" subtitle={`Most recent ${rows.length} call${rows.length === 1 ? '' : 's'} · hover row for error detail`} />
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              {['TIME', 'FEATURE', 'MODEL', 'IN', 'OUT', 'LATENCY', 'COST', 'STATUS'].map((h, i) => (
+                <th key={h} className="h-label" style={{
+                  textAlign: i >= 3 && i <= 6 ? 'right' : 'left',
+                  fontSize: 9.5, color: 'var(--ink-3)', letterSpacing: '0.12em',
+                  padding: '8px 12px', borderBottom: '1px solid var(--rule)',
+                }}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr><td colSpan={8} style={{ padding: 24, textAlign: 'center', color: 'var(--ink-4)', fontFamily: 'var(--ff-mono)', letterSpacing: '0.08em' }}>NO INVOCATIONS YET</td></tr>
+            ) : rows.map(r => {
+              const ok = r.success === true;
+              return (
+                <tr key={r.log_id} title={r.error_type ?? undefined}>
+                  <td className="t-mono" style={cellStyle()}>{fmtTimeShort(r.timestamp)}</td>
+                  <td style={cellStyle()}>
+                    <span style={{ display: 'inline-block', width: 8, height: 8, background: featureColor(r.feature), marginRight: 8, verticalAlign: 'middle' }} />
+                    <span className="t-mono">{r.feature}</span>
+                  </td>
+                  <td className="t-mono" style={cellStyle()}>{r.model}</td>
+                  <td className="t-mono" style={cellStyle('right')}>{fmtInt(r.input_tokens || 0)}</td>
+                  <td className="t-mono" style={cellStyle('right')}>{fmtInt(r.output_tokens || 0)}</td>
+                  <td className="t-mono" style={cellStyle('right')}>{Math.round(r.llm_latency_ms || 0).toLocaleString()} ms</td>
+                  <td className="t-mono" style={cellStyle('right')}>{fmtUsd(r.estimated_cost_usd || 0)}</td>
+                  <td style={cellStyle()}>
+                    <span className="t-mono" style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 5,
+                      fontSize: 10, fontWeight: 600, padding: '2px 8px',
+                      color: ok ? 'var(--pos)' : 'var(--neg)',
+                      border: `1px solid ${ok ? 'var(--pos-dim)' : 'var(--neg-dim)'}`,
+                      background: 'var(--bg-2)',
+                    }}>
+                      <span style={{ width: 5, height: 5, background: 'currentColor' }} />
+                      {ok ? '200' : 'ERR'}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+const cellStyle = (align = 'left') => ({
+  padding: '10px 12px', borderBottom: '1px solid var(--rule-dim)',
+  fontSize: 11.5, color: 'var(--ink-1)', textAlign: align,
+});
+
+// ─── Root component ─────────────────────────────────────────
+const UsageDashboard = ({ getBackendURL, getAuthHeaders }) => {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1);
+  const [range, setRange] = useState('Month');
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    let aborted = false;
+    setLoading(true); setError(null);
+    (async () => {
+      try {
+        const baseURL = getBackendURL();
+        const url = `${baseURL}/api/v1/usage/dashboard?year=${year}&month=${month}&trend_days=30&recent_limit=20`;
+        const headers = await getAuthHeaders();
+        const res = await fetch(url, { headers });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const payload = await res.json();
+        if (!payload.success) throw new Error('API returned success=false');
+        if (!aborted) setData(payload.data);
+      } catch (e) {
+        if (!aborted) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!aborted) setLoading(false);
+      }
+    })();
+    return () => { aborted = true; };
+  }, [year, month, refreshTick, getBackendURL, getAuthHeaders]);
+
+  const handlePrev = () => { const { year: y, month: m } = shiftMonth(year, month, -1); setYear(y); setMonth(m); };
+  const handleNext = () => { const { year: y, month: m } = shiftMonth(year, month, 1); setYear(y); setMonth(m); };
+  const canGoNext = !(year === today.getFullYear() && month === today.getMonth() + 1);
+
+  return (
+    <div style={{ padding: '24px 32px', height: '100%', overflowY: 'auto', background: 'var(--bg-0)' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginBottom: 18 }}>
+        <div>
+          <div className="h-display" style={{ fontSize: 26, color: 'var(--ink-0)' }}>LLM USAGE</div>
+          <div style={{ fontSize: 12, color: 'var(--ink-3)', marginTop: 4 }}>
+            AI機能のトークン使用量・コスト・呼び出し履歴。月次予算と着地予測も併記。
+          </div>
+        </div>
+        <button onClick={() => setRefreshTick(t => t + 1)} className="t-mono" style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          padding: '6px 12px', fontSize: 10.5,
+          letterSpacing: '0.08em', textTransform: 'uppercase',
+          color: 'var(--ink-1)', background: 'var(--bg-1)',
+          border: '1px solid var(--rule)',
+        }}>
+          <IconRefresh size={11} /> Refresh
+        </button>
+      </div>
+
+      <MonthStrip
+        year={year} month={month} range={range}
+        onPrev={handlePrev} onNext={handleNext} onRange={setRange}
+        canGoNext={canGoNext}
+      />
+
+      {error && (
+        <div style={{
+          padding: 12, marginBottom: 16,
+          background: 'var(--bg-1)', border: '1px solid var(--neg-dim)',
+          color: 'var(--neg)', fontSize: 12, fontFamily: 'var(--ff-mono)',
+        }}>
+          Failed to load: {error}
+        </div>
+      )}
+
+      {loading && !data && (
+        <Card><div style={{ padding: 32, textAlign: 'center', color: 'var(--ink-4)', fontFamily: 'var(--ff-mono)', letterSpacing: '0.08em' }}>LOADING…</div></Card>
+      )}
+
+      {data && (
+        <>
+          <KPICards data={data} />
+          <BudgetAndEfficiency data={data} />
+          <div style={{ display: 'grid', gridTemplateColumns: '1.55fr 1fr', gap: 10, marginBottom: 16 }}>
+            <FeatureCard features={data.by_feature || []} />
+            <ModelsCard models={data.by_model || []} />
+          </div>
+          <TrendChart daily={data.daily || []} />
+          <RecentTable rows={data.recent || []} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default UsageDashboard;

--- a/frontend/src/constants/navItems.js
+++ b/frontend/src/constants/navItems.js
@@ -11,4 +11,5 @@ export const NAV_ITEMS = [
   { id: "standings", icon: "medal",  code: "STD", jp: "順位表",          en: "STAND"      },
   { id: "team",      icon: "grid",   code: "TM",  jp: "チームスタッツ",  en: "TEAM"       },
   { id: "profile",   icon: "user",   code: "PRF", jp: "選手プロフィール", en: "PLAYER"    },
+  { id: "usage",     icon: "sparkle", code: "USG", jp: "LLMコスト",       en: "USAGE"      },
 ];

--- a/metricflow/Dockerfile
+++ b/metricflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Introduce a gateway pattern to track every LLM invocation across the app (model, tokens, cost, latency, feature) and expose them via a dedicated dashboard for cost monitoring and monthly budget management.

Backend:
- `llm_gateway_service.py`: single-window gateway with `call_gemini()` for REST callers and `LangchainUsageCallback(BaseCallbackHandler)` for LangChain/LangGraph callers (`ChatGoogleGenerativeAI`).
- Extended `llm_interaction_logs` with model / input_tokens / output_tokens / cached_tokens / estimated_cost_usd / feature columns.
- `usage_stats_service.py` + `usage_endpoints.py`: `GET /api/v1/usage/dashboard` returns 6 aggregations in a single BQ query (CTE + ARRAY<STRUCT>) with 60s in-memory TTL cache.
- Migrated 11 REST callers to gateway; attached LangchainUsageCallback to 6 LangChain instantiation sites (supervisor / agents / strategy / game-summary).

Frontend:
- `UsageDashboard.jsx`: KPI cards, monthly budget tracker with linear projection, efficiency metrics, by-feature panel, models donut, daily trend SVG with metric toggle, recent invocations table. Styled with diamond-lens existing design tokens.

Docs:
- Added section 24 to README.md / README_JP.md and section 8q to README_architecture.md.