### PR TITLE
refactor: replace LangGraph chat path with single-orchestrator design

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An AI-powered analytics interface for exploring Major League Baseball statistics
 - **💬 Chat Mode**: Natural language queries in Japanese with AI-powered responses
 - **⚡ Quick Questions**: Pre-defined common baseball queries for instant results
 - **⚙️ Custom Query Builder**: Advanced analytics with custom situational filters
-- **🤖 Autonomous Agent Mode (NEW)**: High-performance reasoning agent using LangGraph for multi-step data exploration and professional analysis
+- **🤖 Autonomous Agent Mode**: `ChatOrchestrator` (single-LLM-call chat via tool_use loop) + `StrategyAgent` (LangGraph for cross-domain strategy reports)
 - **🎤 Voice Input**: Microphone-based audio capture (MediaRecorder API) with backend transcription, injected directly into the query field
 - **📊 Table Response Format**: Per-query format selection (table / text); structured responses render as a transposable `DataTable` with automatic decimal-column formatting and grouping support
 
@@ -85,20 +85,20 @@ An AI-powered analytics interface for exploring Major League Baseball statistics
 **Business Applications**:
 - **Scouting Efficiency**: Categorize prospects by performance profile
 
-### 4. Autonomous Analyst Agent (Supervisor + LangGraph)
-**Status**: ✅ Production-ready with specialized agents powered by LangGraph
+### 4. Autonomous Analyst Agent (ChatOrchestrator + StrategyAgent)
+**Status**: ✅ Production-ready (chat path refactored 2026-05-17)
+
+**Architecture overview**:
+- **Chat path** — `ChatOrchestrator`: a single-class engine built on **raw `google-genai` SDK + `tool_use` loop**. Replaces the legacy `SupervisorAgent` + 4 LangGraph sub-agents. Default `synthesize_response=False` returns Markdown-formatted tool data after just **1 LLM call**, reducing the previous 4-call chain to 1.
+- **Strategy path** — `StrategyAgent` (retained LangGraph): a 5-node `Planner → ParallelExecutor → Aggregator → Reflection → Strategist` pipeline for cross-domain strategy reports.
 
 **Capabilities**:
-- **🧠 Multi-Agent Orchestration**: Uses a `SupervisorAgent` to intelligently route queries to specialized agents (`StatsAgent`, `MatchupAgent`), each orchestrated by **LangGraph**.
-- **🔍 Reasoning Visualization**: Live display of the autonomous reasoning steps across different specialized graph nodes.
-- **📊 Adaptive UI**: Automatically switches between narrative reports, interactive charts, and data tables based on found data.
-- **⚔️ Specialized Agents**:
-  - **StatsAgent**: Expert in team/player season stats, trends, and group comparisons.
-  - **MatchupAgent**: Expert in batter vs. pitcher head-to-head analytics and historic outcomes.
-  - **StrategyAgent** *(NEW — Phase 1 MVP)*: Cross-domain strategy analysis using Plan-and-Execute + Parallel Fan-Out pattern. Simultaneously invokes all 4 tools (batter stats, pitcher stats, matchup history, matchup analytics) via `asyncio.gather()` and synthesizes a structured 6-section strategy report. Renders a dedicated `StrategyReportCard` UI component.
-- **🏆 Professional Reports**: Generates structured analyst reports with headers, bullet points, and deep insights.
-- **⚖️ Fail-safe Generation**: Code-level guards to ensure complete, natural Japanese sentences without fragments.
-- **🔄 Reflection Loop (Self-Correction)**: Autonomous error recovery mechanism that detects SQL errors or empty query results and self-corrects by analyzing the root cause and retrying with improved parameters (max 2 retries). Intelligently classifies errors as retryable (syntax errors, empty results) vs non-retryable (permission, timeout, schema errors) to avoid wasteful retries.
+- **🧠 LLM-driven NLU via tool_use**: The orchestrator's outer LLM directly extracts structured arguments (`name`, `season`, `query_type`, `metrics`, …) — no internal NLU LLM call inside the tool.
+- **🔧 Common Tools**: `backend/app/services/tools/` houses `get_batter_stats_tool`, `get_pitcher_stats_tool`, `mlb_matchup_history_tool`, `mlb_matchup_analytics_tool` shared by both paths. Optional `query_semantic_metrics_tool` for dbt Semantic Layer (Cloud Run only when `USE_SEMANTIC_LAYER=true`).
+- **🗄️ output_format='data' default**: Tools return raw rows with `bigquery_latency_ms`. The orchestrator either streams a Markdown summary directly, or — if `synthesize_response=True` — runs an extra LLM call to compose a natural-language answer.
+- **💰 Token Budget pool separation (Phase 3-A)**: `chat` and `report` pools tracked independently so a heavy report generation cannot starve chat (and vice-versa).
+- **📊 Adaptive UI**: Automatically switches between narrative, interactive charts, data tables, and `StrategyReportCard` based on tool output.
+- **⚔️ Strategy path retains Reflection Loop**: Self-correction via the Reflection node (max 2 retries) for empty results / SQL errors. The chat path drops the explicit Reflection node and relies on the LLM's natural re-try via the tool_use loop.
 
 ### 5. MLOps: Prompt Versioning, LLM I/O Logging & Evaluation Gate
 **Status**: ✅ Production-ready
@@ -152,7 +152,7 @@ User rates response 👎 + selects category + writes reason
 - **🌐 Global Rate Limit**: 100 requests/minute across all users via custom ASGI middleware
 - **👤 Per-Session Rate Limit**: 20 requests/minute per user (Firebase user_id > Session ID > IP address)
 - **🎯 Per-Endpoint Rate Limit**: Configurable limits per endpoint via slowapi decorators (e.g., AI chat: 5/min, player stats: 10/min, statistics: 10/min)
-- **💰 LLM Token Budget**: Daily token usage cap (default: 1,000,000 tokens/day) with automatic reset at UTC midnight
+- **💰 LLM Token Budget (pool-separated, Phase 3-A)**: Daily token caps split between `chat` (500K/day) and `report` (500K/day) pools, plus a `shared` hard cap (1M/day). Heavy strategy reports cannot starve chat capacity. Automatic reset at UTC midnight.
 - **📊 Monitoring Integration**: All rate limit rejections are logged to Cloud Monitoring custom metrics and BigQuery `llm_interaction_logs`
 - **⚙️ Configurable via `.env`**: All limits are adjustable without code changes
 
@@ -670,15 +670,13 @@ The application supports two chat backends, switchable per service via the `USE_
    - Converts structured data back to natural Japanese responses
    - Supports both narrative (`sentence`) and tabular (`table`) output formats
 
-5. **🤖 Autonomous Multi-Agent Reasoning** (`app/services/agents/`)
-   - **Supervisor Architecture**: Decouples query routing from data retrieval via a `SupervisorAgent`.
-   - **Specialized Agents**: 
-     - `StatsAgent`: Handles general statistical queries and trend analysis.
-     - `MatchupAgent`: Handles specific head-to-head player historical comparisons.
-   - **LangGraph Implementation**: Each agent maintains its own "Oracle" (Planning), "Executor" (Data Retrieval), and "Synthesizer" (Final Reporting) loop.
-   - **Feedback Loop**: Agents can self-correct and perform multiple tool calls if the initial measurement is insufficient.
-   - **Reflection Loop**: Each agent includes a `reflection` node that detects executor errors (SQL syntax, empty results) and feeds diagnostic context back to the LLM for self-correction, with a max retry cap to prevent infinite loops.
-   - **Integrated UI**: Pipes structured chart/table metadata directly into the specialized frontend components.
+5. **🤖 Autonomous Reasoning — `ChatOrchestrator` + `StrategyAgent`** (refactored 2026-05-17)
+   - **`ChatOrchestrator`** (`app/services/chat_orchestrator.py`): single-class engine. Raw `google-genai` SDK + `tool_use` loop. Replaces the former `SupervisorAgent` + 4 LangGraph sub-agents (Batter / Pitcher / Matchup / Stats). The outer LLM does NLU itself and calls common tools with structured args.
+   - **`StrategyAgent`** (`app/services/agents/strategy_agent.py`): the only remaining LangGraph agent. 5-node pipeline (Planner → ParallelExecutor → Aggregator → Reflection → Strategist) for cross-domain strategy reports.
+   - **Common Tools** (`app/services/tools/`): shared by both paths. Tools return raw rows (`output_format='data'`) so the orchestrator/agent owns response composition.
+   - **Reflection**: chat path drops the explicit Reflection node and trusts the LLM's natural re-try via the tool_use loop. Strategy path keeps an explicit Reflection node (max 2 retries).
+   - **Token Budget pool separation (Phase 3-A)**: chat / report pools tracked independently in `token_budget_service.py`.
+   - **Integrated UI**: Pipes structured chart / table / matchup metadata directly into the specialized frontend components.
 
 ### ML Model Architecture: 3-Layer Separation of Concerns
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -10,7 +10,7 @@
 - **💬 チャットモード**: 日本語での自然言語クエリとAI搭載レスポンス
 - **⚡ クイック質問**: 事前定義された一般的な野球クエリで即座に結果を取得
 - **⚙️ カスタムクエリビルダー**: カスタム状況フィルターを使った高度なアナリティクス
-- **🤖 自律型エージェントモード (NEW)**: LangGraphを使用した複数ステップのデータ探索とプロフェッショナルな推論・分析
+- **🤖 自律型エージェントモード**: `ChatOrchestrator`（素の Gemini SDK + tool_use ループによる単一 LLM 呼び出しチャット）と `StrategyAgent`（LangGraph による対戦戦略レポート）の 2 系統構成
 - **🎤 音声入力**: MediaRecorder APIによるマイク録音→バックエンドでテキスト変換し、クエリフィールドに直接注入
 - **📊 表形式レスポンス**: クエリごとにテーブル/テキストの出力形式を選択可能。構造化データをトランスポーズ対応の `DataTable` として表示し、小数点カラムの自動フォーマット・グループ表示にも対応
 
@@ -85,20 +85,20 @@
 **ビジネス応用**:
 - **スカウティング効率化**: パフォーマンスプロファイルによる見込み選手の分類
 
-### 4. 自律型アナリストエージェント（Supervisor + LangGraph）
-**ステータス**: ✅ LangGraphで動作する特化型エージェントを備えた本番環境対応
+### 4. 自律型アナリストエージェント（ChatOrchestrator + StrategyAgent）
+**ステータス**: ✅ 本番環境対応（2026-05-17 にチャット側を全面リファクタ）
+
+**アーキテクチャ概要**:
+- **チャット経路 — `ChatOrchestrator`**: 素の `google-genai` SDK + `tool_use` ループで動く単一クラスエンジン。旧 `SupervisorAgent` + 4 LangGraph sub-agent (Batter / Pitcher / Matchup / Stats) を畳んだ。デフォルト `synthesize_response=False` で **LLM 1 回だけ呼んで** Markdown 整形済みツール戻り値を返却（旧 4 回チェーンを 1 回に短縮）。
+- **戦略経路 — `StrategyAgent`**: LangGraph を維持。5 ノード構成 (`Planner → ParallelExecutor → Aggregator → Reflection → Strategist`) で横断的な戦略レポートを生成。
 
 **機能**:
-- **🧠 マルチエージェント・オーケストレーション**: `SupervisorAgent` を使用して、クエリを特化型エージェント（`StatsAgent`, `MatchupAgent`）にインテリジェントにルーティングします。各エージェントは **LangGraph** によって制御されています。
-- **🔍 推論プロセスの可視化**: 特化型グラフの各ノードにおける内部思考プロセス（Reasoning Steps）をリアルタイム表示。
-- **📊 アダプティブUI**: 取得データに基づいて、ナラティブレポート、インタラクティブチャート、データテーブルを自動的に切り替え。
-- **⚔️ 特化型エージェント**:
-  - **StatsAgent**: チーム/選手のシーズン成績、トレンド、グループ比較の専門家。
-  - **MatchupAgent**: 打者 vs 投手の直接対決アナリティクスと過去の実績の専門家。
-  - **StrategyAgent** *(NEW — Phase 1 MVP)*: Plan-and-Execute + Parallel Fan-Out パターンによる横断的な戦略分析。打者スタッツ・投手スタッツ・対戦履歴・対戦アナリティクスの4ツールを `asyncio.gather()` で並列実行し、6セクション構成の戦略レポートを生成。専用の `StrategyReportCard` UIコンポーネントで表示。
-- **🏆 プロフェッショナルレポート**: 見出し、箇条書き、深い洞察を備えた構造化されたアナリストレポートを生成。
-- **⚖️ フェイルセーフ生成**: 文の断片を防ぎ、完全で自然な日本語を保証するためのコードレベルのガードレール。
-- **🔄 Reflection Loop（自己修正）**: SQLエラーや空結果を検知し、原因を分析してパラメータを修正し再試行する自律的エラー回復メカニズム（最大2回リトライ）。リトライ可能なエラー（構文エラー、空結果）とリトライ不可エラー（認証、タイムアウト、スキーマエラー）をインテリジェントに分類し、無駄なリトライを回避。
+- **🧠 tool_use による LLM 駆動 NLU**: Orchestrator 外側 LLM が直接構造化引数 (`name`, `season`, `query_type`, `metrics`, ...) を抽出。ツール内 NLU LLM 呼び出しは廃止。
+- **🔧 共通ツール**: `backend/app/services/tools/` に集約された `get_batter_stats_tool`, `get_pitcher_stats_tool`, `mlb_matchup_history_tool`, `mlb_matchup_analytics_tool` を両経路で共有。`USE_SEMANTIC_LAYER=true` 時は `query_semantic_metrics_tool` (dbt Semantic Layer) に切替（Cloud Run 専用）。
+- **🗄️ output_format='data' デフォルト**: ツールは生データと `bigquery_latency_ms` を返却。Orchestrator は Markdown 整形版を即返却。`synthesize_response=True` 時のみ追加 LLM 呼び出しで自然言語化。
+- **💰 Token Budget プール分離 (Phase 3-A)**: `chat` / `report` プールを独立管理。レポート 1 本生成でチャット枠が枯渇するリスクを解消。
+- **📊 アダプティブ UI**: ツール出力に応じてナラティブ・テーブル・チャート・`StrategyReportCard` を自動切替。
+- **⚔️ Reflection Loop**: 戦略経路 (`StrategyAgent`) は明示的な Reflection ノードを維持（最大 2 回リトライ）。チャット経路は LLM の自然な tool_use 再試行に委ねる設計。
 
 ### 5. MLOps: プロンプトバージョニング、LLM I/Oロギング＆評価ゲート
 **ステータス**: ✅ 本番環境対応
@@ -664,15 +664,13 @@ PrefixCache.put(...)
    - 構造化データを自然な日本語レスポンスに変換
    - ナラティブ（`sentence`）と表形式（`table`）の出力形式の両方をサポート
 
-5. **🤖 自律型マルチエージェント推論** (`app/services/agents/`)
-   - **Supervisorアーキテクチャ**: `SupervisorAgent` を介して、クエリのルーティングとデータ取得を分離。
-   - **特化型エージェント**: 
-     - `StatsAgent`: 一般的な統計クエリとトレンド分析を担当。
-     - `MatchupAgent`: 特定の選手間対決の履歴比較を担当。
-   - **LangGraphの実装**: 各エージェントが独自の「Oracle」（計画）、「Executor」（データ取得）、「Synthesizer」（最終報告）ループを維持。
-   - **フィードバックループ**: 最初のデータ取得が不十分な場合、エージェントが自己修正して複数のツール呼び出しを実行。
-   - **Reflection Loop**: 各エージェントに`reflection`ノードを追加。Executor実行時のエラー（SQL構文エラー、空結果）を検知し、診断コンテキストをLLMにフィードバックして自己修正。無限ループ防止のための最大リトライ制限付き。
-   - **統合UI**: 構造化されたチャート/テーブルメタデータをフロントエンドコンポーネントに直接流し込み。
+5. **🤖 自律型推論 — `ChatOrchestrator` + `StrategyAgent`**（2026-05-17 リファクタ）
+   - **`ChatOrchestrator`** (`app/services/chat_orchestrator.py`): 単一クラスエンジン。素の `google-genai` SDK + `tool_use` ループ。旧 `SupervisorAgent` + 4 LangGraph sub-agent (Batter / Pitcher / Matchup / Stats) を畳んだ。外側 LLM が NLU を担当し、構造化引数で共通ツールを呼ぶ。
+   - **`StrategyAgent`** (`app/services/agents/strategy_agent.py`): 唯一残った LangGraph エージェント。5 ノード (Planner → ParallelExecutor → Aggregator → Reflection → Strategist) で横断的な戦略レポートを生成。
+   - **共通ツール** (`app/services/tools/`): 両経路で共有。ツールは生データを返し (`output_format='data'`)、応答合成は Orchestrator/Agent の責務。
+   - **Reflection**: チャット経路は Reflection ノードを廃止し、LLM の自然な tool_use 再試行に委ねる設計。戦略経路は明示的 Reflection ノードを維持 (最大 2 回リトライ)。
+   - **Token Budget プール分離 (Phase 3-A)**: `token_budget_service.py` で chat / report プールを独立追跡。
+   - **統合UI**: 構造化されたチャート/テーブル/マッチアップカードのメタデータをフロントエンドコンポーネントに直接流し込み。
 
 ### MLモデルアーキテクチャ: 3層分離アーキテクチャ
 

--- a/README_ai_architecture.md
+++ b/README_ai_architecture.md
@@ -1,0 +1,521 @@
+# Diamond Lens - AI / LLM Harness Architecture
+
+> Diamond Lens における AI/LLM 機能と、その品質・コスト・安全性を担保する harness 層の設計図でございます。
+> 既存の `README.md` / `README_JP.md` / `README_architecture.md` がプロダクト・インフラ全体を扱うのに対し、本ドキュメントは **AI コア部分のみ** を集中的に解説いたします。
+
+---
+
+## 目次
+
+| Section | 内容 |
+|---|---|
+| [1. 全体像](#1-全体像) | AI コアと harness 層の俯瞰図 |
+| [2. LLM Gateway](#2-llm-gateway-層) | 全 LLM 呼び出しの単一窓口 |
+| [3. Logging & Cost Tracking](#3-logging--cost-tracking-層) | BigQuery への観測ログ |
+| [4. Prompt Registry](#4-prompt-registry-層) | プロンプト版管理（active / shadow） |
+| [5. Judge Layer](#5-judge-layer-llm-as-a-judge) | 5 種の LLM Judge |
+| [6. Eval Pipeline](#6-eval-pipeline-ゴールデンデータセット) | ゴールデンセット & 回帰評価 |
+| [7. Security Guardrail](#7-security-guardrail) | プロンプトインジェクション対策 |
+| [8. Reflection Loop](#8-reflection-loop) | 自己修正フロー |
+| [9. Request Lifecycle](#9-request-lifecycle-1-クエリの旅) | 1 クエリの旅 |
+| [9.5. Token Budget プール分離](#95-token-budget-プール分離-phase-3-a) | chat / report 別予算管理 (Phase 3-A) |
+| [10. CI/CD 統合状況](#10-cicd-統合状況とギャップ) | 現状とギャップ |
+
+---
+
+## 1. 全体像
+
+> **2026-05-17 改訂**: チャット側を **`ChatOrchestrator` (素の Gemini SDK + tool_use ループ)** へ刷新。旧 `SupervisorAgent` + 4 sub-agent (Batter/Pitcher/Matchup/Stats) の LangGraph 構造を畳み、LLM 呼び出し回数を 4 回→ 2 回 (synthesize_response=False で 1 回) に削減。`StrategyAgent` のみ LangGraph 維持。
+
+AI コアは **「Gateway を必ず通す → 自動でログ & コスト計測 → 別軸で Judge が品質採点」** という三層構造でございます。
+
+```mermaid
+graph TB
+    User[User Query]
+
+    subgraph Guardrail["Security Guardrail (前段防御)"]
+        InjCheck[Injection 検知]
+        OffTopic[Off-topic 検知]
+    end
+
+    subgraph ChatPath["Chat Path (新)"]
+        ChatOrch["ChatOrchestrator<br/>素の Gemini SDK + tool_use loop<br/>(synthesize_response=False がデフォルト)"]
+    end
+
+    subgraph StrategyPath["Strategy Path"]
+        StrategyAgent["StrategyAgent (LangGraph)<br/>Planner → ParallelExec → Aggregator → Reflection → Strategist"]
+    end
+
+    subgraph CommonTools["Common Tools (backend/app/services/tools/)"]
+        T1[get_batter_stats_tool]
+        T2[get_pitcher_stats_tool]
+        T3[mlb_matchup_history_tool]
+        T4[mlb_matchup_analytics_tool]
+        T5["query_semantic_metrics_tool<br/>(USE_SEMANTIC_LAYER=true 時)"]
+    end
+
+    subgraph Gateway["LLM Gateway 層 (単一窓口)"]
+        CallGemini["call_gemini()"]
+        LCCallback["LangchainUsageCallback<br/>(pool='chat' / 'report')"]
+        PromptReg[Prompt Registry<br/>active / shadow]
+    end
+
+    subgraph Budget["Token Budget (Phase 3-A)"]
+        BudgetChat["chat プール<br/>500K/day"]
+        BudgetReport["report プール<br/>500K/day"]
+        BudgetShared["shared hard cap<br/>1M/day"]
+    end
+
+    subgraph Observability["Observability 層 (BQ)"]
+        LogService[LLMLoggerService<br/>非同期書込]
+        BQLogs[(BQ: llm_interaction_logs<br/>tokens / cost / latency / trace_id / pool)]
+    end
+
+    subgraph Judges["Judge Layer (品質採点・非同期)"]
+        J1[#1 ParseJudge]
+        J2[#2 SynthesizerJudge]
+        J3[#3 ReflectionJudge]
+        J4[#4 RoutingJudge]
+        J5[#5 DriftAlertJudge]
+    end
+
+    User --> Guardrail
+    Guardrail -->|pass / chat| ChatOrch
+    Guardrail -->|pass / strategy| StrategyAgent
+    ChatOrch --> CommonTools
+    StrategyAgent --> CommonTools
+    ChatOrch --> Gateway
+    StrategyAgent --> Gateway
+    Judges --> Gateway
+
+    Gateway --> Budget
+    Gateway --> LogService
+    LogService --> BQLogs
+```
+
+### 設計の要
+
+| 原則 | 実装 |
+|---|---|
+| LLM を呼ぶ＝Gateway を通る＝必ずログが書かれる | `call_gemini()` / `LangchainUsageCallback` / `ChatOrchestrator` の各 LLM 呼び出しが `LLMLogEntry` を `try/finally` で書く |
+| ユーザー質問の NLU は **Orchestrator の LLM 自身** が責任を持つ | ツール内 `_parse_query_with_llm` (NLU 用 LLM) は廃止。LLM が tool_use で構造化引数を直接生成 |
+| ツールは「動的 SQL → BQ フェッチ → 生データ返却」のみ | `output_format='data'` がデフォルト。ツール内の応答生成 LLM は呼ばない |
+| Token Budget はチャット / レポートで分離 | プール別に超過判定し、レポート 1 本がチャット枠を枯渇させない (Phase 3-A) |
+
+---
+
+## 2. LLM Gateway 層
+
+ファイル: [backend/app/services/llm_gateway_service.py](backend/app/services/llm_gateway_service.py)
+
+### 役割
+
+| 機能 | 実装 |
+|---|---|
+| Gemini 呼び出しの単一窓口 | `call_gemini(prompt, model, response_mime_type, feature, ...)` |
+| トークン抽出 | `response.usage_metadata` から `input_tokens / output_tokens / cached_tokens` |
+| コスト計算 | `PRICING` マップ（モデル別 USD 単価）から `estimated_cost_usd` を算出 |
+| LangChain 経路の補足 | `LangchainUsageCallback` が `on_llm_end` を捕捉して同等のログを書く |
+| エラーハンドリング | 例外を握り `None` を返す。ログには `error_type / error_message` を残す |
+
+### 価格表（[llm_gateway_service.py:38-49](backend/app/services/llm_gateway_service.py#L38-L49)）
+
+| モデル | input / 1M | output / 1M | cached / 1M |
+|---|---|---|---|
+| gemini-2.5-flash | $0.30 | $2.50 | $0.03 |
+| gemini-2.0-flash | $0.10 | $0.40 | $0.025 |
+
+### 経路 2 系統
+
+```mermaid
+flowchart LR
+    A[Caller: ai_service / judge / etc.] -->|直接| Gateway["call_gemini()"]
+    B[Caller: LangChain Agent<br/>ChatGoogleGenerativeAI] -->|callbacks=| LCCB[LangchainUsageCallback]
+    Gateway --> Log[LLMLoggerService.log]
+    LCCB --> Log
+    Log --> BQ[(BQ Streaming Insert)]
+```
+
+LangChain は SDK ラッパー越しに呼ぶため `call_gemini()` を経由いたしません。同等の観測性を保つため `LangchainUsageCallback` を別途用意し、`on_llm_end` で `usage_metadata` を抽出いたします。
+
+---
+
+## 3. Logging & Cost Tracking 層
+
+ファイル: [backend/app/services/llm_logger_service.py](backend/app/services/llm_logger_service.py)
+テーブル: `tksm-dash-test-25.mlb_analytics_dash_25.llm_interaction_logs`
+
+### スキーマ（抜粋）
+
+| フィールド | 用途 | 埋まり方 |
+|---|---|---|
+| `log_id`, `timestamp` | 識別 | `LLMLogEntry.__init__` で自動生成 |
+| `trace_id`, `request_id`, `user_id`, `endpoint`, `session_id` | 横断追跡 | **ContextVar から auto-populate** (caller の明示指定で上書き可) |
+| `feature` | 集計軸 (例: `chat_orchestrator_iter_0`, `strategy_report`, `analytics_batter`) | caller が明示 |
+| `user_query`, `resolved_query` | 入力側の文脈 | caller が `call_gemini(user_query=...)` で渡す |
+| `prompt_name`, `prompt_version` | プロンプト版追跡 | caller が `get_prompt_version()` 経由で渡す |
+| `parsed_query_type`, `parsed_metrics`, `parsed_player_name`, `parsed_season` | LLM のパース結果 | `call_gemini(post_response_hook=...)` で caller が転記 / Orchestrator は tool_use args から自動転記 |
+| `routing_result` | (旧 Supervisor) ルーティング結果 | Phase 2 で実質非使用 |
+| `response_answer`, `response_has_table`, `response_has_chart` | 出力 | `call_gemini` が自動 (`response_answer`)、caller が明示 (others) |
+| `model`, `input_tokens`, `output_tokens`, `cached_tokens`, `estimated_cost_usd` | コスト追跡 | `usage_metadata` から自動 |
+| `llm_latency_ms`, `total_latency_ms`, `bigquery_latency_ms` | パフォーマンス | LLM/全体時間は自動、BQ 時間は tool 戻り値経由 (ContextVar が StreamingResponse 配下で伝搬不能のため) |
+| `is_retry`, `retry_count`, `retry_reason`, `reflection_pre_query`, `reflection_post_query`, `synthesizer_source_data` | Reflection Loop | **StrategyAgent のみ** 使用 (ChatOrchestrator は Reflection ノードを持たない) |
+| `user_rating`, `feedback_category`, `feedback_reason` | HITL フィードバック | フィードバック API 経由で後追い UPDATE |
+| `success`, `error_type`, `error_message` | 失敗観測 | `try/finally` で必ず記録 |
+
+### 書き込みフロー
+
+```mermaid
+sequenceDiagram
+    participant Caller as Service Layer
+    participant GW as call_gemini()
+    participant LogSvc as LLMLoggerService
+    participant Thread as Daemon Thread
+    participant BQ as BigQuery
+
+    Caller->>GW: prompt + feature + user_id
+    GW->>GW: Gemini API call (try)
+    GW->>GW: token / cost 抽出 (try)
+    GW->>LogSvc: log(entry)  [finally]
+    LogSvc->>Thread: spawn(daemon=True)
+    LogSvc-->>GW: return immediately
+    GW-->>Caller: text or None
+    Thread->>BQ: insert_rows_json (非同期)
+```
+
+ログ書込は別スレッドのため、API レスポンス速度に影響を与えません。フィードバック更新は Streaming Buffer の UPDATE 制約のため、`[FEEDBACK_UPDATE]` プレースホルダ行を別途 INSERT する設計でございます。
+
+---
+
+## 4. Prompt Registry 層
+
+ファイル: [backend/app/config/prompt_registry.py](backend/app/config/prompt_registry.py)
+プロンプト本体: [backend/app/prompts/](backend/app/prompts/)
+
+プロンプトを **コードから外出し** し、active / shadow の 2 経路で版管理いたします。
+
+### 登録済みプロンプト（2026-05 時点）
+
+| prompt_name | active | shadow | 用途 |
+|---|---|---|---|
+| `parse_query` | v1 | — | 自然言語 → 構造化クエリ (legacy: batter_services._parse_query_with_llm 用) |
+| `generate_response` | v1 | — | テーブル/チャート＋自然文応答 |
+| `routing` | v2 | v2 | (旧) Supervisor のルート決定。Phase 2 で ChatOrchestrator に置換 |
+| `strategy_planner` | v1 | — | Strategy Agent のプラン生成 |
+| `strategy_synthesizer` | v1 | — | Strategy Agent のレポート合成 |
+| `oracle_semantic` | v1 | — | Semantic Layer 用 Oracle（USE_SEMANTIC_LAYER=true 時に Cloud Run で使用） |
+| `chat_orchestrator_system` | v1 | — | ChatOrchestrator のシステムプロンプト (`_build_system_prompt()` で動的構築) |
+
+### 使い方
+
+```python
+# active 版（本番経路）
+prompt = get_prompt("parse_query", query="大谷のHR数は？", season=2025)
+
+# shadow 版（並走評価用）
+shadow_prompt = get_prompt("parse_query", role="shadow", query="大谷のHR数は？")
+```
+
+`{key}` 形式のプレースホルダのみを明示的に置換するため、JSON テンプレート内の `{` `}` を壊しません。
+
+---
+
+## 5. Judge Layer (LLM-as-a-Judge)
+
+AI コアの 5 つの判断ポイントに対し、それぞれ専用の LLM Judge を配置しております。全 Judge は **Gateway 経由** で Gemini を呼ぶため、Judge 自身の呼び出しコストも `llm_interaction_logs` に記録されます。
+
+```mermaid
+graph LR
+    Q[User Query] --> R{Supervisor Routing}
+    R -->|採点| J4[#4 RoutingJudge]
+    R --> P[LLM Parser]
+    P -->|採点| J1[#1 ParseJudge]
+    P --> Ref{Reflection?}
+    Ref -->|採点| J3[#3 ReflectionJudge]
+    Ref --> S[Synthesizer]
+    S -->|採点| J2[#2 SynthesizerJudge]
+
+    D[Data Drift Detector] -->|採点| J5[#5 DriftAlertJudge]
+```
+
+### Judge 一覧
+
+| # | Judge | ファイル | 評価対象 | 主要次元 (1-5) | 閾値 |
+|---|---|---|---|---|---|
+| 1 | **Parse Judge** | [llm_judge_service.py](backend/app/services/llm_judge_service.py) | 自然言語 → 構造化クエリのパース精度 | query_type / metrics / entity / intent | overall ≥ 3.5 |
+| 2 | **Synthesizer Judge** | [synthesizer_judge_service.py](backend/app/services/synthesizer_judge_service.py) | レポート・回答テキストの品質 | 5 次元（factual / readability / usefulness 等） | — |
+| 3 | **Reflection Judge** | [reflection_judge_service.py](backend/app/services/reflection_judge_service.py) | 自己修正トリガーと修正策の妥当性 | 過修正の有無を含む | — |
+| 4 | **Routing Judge** | [routing_judge_service.py](backend/app/services/routing_judge_service.py) | Supervisor の routing 判断 | batter / pitcher / stats / matchup の分類精度 | — |
+| 5 | **Drift Alert Judge** | [drift_alert_judge_service.py](backend/app/services/drift_alert_judge_service.py) | データドリフト統計検知のセカンドオピニオン | アクションが本当に必要か | ACTION_THRESHOLD ≥ 3.5 |
+
+### Parse Judge の評価出力（例）
+
+```json
+{
+  "case_id": "GD-001",
+  "query_type_accuracy": 5,
+  "metrics_accuracy": 4,
+  "entity_resolution": 5,
+  "intent_understanding": 5,
+  "overall_score": 4.75,
+  "passed": true,
+  "reasoning": "メトリクスに不要な runs が追加されているが本質は正しい",
+  "failure_category": "over_extraction"
+}
+```
+
+`failure_category` は `unregistered_metric_key / entity_resolution_error / missing_context / schema_violation / over_extraction / type_misclassification` から 1 つを選択させ、後工程で集計いたします。
+
+---
+
+## 6. Eval Pipeline (ゴールデンデータセット)
+
+オフライン評価の構造でございます。
+
+```mermaid
+flowchart TB
+    Prod[Production traffic<br/>llm_interaction_logs] -->|HITL 抽出| Pending[pending_review.json]
+    Pending -->|人手レビュー| Approve[approve_to_golden.py]
+    Approve --> Golden[(golden_dataset.json<br/>現在 14 ケース)]
+
+    Golden --> RunEval[evaluate_with_llm_judge.py]
+    RunEval --> Parser1[Batting Parser]
+    RunEval --> Parser2[Pitching Parser]
+    Parser1 --> Rule[Rule-Based Eval<br/>フィールド完全一致]
+    Parser2 --> Rule
+    Parser1 --> Judge[LLM Judge<br/>4 次元採点]
+    Parser2 --> Judge
+    Rule --> Results[llm_judge_results_*.json]
+    Judge --> Results
+
+    GateScript[evaluate_llm_accuracy.py<br/>CI Gate 80% 閾値] --> Golden
+    GateScript --> ExitCode{exit 0 / 1}
+```
+
+### ファイル
+
+| ファイル | 役割 |
+|---|---|
+| [backend/tests/golden_dataset.json](backend/tests/golden_dataset.json) | 14 ケース（季打 / 季投 / splits / 通算） |
+| [backend/tests/pending_review.json](backend/tests/pending_review.json) | HITL レビュー待ちキュー |
+| [backend/scripts/extract_golden_dataset.py](backend/scripts/extract_golden_dataset.py) | BQ ログから候補を抽出 |
+| [backend/scripts/approve_to_golden.py](backend/scripts/approve_to_golden.py) | レビュー済みを Golden へ昇格 |
+| [backend/scripts/evaluate_with_llm_judge.py](backend/scripts/evaluate_with_llm_judge.py) | ルールベース + Judge 並列実行 |
+| [backend/scripts/evaluate_llm_accuracy.py](backend/scripts/evaluate_llm_accuracy.py) | CI 用ゲート（accuracy ≥ 80% で exit 0） |
+| [backend/tests/test_llm_evaluation.py](backend/tests/test_llm_evaluation.py) | Golden の構造検証（LLM 非依存） |
+
+### テストケース構造
+
+```json
+{
+  "id": "GD-001",
+  "category": "season_batting",
+  "query": "2025年のホームラン王は誰？",
+  "season": null,
+  "expected": {
+    "query_type": "season_batting",
+    "metrics_contains": ["homerun"],
+    "season": 2025,
+    "order_by": "homerun",
+    "name": null
+  }
+}
+```
+
+---
+
+## 7. Security Guardrail
+
+ファイル: [backend/app/services/security_guardrail.py](backend/app/services/security_guardrail.py)
+
+LLM に到達する**前段**でユーザー入力を 3 層で検査いたします。
+
+```mermaid
+graph LR
+    Input[User Input] --> L1{Layer 1<br/>Injection 正規表現}
+    L1 -->|hit| Block1[Block + Log]
+    L1 -->|pass| L2{Layer 2<br/>Off-topic 検知}
+    L2 -->|hit| Block2[Block + Log]
+    L2 -->|pass| L3{Layer 3<br/>長さ・構造異常}
+    L3 -->|hit| Block3[Block + Log]
+    L3 -->|pass| AICore[AI Core へ通過]
+```
+
+| Layer | 対象 |
+|---|---|
+| 1 | "ignore previous instructions" 等の上書き試行（日英両対応） |
+| 2 | MLB ドメイン外（料理・天気・コーディング依頼など）の検知 |
+| 3 | 異常な入力長・制御文字・反復構造 |
+
+ブロック時も `llm_interaction_logs` に `error_type = guardrail_*` で記録され、傾向を分析可能でございます。
+
+---
+
+## 8. Reflection Loop
+
+> **2026-05-17 改訂**: チャット側 (`ChatOrchestrator`) は Reflection ノードを廃止し、LLM の自然な再試行能力に委ねる設計に変更。`StrategyAgent` (LangGraph) のみ明示的な Reflection ノードを維持。
+
+### StrategyAgent の Reflection (現役)
+
+`should_reflect()` でリトライ要否を判定し、必要なら **クエリを書き直して再実行** する自己修正フローでございます。
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Planner as Planner
+    participant Exec as ParallelExecutor
+    participant Agg as Aggregator
+    participant Reflect as Reflection
+    participant Judge3 as ReflectionJudge
+    participant Strategist
+    participant Logger as LLMLogger
+
+    User->>Planner: 戦略レポート要求
+    Planner->>Exec: 並列ツール呼び出し計画
+    Exec->>Agg: 結果集約
+    Agg->>Reflect: should_reflect?
+    alt 空結果 / SQL エラー
+        Reflect->>Reflect: クエリ書き直し
+        Reflect->>Exec: 再試行 (retry_count++)
+        Reflect->>Judge3: 修正策の妥当性採点
+    end
+    Agg->>Strategist: レポート生成
+    Strategist->>Logger: is_retry / retry_count /<br/>reflection_pre_query / post_query を記録
+```
+
+### ChatOrchestrator の挙動 (Phase 2.5 以降)
+
+ChatOrchestrator は Reflection ノードを持たず、以下のフローで自然な再試行を実現いたします:
+
+1. LLM #1 が tool_use で構造化引数を生成
+2. ツール実行 → 空結果やエラー
+3. LLM が結果を見て自発的に引数を見直し、再度 tool_use (MAX_TOOL_ITERATIONS=6 まで)
+4. 必要データが揃ったら `final_answer`
+
+明示的な Reflection ノードを置かない理由は **「LLM が自分で再試行判断する方が柔軟」** だからでございます。system prompt に「空結果やエラー時は引数を見直して 1〜2 回まで再試行してください」と明記。
+
+---
+
+## 9. Request Lifecycle (1 クエリの旅)
+
+> **2026-05-17 改訂**: ChatOrchestrator 経路に刷新。LLM 呼び出しが旧 4 回 → 新 1 回 (synthesize_response=False 時) に削減。
+
+### チャット経路 (`POST /api/v1/qa/agentic-stats-stream`)
+
+```mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant API as FastAPI Endpoint
+    participant Guard as Guardrail
+    participant Orch as ChatOrchestrator
+    participant Tool as get_batter_stats_tool
+    participant BQ as llm_interaction_logs
+
+    FE->>API: query + trace_id (header)
+    API->>API: set_session_id() / reset_bq_latency_ms()
+    API->>Guard: check(query)
+    alt blocked
+        Guard->>BQ: log(error_type=guardrail_*)
+        Guard-->>FE: 4xx
+    end
+    Guard->>Orch: run_stream(query)
+    Orch->>Orch: LLM #1: tool_use で構造化引数生成<br/>(name=..., season=..., metrics=[...])
+    Orch->>BQ: log (feature=chat_orchestrator_iter_0,<br/>parsed_player_name / parsed_season etc.)
+    Orch->>Tool: invoke(structured_args, output_format='data')
+    Tool->>Tool: 動的 SQL 構築
+    Tool->>Tool: BigQuery クエリ実行
+    Tool-->>Orch: {data, bigquery_latency_ms}
+    Note over Orch: synthesize_response=False<br/>→ LLM #2 を呼ばず即 return
+    Orch-->>API: final_answer event<br/>(answer=Markdown 整形, bigquery_latency_ms)
+    API->>BQ: log (endpoint summary,<br/>total_latency_ms / bigquery_latency_ms)
+    API-->>FE: SSE stream
+    Note over BQ: 同一 trace_id で 2 行紐づく<br/>(orchestrator + endpoint summary)
+```
+
+### Strategy 経路 (`POST /api/v1/strategy-report`)
+
+`StrategyAgent` (LangGraph) は Planner → ParallelExecutor → Aggregator → Reflection → Strategist の 5 ノード構成を維持。
+
+### ContextVar による横断トレース
+
+`trace_id` / `request_id` / `user_id` / `endpoint` / `session_id` は `backend/app/middleware/request_context.py` の ContextVar で各ステージに伝搬されるため、1 クエリで発生した複数の LLM 呼び出しを BQ 側で `JOIN` できます。`LLMLogEntry.__init__` で auto-populate されるため caller の明示指定は不要でございます。
+
+---
+
+## 9.5. Token Budget プール分離 (Phase 3-A)
+
+ファイル: [backend/app/services/token_budget_service.py](backend/app/services/token_budget_service.py)
+
+**Phase 3-A** で Token Budget を **chat / report の 2 プール** に分離いたしました。レポート 1 本生成 (StrategyAgent は数千トークン消費) でチャット枠も枯渇する旧設計の問題を解消。
+
+### プール構成
+
+| プール | 用途 | 既定上限 (settings.py) |
+|---|---|---|
+| `chat` | ChatOrchestrator 経由の LLM 呼び出し | `LLM_DAILY_TOKEN_BUDGET_CHAT=500_000` tokens/day |
+| `report` | StrategyAgent / strategy-report エンドポイント / tactics 等 | `LLM_DAILY_TOKEN_BUDGET_REPORT=500_000` tokens/day |
+| `shared` | 上記合算の hard cap (旧 `LLM_DAILY_TOKEN_BUDGET` 互換) | `LLM_DAILY_TOKEN_BUDGET=1_000_000` tokens/day |
+
+### API
+
+```python
+svc = get_token_budget_service()
+
+# 計上
+svc.record_usage(tokens=1234, pool="chat")
+svc.record_usage(tokens=5678, pool="report")
+
+# 判定 (プール超過 OR shared 超過のいずれかで True)
+svc.is_budget_exceeded(pool="chat")
+svc.is_budget_exceeded(pool="report")
+
+# 残量
+svc.get_remaining(pool="chat")
+```
+
+### 各 caller のプール指定
+
+| 呼び出し元 | pool |
+|---|---|
+| `ChatOrchestrator` (各 LLM 呼び出し後) | `"chat"` |
+| `LangchainUsageCallback(feature="strategy_report", pool="report")` | `"report"` |
+| `LangchainUsageCallback(feature="strategy_tactics", pool="report")` | `"report"` |
+| `ai_analytics_endpoints` の budget チェック | `is_budget_exceeded("chat")` |
+| `strategy_report_endpoints` の budget チェック | `is_budget_exceeded("report")` |
+
+ログには `pool` フィールドが入る `token_budget_recorded` イベントが構造化記録されます。
+
+---
+
+## 10. CI/CD 統合状況とギャップ
+
+### 現状
+
+| 項目 | 状態 | 場所 |
+|---|---|---|
+| Unit test | コメントアウト | [cloudbuild.yaml:6-16](cloudbuild.yaml#L6-L16) |
+| Schema validation gate | コメントアウト | [cloudbuild.yaml:20-32](cloudbuild.yaml#L20-L32) |
+| **LLM accuracy gate** | **コメントアウト** | [cloudbuild.yaml:37-50](cloudbuild.yaml#L37-L50) |
+| ML data drift gate | コメントアウト | [cloudbuild.yaml:53-66](cloudbuild.yaml#L53-L66) |
+| Backend / Frontend deploy | 稼働中 | [cloudbuild.yaml:176-294](cloudbuild.yaml#L176-L294) |
+
+評価スクリプト自体は完成しておりますが、Cloud Build の該当ステップが**丸ごとコメントアウト**されているため、現状 CI ゲートとしては機能しておりません。
+
+### 未着手の領域
+
+| 領域 | 内容 |
+|---|---|
+| baseline 比較 | 前回スコアとの差分による回帰検知（`-2%` 劣化で fail 等） |
+| per_category recall / confusion matrix | カテゴリ別精度の可視化 |
+| Judge 結果の BQ 化 | 現在は JSON ファイル出力。BQ テーブル化で時系列追跡が可能になる |
+| 自由文出力への Judge 適用拡張 | 現状 Parse Judge は構造化出力のみ。chat 自由文への rubric ベース Judge は未実装 |
+| しきい値の校正 | `PASS_THRESHOLD=3.5`, `SIMILARITY_THRESHOLD=0.15`, PSI `0.1 / 0.2` は経験則 |
+
+---
+
+## 関連ドキュメント
+
+- [README.md](README.md) — プロダクト全体（英語）
+- [README_JP.md](README_JP.md) — プロダクト全体（日本語）
+- [README_architecture.md](README_architecture.md) — システム・インフラ全体
+- 本ドキュメント — AI / LLM レイヤー専用

--- a/README_architecture.md
+++ b/README_architecture.md
@@ -49,14 +49,11 @@ subgraph "Application Layer - Cloud Run"
         Frontend[mlb-diamond-lens-frontend<br/>React + Vite<br/>User dashboard]
         MCPServer[MCP Server<br/>Model Context Protocol<br/>Claude Desktop/Cursor]
         
-        subgraph "AI Core"
+        subgraph "AI Core (Refactored 2026-05-17)"
             StandardAI[Standard AI Service<br/>Gemini 2.5 Flash<br/>Simple Q&A]
-            subgraph "Multi-Agent System"
-                Supervisor[SupervisorAgent<br/>Query Routing]
-                StatsAgent[StatsAgent<br/>Season Analytics]
-                MatchupAgent[MatchupAgent<br/>Matchup History]
-                StrategyAgent[StrategyAgent<br/>Strategy Analysis<br/>Parallel Fan-Out]
-            end
+            ChatOrch[ChatOrchestrator<br/>素の Gemini SDK + tool_use loop<br/>LLM 1 回 (synthesize_response=False)]
+            StrategyAgent[StrategyAgent<br/>LangGraph: Planner→ParallelExec→Aggregator→Reflection→Strategist]
+            CommonTools[Common Tools<br/>backend/app/services/tools/<br/>batter/pitcher/matchup × 2]
         end
     end
 
@@ -92,14 +89,13 @@ subgraph "Application Layer - Cloud Run"
     Frontend --> FirebaseAuth
     FirebaseAuth --> Backend
     Backend --> StandardAI
-    Backend --> Supervisor
+    Backend --> ChatOrch
+    Backend --> StrategyAgent
     MCPServer --> StandardAI
-    Supervisor --> StatsAgent
-    Supervisor --> MatchupAgent
-    Supervisor --> StrategyAgent
+    ChatOrch --> CommonTools
+    StrategyAgent --> CommonTools
     StandardAI --> Frontend
-    StatsAgent --> Frontend
-    MatchupAgent --> Frontend
+    ChatOrch --> Frontend
     StrategyAgent --> Frontend
 
     subgraph "ML Model Architecture (3-Layer Separation)"
@@ -235,7 +231,8 @@ predictions = await self._predict_with_vertex_ai(endpoint_id, instances)
 | **Backend** | FastAPI, Cloud Run | REST API for analytics |
 | **Frontend** | React + Vite, Cloud Run | User interface |
 | **MCP Server** | Model Context Protocol | Claude Desktop/Cursor integration |
-| **AI Agent** | LangGraph, Gemini 2.5 Flash | Multi-step reasoning & Tool use |
+| **AI Agent (Chat)** | ChatOrchestrator (raw `google-genai` SDK + tool_use loop), Gemini 2.5 Flash | Single-LLM-call chat (`synthesize_response=False`) |
+| **AI Agent (Strategy)** | LangGraph (StateGraph), Gemini 2.5 Flash | Plan-and-Execute + Parallel Fan-Out for strategy reports |
 | **MLOps** | Prompt Registry, Golden Dataset, BigQuery Logging | Prompt versioning, LLM evaluation gate, I/O observability |
 | **ML Monitoring** | Data Drift Service, Model Registry, GCS, BigQuery | Data drift detection (PSI/KS), model versioning & auto-baseline CI/CD gate |
 | **Stuff+/Pitching+/Pitching++** | XGBoost, Model Registry, BigQuery | Pitch quality evaluation, sequence context modeling, pre-computed rankings, real-time inference |
@@ -365,34 +362,51 @@ predictions = await self._predict_with_vertex_ai(endpoint_id, instances)
 
 **Why a separate Cloud Run service**: Keeps heavy dbt + MetricFlow dependencies out of the main backend image; lets the dbt project version (submodule SHA) be advanced independently of backend code releases; can be scaled, monitored, and IAM-restricted independently.
 
-### 6. Agentic AI System (Supervisor + LangGraph)
+### 6. Agentic AI System (ChatOrchestrator + StrategyAgent)
+
+> **2026-05-17 Refactored**: Chat path migrated from `SupervisorAgent` + 4 LangGraph sub-agents to a **single `ChatOrchestrator`** built on raw `google-genai` SDK with tool_use loop. Reduces LLM calls per chat request from 4 to 1 (`synthesize_response=False` default). `StrategyAgent` retains LangGraph.
+
+#### Chat Path (`ChatOrchestrator`)
 
 | Property | Value |
 |----------|-------|
-| **Architecture** | Supervisor + Specialized Agents |
-| **Core Engine** | LangGraph (StateGraph) |
-| **LLM Model** | Gemini 2.0/2.5 Flash |
-| **Supervisor** | `SupervisorAgent` - Parses intent and routes to Stats or Matchup |
-| **Specialized Agents** | `StatsAgent` (Season/Trend), `MatchupAgent` (Head-to-Head) |
-| **State Management** | `AgentState` (TypedDict with message history, UI meta, and specialized analytics data) |
-| **Nodes per Agent** | Oracle (Planning), Executor (Tool Execution), Reflection (Self-Correction), Synthesizer (Reporting) |
-| **Reflection Loop** | Detects SQL errors and empty results in Executor, feeds diagnostic context to LLM for self-correction (max 2 retries). Classifies errors as retryable (syntax, empty result) vs non-retryable (permission, timeout, schema) |
-| **Capabilities** | Intelligently handles complex vs specific queries, automated visualization, professional analyst reports, and autonomous error recovery |
-| **Frontend Sync** | Structured `matchupData` or `chartData` triggers specialized UI components |
-| **Streaming Mode** | Server-Sent Events (SSE) with real-time token and state updates via `/api/v1/qa/agentic-stats-stream` |
+| **Architecture** | Single Orchestrator + Common Tools (no sub-agents, no LangGraph) |
+| **Core Engine** | Raw `google-genai` SDK with `tool_use` loop (`MAX_TOOL_ITERATIONS=6`) |
+| **LLM Model** | Gemini 2.5 Flash |
+| **NLU** | Orchestrator's outer LLM extracts structured args via `tool_use` directly (no internal NLU LLM call) |
+| **Tool Set** | `backend/app/services/tools/`: `get_batter_stats_tool`, `get_pitcher_stats_tool`, `mlb_matchup_history_tool`, `mlb_matchup_analytics_tool` (legacy METRIC_MAP path) |
+| **Semantic Layer Path** | When `USE_SEMANTIC_LAYER=true`: swaps to `query_semantic_metrics_tool` (dbt MetricFlow). Cloud Run only (local lacks SA auth) |
+| **Tool Output Mode** | `output_format='data'` default — tool returns raw rows without internal LLM narration |
+| **Response Synthesis** | `synthesize_response=False` default — orchestrator returns Markdown-formatted tool data directly. `True` enables an extra LLM call to compose natural language |
+| **Token Budget Pool** | `chat` (Phase 3-A) |
+| **Capabilities** | Single-LLM-call chat, complex query routing via tool_use, automated visualization, table/chart/matchup card structured output |
+| **Streaming Mode** | Server-Sent Events (SSE) via `/api/v1/qa/agentic-stats-stream`. Maintains the legacy event contract (`routing`, `state_update`, `tool_start`, `tool_end`, `token`, `final_answer`) for frontend compatibility |
+
+#### Strategy Path (`StrategyAgent`, unchanged)
+
+| Property | Value |
+|----------|-------|
+| **Architecture** | LangGraph StateGraph (5 nodes) |
+| **Nodes** | Planner → ParallelExecutor → Aggregator → Reflection → Strategist |
+| **Reflection Loop** | Active. Detects empty results / SQL errors, rewrites the query, retries (max 2). Logged to BQ as `is_retry`, `retry_count`, `retry_reason` |
+| **Token Budget Pool** | `report` (Phase 3-A) |
+| **Endpoint** | `POST /api/v1/strategy-report` |
 
 ### 6.1. Real-Time Streaming Architecture (SSE)
+
+> **2026-05-17 Refactored**: Backend engine migrated from LangGraph `astream_events` to `ChatOrchestrator.run_stream()` (raw `google-genai` SDK). SSE event contract is preserved for frontend compatibility.
 
 | Property | Value |
 |----------|-------|
 | **Protocol** | Server-Sent Events (SSE) |
 | **Content-Type** | `text/event-stream` |
 | **Backend Engine** | FastAPI StreamingResponse + AsyncGenerator |
-| **LangGraph Integration** | `astream_events(version="v2")` for event streaming |
-| **Event Types** | `session_start`, `routing`, `state_update` (oracle, executor, synthesizer, reflection), `tool_start`, `tool_end`, `token`, `final_answer`, `stream_end`, `error` |
+| **Orchestrator Engine** | `ChatOrchestrator.run_stream()` — raw `google-genai` `generate_content_stream()` with tool_use loop |
+| **Event Types** | `routing` (agent_type='chat' fixed for compatibility), `state_update`, `tool_start`, `tool_end`, `token`, `final_answer`, `stream_end`, `error` |
 | **Frontend** | ReadableStream API with SSE parsing |
-| **UI Updates** | Real-time streaming status display: `準備中` → `質問を分析中 🤔` → `データ取得中 🔍` → `🔄 エラーを分析し、修正を試みています` (reflection) → `回答生成中 ✍️` |
+| **UI Updates** | Real-time streaming status display: `準備中` → `質問を分析中 🤔` → `データ取得中 🔍` → `回答生成中 ✍️` |
 | **Token Accumulation** | LLM tokens streamed incrementally and accumulated in frontend |
+| **BQ Latency Propagation** | Tool returns `bigquery_latency_ms` in its data dict → Orchestrator aggregates → passes via `final_answer` event → endpoint writes to `LLMLogEntry.bigquery_latency_ms` (ContextVar bypassed since it fails under StreamingResponse) |
 
 **Streaming Data Flow:**
 
@@ -401,8 +415,10 @@ sequenceDiagram
     participant User as ユーザー
     participant Frontend as React Frontend
     participant Backend as FastAPI Backend
-    participant LangGraph as LangGraph Agent
+    participant Orch as ChatOrchestrator
+    participant Tool as get_batter_stats_tool
     participant LLM as Gemini 2.5 Flash
+    participant BQ as BigQuery
 
     User->>Frontend: クエリ入力 & Enter
     Frontend->>Frontend: handleSendMessageStream()
@@ -410,58 +426,40 @@ sequenceDiagram
 
     Frontend->>Backend: POST /agentic-stats-stream
     activate Backend
-    Backend->>Backend: SupervisorAgent.route_query()
-    Backend-->>Frontend: event: routing<br/>data: {agent_type: "batter"}
-    Frontend->>Frontend: streamingStatus: 'batterエージェントで処理中'
+    Backend->>Backend: set_session_id()<br/>reset_bq_latency_ms()
+    Backend-->>Frontend: event: routing<br/>data: {agent_type: "chat"}
+    Frontend->>Frontend: streamingStatus: 'ChatOrchestratorで処理中'
 
-    Backend->>LangGraph: agent.app.astream_events()
-    activate LangGraph
-    LangGraph->>LangGraph: oracle node start
-    LangGraph-->>Backend: on_chain_start (oracle)
-    Backend-->>Frontend: event: state_update<br/>data: {node: "oracle"}
+    Backend->>Orch: run_stream(query)
+    activate Orch
+    Orch-->>Backend: event: state_update<br/>data: {node: "oracle"}
+    Backend-->>Frontend: event forwarded
     Frontend->>Frontend: streamingStatus: '質問を分析中 🤔'
 
-    LangGraph->>LangGraph: executor node start
-    LangGraph-->>Backend: on_chain_start (executor)
-    Backend-->>Frontend: event: state_update<br/>data: {node: "executor"}
-    Frontend->>Frontend: streamingStatus: 'データ取得中 🔍'
+    Orch->>LLM: generate_content_stream<br/>(with tool declarations)
+    LLM-->>Orch: function_call<br/>(structured args: name, season, metrics)
+    Orch->>Orch: Log LLM #1 to BQ<br/>(parsed_player_name, parsed_season, etc.)
 
-    LangGraph->>LLM: BigQuery tool call
+    Orch-->>Backend: event: tool_start<br/>data: {tool_name: "get_batter_stats_tool"}
+    Backend-->>Frontend: streamingStatus: 'データ取得中 🔍'
 
-    opt Reflection Loop (SQL error or empty result)
-        LangGraph->>LangGraph: reflection node start
-        LangGraph-->>Backend: on_chain_start (reflection)
-        Backend-->>Frontend: event: state_update<br/>data: {node: "reflection"}
-        Frontend->>Frontend: streamingStatus: '🔄 エラーを分析し、修正を試みています'
-        LangGraph->>LangGraph: oracle node (retry)
-        LangGraph->>LangGraph: executor node (retry)
-        LangGraph->>LLM: Corrected BigQuery tool call
-    end
+    Orch->>Tool: invoke(structured args, output_format='data')
+    Tool->>BQ: dynamic SQL query
+    BQ-->>Tool: rows
+    Tool-->>Orch: {data, bigquery_latency_ms}
 
-    LangGraph->>LangGraph: synthesizer node start
-    LangGraph-->>Backend: on_chain_start (synthesizer)
-    Backend-->>Frontend: event: state_update<br/>data: {node: "synthesizer"}
-    Frontend->>Frontend: streamingStatus: '回答生成中 ✍️'
+    Orch-->>Backend: event: tool_end<br/>data: {output_summary: "1件のデータを取得"}
 
-    LLM-->>LangGraph: token stream
-    loop トークンストリーミング
-        LangGraph-->>Backend: on_chat_model_stream
-        Backend->>Backend: accumulated_answer += token
-        Backend-->>Frontend: event: token<br/>data: {content: "大"}
-        Frontend->>Frontend: content += "大"
-        LangGraph-->>Backend: on_chat_model_stream
-        Backend-->>Frontend: event: token<br/>data: {content: "谷"}
-        Frontend->>Frontend: content += "谷"
-    end
+    Note over Orch: synthesize_response=False<br/>→ skip LLM #2
 
-    deactivate LangGraph
-    Backend->>Backend: ストリーミング完了
-    Backend-->>Frontend: event: final_answer<br/>data: {answer: "...", isTable: false}
-    Frontend->>Frontend: isStreaming: false<br/>streamingStatus: undefined
+    Orch->>Orch: _format_rows_as_markdown(tool_results)
+    Orch-->>Backend: event: final_answer<br/>{answer: "### Aaron Judge / 2024年...",<br/>bigquery_latency_ms: 1502}
+    deactivate Orch
+    Backend->>Backend: log_entry.bigquery_latency_ms = event['bigquery_latency_ms']<br/>token_budget.record_usage(pool="chat")
 
     Backend-->>Frontend: event: stream_end
     deactivate Backend
-    Frontend->>User: 完全な応答を表示
+    Frontend->>User: Markdown 整形応答を表示
 ```
 
 **Key Implementation Details:**

--- a/backend/app/api/endpoints/ai_analytics_endpoints.py
+++ b/backend/app/api/endpoints/ai_analytics_endpoints.py
@@ -14,6 +14,11 @@ from backend.app.services.ai_agent_service import run_mlb_agent
 from backend.app.services.llm_logger_service import get_llm_logger, LLMLogEntry
 from backend.app.config.prompt_registry import get_prompt_version
 from backend.app.middleware.request_id import get_request_id
+from backend.app.middleware.request_context import (
+    get_bq_latency_ms,
+    reset_bq_latency_ms,
+    set_session_id,
+)
 from backend.app.core.exceptions import PromptInjectionError
 from fastapi.responses import StreamingResponse
 from backend.app.utils.streaming import stream_json_events, format_sse
@@ -21,6 +26,7 @@ from backend.app.api.rate_limit import limiter
 from backend.app.config.settings import get_settings
 from backend.app.services.token_budget_service import get_token_budget_service
 from backend.app.services.bq_embedding_service import get_bq_embedding_service
+from backend.app.services.chat_orchestrator import ChatOrchestrator
 import asyncio
 import logging
 import time
@@ -68,10 +74,12 @@ async def get_player_stats_qna_endpoint(
     llm_logger = get_llm_logger()
     # セッションIDがない場合は新規作成
     session_id = request_body.session_id or str(uuid4())
+    set_session_id(session_id)
+    reset_bq_latency_ms()
 
     # トークンバジェットチェック
     token_budget = get_token_budget_service()
-    if token_budget.is_budget_exceeded():
+    if token_budget.is_budget_exceeded("chat"):
         return {
             "answer": "本日のAI分析サービスの利用上限に達しました。明日以降に再度お試しください。",
             "isTable": False,
@@ -297,10 +305,12 @@ async def get_agentic_stats_endpoint(
     """
     llm_logger = get_llm_logger()
     session_id = body.session_id or str(uuid4())
+    set_session_id(session_id)
+    reset_bq_latency_ms()
 
     # トークンバジェットチェック
     token_budget = get_token_budget_service()
-    if token_budget.is_budget_exceeded():
+    if token_budget.is_budget_exceeded("chat"):
         return {
             "query": body.query,
             "answer": "本日のAI分析サービスの利用上限に達しました。明日以降に再度お試しください。",
@@ -360,6 +370,7 @@ async def get_agentic_stats_endpoint(
 
         # ログエントリに結果を記録
         log_entry.total_latency_ms = elapsed_time * 1000
+        log_entry.bigquery_latency_ms = get_bq_latency_ms() or None
         log_entry.response_answer = answer
         log_entry.response_has_table = result_state.get("isTable", False)
         log_entry.response_has_chart = result_state.get("isChart", False)
@@ -479,10 +490,13 @@ async def get_agentic_stats_stream_endpoint(
     Server-Sent Events (SSE) を使用して、リアルタイムで結果を送信します。
     """
     session_id = body.session_id or str(uuid4())
+    # ContextVar にセット → 下流の call_gemini ログにも auto-populate される
+    set_session_id(session_id)
+    reset_bq_latency_ms()
 
     # トークンバジェットチェック
     token_budget = get_token_budget_service()
-    if token_budget.is_budget_exceeded():
+    if token_budget.is_budget_exceeded("chat"):
         from starlette.responses import JSONResponse
         return JSONResponse(
             status_code=503,
@@ -534,15 +548,26 @@ async def get_agentic_stats_stream_endpoint(
                 "message": "エージェントが質問を分析しています..."
             }
 
-            # Execute LangGraph streaming
-            from backend.app.services.ai_agent_service import run_mlb_agent_stream
-
-            async for event in run_mlb_agent_stream(
-                resolved_query,
-                request_id=log_entry.request_id,
-                session_id=session_id,
-                user_id=log_entry.user_id,
-            ):
+            # Feature flag による新旧切替（Phase 2 移行期間）
+            settings = get_settings()
+            if settings.use_legacy_chat_agent:
+                from backend.app.services.ai_agent_service import run_mlb_agent_stream
+                event_iter = run_mlb_agent_stream(
+                    resolved_query,
+                    request_id=log_entry.request_id,
+                    session_id=session_id,
+                    user_id=log_entry.user_id,
+                )
+            else:
+                orchestrator = ChatOrchestrator()
+                event_iter = orchestrator.run_stream(
+                    resolved_query,
+                    request_id=log_entry.request_id,
+                    session_id=session_id,
+                    user_id=log_entry.user_id,
+                )
+            
+            async for event in event_iter:
                 event_type = event.get("type")
                 # トークンを無条件で蓄積（current_node 等のフィルタは介在しない）
                 if event_type == "token":
@@ -559,6 +584,11 @@ async def get_agentic_stats_stream_endpoint(
                     log_entry.response_has_table = event.get("isTable", False)
                     log_entry.response_has_chart = event.get("isChart", False)
                     log_entry.llm_latency_ms = event.get("llm_latency_ms")
+                    # ChatOrchestrator が tool 戻り値から集計した BQ 時間を受け取る
+                    # (ContextVar 経由が StreamingResponse 配下で伝わらないための回避策)
+                    _event_bq_ms = event.get("bigquery_latency_ms")
+                    if _event_bq_ms:
+                        log_entry.bigquery_latency_ms = _event_bq_ms
                 yield event
 
             # Session end event
@@ -576,6 +606,12 @@ async def get_agentic_stats_stream_endpoint(
                 )
 
             log_entry.total_latency_ms = (time.time() - stream_start_time) * 1000
+            # event 経由で既にセット済みなら ContextVar からの上書きは不要
+            if log_entry.bigquery_latency_ms is None:
+                _bq_ms = get_bq_latency_ms()
+                log_entry.bigquery_latency_ms = _bq_ms if _bq_ms > 0 else None
+            logger.info(f"📊 Endpoint log: bigquery_latency_ms={log_entry.bigquery_latency_ms}, "
+                       f"total_latency_ms={log_entry.total_latency_ms:.0f}ms")
             llm_logger.log(log_entry)
 
         except PromptInjectionError as e:
@@ -583,6 +619,7 @@ async def get_agentic_stats_stream_endpoint(
             log_entry.error_type = "prompt_injection"
             log_entry.error_message = e.detected_pattern
             log_entry.total_latency_ms = (time.time() - stream_start_time) * 1000
+            log_entry.bigquery_latency_ms = get_bq_latency_ms() or None
             llm_logger.log(log_entry)
             yield {
                 "type": "error",
@@ -596,6 +633,7 @@ async def get_agentic_stats_stream_endpoint(
             log_entry.error_type = "stream_error"
             log_entry.error_message = str(e)
             log_entry.total_latency_ms = (time.time() - stream_start_time) * 1000
+            log_entry.bigquery_latency_ms = get_bq_latency_ms() or None
             llm_logger.log(log_entry)
             yield {
                 "type": "error",

--- a/backend/app/api/endpoints/strategy_report_endpoints.py
+++ b/backend/app/api/endpoints/strategy_report_endpoints.py
@@ -51,7 +51,7 @@ async def generate_strategy_report_endpoint(
     request_id = str(uuid4())
 
     token_budget = get_token_budget_service()
-    if token_budget.is_budget_exceeded():
+    if token_budget.is_budget_exceeded("report"):
         return {
             "request_id": request_id,
             "final_answer": "本日のAI分析サービスの利用上限に達しました。明日以降に再度お試しください。",
@@ -81,7 +81,7 @@ async def generate_strategy_report_endpoint(
             model="gemini-2.5-flash",
             google_api_key=os.getenv("GEMINI_API_KEY_V2"),
             temperature=0,
-            callbacks=[LangchainUsageCallback(feature="strategy_report", model="gemini-2.5-flash")],
+            callbacks=[LangchainUsageCallback(feature="strategy_report", model="gemini-2.5-flash", pool="report")],
         )
         agent = StrategyAgent(model=model)
         result = agent.run_structured(
@@ -1385,7 +1385,7 @@ async def get_tactics_endpoint(
 
     # Token budget
     token_budget = get_token_budget_service()
-    if token_budget.is_budget_exceeded():
+    if token_budget.is_budget_exceeded("report"):
         return {
             "request_id":   request_id,
             "side":         side,
@@ -1538,7 +1538,7 @@ target, alert, users, bolt, shield, crosshair
             model="gemini-2.5-flash",
             google_api_key=api_key,
             temperature=0,
-            callbacks=[LangchainUsageCallback(feature="strategy_tactics", model="gemini-2.5-flash")],
+            callbacks=[LangchainUsageCallback(feature="strategy_tactics", model="gemini-2.5-flash", pool="report")],
         )
         structured_llm = llm.with_structured_output(TacticsResponse)
 

--- a/backend/app/config/prompt_registry.py
+++ b/backend/app/config/prompt_registry.py
@@ -24,6 +24,7 @@ ACTIVE_VERSIONS: Dict[str, str] = {
     "strategy_planner": "v1",
     "strategy_synthesizer": "v1",
     "oracle_semantic": "v1",  # Phase 3: Semantic Layer 用 Oracle プロンプト（Phase 4で実利用）
+    "chat_orchestrator_system": "v1",  # Phase 2.5: ChatOrchestrator のシステムプロンプト (インライン定義)
 }
 
 SHADOW_VERSIONS: Dict[str, Optional[str]] = {
@@ -33,6 +34,7 @@ SHADOW_VERSIONS: Dict[str, Optional[str]] = {
     "strategy_planner": None,
     "strategy_synthesizer": None,
     "oracle_semantic": None,
+    "chat_orchestrator_system": None,
 }
 
 PromptRole = Literal["active", "shadow"]

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -99,8 +99,11 @@ class Settings(BaseSettings):
     rate_limit_player_stats_per_minute: int = 10
     rate_limit_agent_chat_per_minute: int = 5
     rate_limit_statistics_per_minute: int = 10
-    # LLM Token Budget: 日次トークン上限
+    # LLM Token Budget: 日次トークン上限 (合算 hard cap、既存互換)
     llm_daily_token_budget: int = 1_000_000  # 1M tokens/day
+    # Phase 3-A: プール別予算 (チャット / レポート)。合算は llm_daily_token_budget を超えない
+    llm_daily_token_budget_chat: int = 500_000   # ChatOrchestrator 経由
+    llm_daily_token_budget_report: int = 500_000  # StrategyAgent / strategy-report 経由
     # Rate Limit有効/無効（開発時にOFFにする用）
     rate_limit_enabled: bool = True
 
@@ -160,6 +163,17 @@ class Settings(BaseSettings):
     # ============================================================
     metricflow_server_url: Optional[str] = Field(default=None, validation_alias='METRICFLOW_SERVER_URL')
     use_semantic_layer: bool = False  # Phase 4 のカナリアフラグ。True にするとSemantic Layer経路に切替
+
+    # ============================================================
+    # Phase 2: ChatOrchestrator feature flag
+    # ============================================================
+    # True → 旧 LangGraph (SupervisorAgent + 5 sub-agents) を使用
+    # False → 新 ChatOrchestrator (素の Gemini SDK + tool_use loop) を使用
+    # 段階リリース完了後（Phase 2-G）にこのフラグごと削除予定。
+    use_legacy_chat_agent: bool = Field(
+        default=True, # 安全側: デフォルトは旧実装
+        description="Phase 2 移行期間中のみ使用する切替フラグ。Phase 2-G 完了で削除。",
+    )
 
 
     class Config:

--- a/backend/app/middleware/firebase_auth.py
+++ b/backend/app/middleware/firebase_auth.py
@@ -1,5 +1,6 @@
 import os
 import json
+from backend.app.middleware.request_context import set_user_id
 from backend.app.services.firebase_service import verify_firebase_token
 from backend.app.utils.structured_logger import get_logger
 from google.oauth2 import id_token
@@ -49,6 +50,7 @@ class FirebaseAuthMiddleware:
             scope["state"] = scope.get("state", {})
             scope["state"]["user_id"] = "dev_user"
             scope["state"]["user_email"] = "dev@localhost"
+            set_user_id("dev_user")
             await self.app(scope, receive, send)
             return
 
@@ -93,6 +95,7 @@ class FirebaseAuthMiddleware:
                 scope["state"] = scope.get("state", {})
                 scope["state"]["user_id"] = caller_email
                 scope["state"]["user_email"] = caller_email
+                set_user_id(caller_email)
                 logger.info("OIDC auth success", email=caller_email)
             except Exception as e:
                 logger.warning("OIDC auth failed", error=str(e))
@@ -107,6 +110,7 @@ class FirebaseAuthMiddleware:
             scope["state"] = scope.get("state", {})
             scope["state"]["user_id"] = decoded_token["uid"]
             scope["state"]["user_email"] = decoded_token.get("email", "")
+            set_user_id(decoded_token["uid"])
             logger.info("Auth success", user_id=decoded_token["uid"])
         except Exception as e:
             logger.warning("Auth failed", error=str(e))

--- a/backend/app/middleware/request_context.py
+++ b/backend/app/middleware/request_context.py
@@ -5,6 +5,13 @@ _user_id_var: ContextVar[str] = ContextVar("user_id", default="")
 # Snowflake-style 横断的 trace id。Phase 2 では request_id と並走させ、
 # Phase 3 以降で BQ ログ・SSE event payload にも流す。
 _trace_id_var: ContextVar[str] = ContextVar("trace_id", default="")
+# HTTP リクエストのエンドポイントパス。LLM ロガーが自動取得用に使う。
+_endpoint_var: ContextVar[str] = ContextVar("endpoint", default="")
+# session_id (フロントからの会話セッション識別子)。LLM ロガーが自動取得用に使う。
+_session_id_var: ContextVar[str] = ContextVar("session_id", default="")
+# BigQuery クエリの累計実行時間 (ms)。1 リクエスト内で複数 BQ クエリが走った場合は合算。
+# analytics service が add_bq_latency_ms() で加算し、エンドポイントが最後に読む。
+_bq_latency_ms_var: ContextVar[float] = ContextVar("bq_latency_ms", default=0.0)
 
 
 def get_request_id() -> str:
@@ -28,3 +35,31 @@ def get_trace_id() -> str:
 
 def set_trace_id(trace_id: str) -> None:
     _trace_id_var.set(trace_id)
+
+
+def get_endpoint() -> str:
+    return _endpoint_var.get()
+
+
+def set_endpoint(endpoint: str) -> None:
+    _endpoint_var.set(endpoint)
+
+
+def get_session_id() -> str:
+    return _session_id_var.get()
+
+
+def set_session_id(session_id: str) -> None:
+    _session_id_var.set(session_id)
+
+
+def get_bq_latency_ms() -> float:
+    return _bq_latency_ms_var.get()
+
+
+def add_bq_latency_ms(ms: float) -> None:
+    _bq_latency_ms_var.set(_bq_latency_ms_var.get() + ms)
+
+
+def reset_bq_latency_ms() -> None:
+    _bq_latency_ms_var.set(0.0)

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -1,6 +1,7 @@
 import uuid
 from backend.app.middleware.request_context import (
     get_request_id,  # noqa: F401  re-exported for backward compat
+    set_endpoint,
     set_request_id,
     set_trace_id,
 )
@@ -42,6 +43,7 @@ class RequestIDMiddleware:
         # ContextVar にセット → 同一リクエスト内のどこからでも取得可能
         set_request_id(request_id)
         set_trace_id(trace_id)
+        set_endpoint(scope.get("path", ""))
 
         # レスポンスヘッダに両方付与
         async def send_with_ids(message):

--- a/backend/app/services/agents/batter_agents.py
+++ b/backend/app/services/agents/batter_agents.py
@@ -37,7 +37,7 @@ class BatterAgent:
             )
         else:
             # 既存パス（query_maps.py 経由）
-            from ..ai_agent_service import get_batter_stats_tool
+            from ..tools import get_batter_stats_tool
             self.tools = [get_batter_stats_tool]
             self._semantic_tool_name = None
             self._metric_metadata = None
@@ -183,7 +183,7 @@ class BatterAgent:
                     args["output_format"] = "table"
                 result = query_semantic_metrics_tool.invoke(args)
             else:
-                from ..ai_agent_service import get_batter_stats_tool
+                from ..tools import get_batter_stats_tool
                 if force_table and tool_name == "get_batter_stats_tool":
                     args["output_format"] = "table"
                 result = get_batter_stats_tool.invoke(args)

--- a/backend/app/services/agents/matchup_agent.py
+++ b/backend/app/services/agents/matchup_agent.py
@@ -17,7 +17,7 @@ class MatchupAgent:
         self.raw_model = model  # For text generation (no tools)
         
         # Import and define tools first
-        from ..ai_agent_service import mlb_matchup_history_tool, mlb_matchup_analytics_tool
+        from ..tools import mlb_matchup_history_tool, mlb_matchup_analytics_tool
         self.tools = [mlb_matchup_history_tool, mlb_matchup_analytics_tool]
         
         # Then bind tools to model

--- a/backend/app/services/agents/pitcher_agents.py
+++ b/backend/app/services/agents/pitcher_agents.py
@@ -36,7 +36,7 @@ class PitcherAgent:
             )
         else:
             # 既存パス
-            from ..ai_agent_service import get_pitcher_stats_tool
+            from ..tools import get_pitcher_stats_tool
             self.tools = [get_pitcher_stats_tool]
             self._metric_metadata = None
 
@@ -187,7 +187,7 @@ class PitcherAgent:
                     args["output_format"] = "table"
                 result = query_semantic_metrics_tool.invoke(args)
             else:
-                from ..ai_agent_service import get_pitcher_stats_tool
+                from ..tools import get_pitcher_stats_tool
                 result = get_pitcher_stats_tool.invoke(tool_call["args"])
 
             # ===== エラー/空結果の検出 =====

--- a/backend/app/services/agents/strategy_agent.py
+++ b/backend/app/services/agents/strategy_agent.py
@@ -52,7 +52,7 @@ class StrategyAgent:
         self.raw_model = model  # ツールなし（最終レポート生成用）
 
         # 4つのツールをインポートしてバインド
-        from ..ai_agent_service import (
+        from ..tools import (
             get_batter_stats_tool,
             get_pitcher_stats_tool,
             mlb_matchup_history_tool,

--- a/backend/app/services/ai_agent_service.py
+++ b/backend/app/services/ai_agent_service.py
@@ -372,136 +372,148 @@ def mlb_stats_tool(query: str, season: int = None):
             "isTable": False
         }
 
+# ---- 共通ツールの再エクスポート（Phase 1 リファクタ） ----
+# 旧 import パス (`from backend.app.services.ai_agent_service import get_batter_stats_tool` 等)
+# を温存するため、tools/ パッケージから明示的に再エクスポートする。
+# Phase 2 でチャット側 LangGraph を剥がし切ったタイミングで削除予定。
+from .tools import (
+    get_batter_stats_tool,
+    get_pitcher_stats_tool,
+    mlb_matchup_history_tool,
+    mlb_matchup_analytics_tool,
+)
 
-@tool
-def get_batter_stats_tool(query: str, season: int = None, output_format: str = "sentence"):
-    """打撃成績（打率、本塁打、ランキング、状況別スタッツ等）を取得する専門ツール。output_formatに'table'を指定するとテーブル形式で返す"""
-    from .analytics.batter_services import get_ai_response_for_batter_stats
-    return get_ai_response_for_batter_stats(query, season, output_format=output_format)
+# [NOTE] These have been moved to tools/
+# Will be deleted after refactoring (May 17, 2026)
+# @tool
+# def get_batter_stats_tool(query: str, season: int = None, output_format: str = "sentence"):
+#     """打撃成績（打率、本塁打、ランキング、状況別スタッツ等）を取得する専門ツール。output_formatに'table'を指定するとテーブル形式で返す"""
+#     from .analytics.batter_services import get_ai_response_for_batter_stats
+#     return get_ai_response_for_batter_stats(query, season, output_format=output_format)
 
 
-@tool
-def get_pitcher_stats_tool(query: str, season: int = None):
-    """投球成績（防御率、奪三振、ランキング、状況別スタッツ等）を取得する専門ツール"""
-    from .analytics.pitcher_services import get_ai_response_for_pitcher_stats
-    return get_ai_response_for_pitcher_stats(query, season)
+# @tool
+# def get_pitcher_stats_tool(query: str, season: int = None):
+#     """投球成績（防御率、奪三振、ランキング、状況別スタッツ等）を取得する専門ツール"""
+#     from .analytics.pitcher_services import get_ai_response_for_pitcher_stats
+#     return get_ai_response_for_pitcher_stats(query, season)
 
 
-@tool
-def mlb_matchup_history_tool(batter_name: str, pitcher_name: str):
-    """
-    特定の打者と投手の『過去の全対決履歴』を取得するツール。
-    打席ごとの配球（球種の流れ）や、結果、コースなどの詳細なプロセスを取得できます。
-    batter_name: 打者のフルネーム（例: 'Shohei Ohtani'）
-    pitcher_name: 投手のフルネーム（例: 'Yu Darvish'）
-    """
-    logger.info(f"🔍 DEBUG: mlb_matchup_history_tool called with batter='{batter_name}', pitcher='{pitcher_name}'")
-    batter_name = batter_name.strip()
-    pitcher_name = pitcher_name.strip()
+# @tool
+# def mlb_matchup_history_tool(batter_name: str, pitcher_name: str):
+#     """
+#     特定の打者と投手の『過去の全対決履歴』を取得するツール。
+#     打席ごとの配球（球種の流れ）や、結果、コースなどの詳細なプロセスを取得できます。
+#     batter_name: 打者のフルネーム（例: 'Shohei Ohtani'）
+#     pitcher_name: 投手のフルネーム（例: 'Yu Darvish'）
+#     """
+#     logger.info(f"🔍 DEBUG: mlb_matchup_history_tool called with batter='{batter_name}', pitcher='{pitcher_name}'")
+#     batter_name = batter_name.strip()
+#     pitcher_name = pitcher_name.strip()
 
-    query = f"""
-    SELECT *
-    FROM `tksm-dash-test-25.mlb_analytics_dash_25.view_matchup_specific_history`
-    WHERE (
-        (UPPER(batter_name) = UPPER(@batter_name)) OR
-        (UPPER(batter_name) = UPPER(@batter_reversed)) OR
-        (UPPER(batter_name) LIKE UPPER(@batter_part))
-    ) AND (
-        (UPPER(pitcher_name) = UPPER(@pitcher_name)) OR
-        (UPPER(pitcher_name) = UPPER(@pitcher_reversed)) OR
-        (UPPER(pitcher_name) LIKE UPPER(@pitcher_part))
-    )
-    ORDER BY game_date DESC, at_bat_number DESC
-    LIMIT 30
-    """
+#     query = f"""
+#     SELECT *
+#     FROM `tksm-dash-test-25.mlb_analytics_dash_25.view_matchup_specific_history`
+#     WHERE (
+#         (UPPER(batter_name) = UPPER(@batter_name)) OR
+#         (UPPER(batter_name) = UPPER(@batter_reversed)) OR
+#         (UPPER(batter_name) LIKE UPPER(@batter_part))
+#     ) AND (
+#         (UPPER(pitcher_name) = UPPER(@pitcher_name)) OR
+#         (UPPER(pitcher_name) = UPPER(@pitcher_reversed)) OR
+#         (UPPER(pitcher_name) LIKE UPPER(@pitcher_part))
+#     )
+#     ORDER BY game_date DESC, at_bat_number DESC
+#     LIMIT 30
+#     """
 
-    def reverse_name(name):
-        parts = name.split()
-        return f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) > 1 else name
+#     def reverse_name(name):
+#         parts = name.split()
+#         return f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) > 1 else name
 
-    b_rev = reverse_name(batter_name)
-    p_rev = reverse_name(pitcher_name)
-    b_part = f"%{batter_name.split()[-1]}%" if len(batter_name.split()) > 0 else "%"
-    p_part = f"%{pitcher_name.split()[-1]}%" if len(pitcher_name.split()) > 0 else "%"
+#     b_rev = reverse_name(batter_name)
+#     p_rev = reverse_name(pitcher_name)
+#     b_part = f"%{batter_name.split()[-1]}%" if len(batter_name.split()) > 0 else "%"
+#     p_part = f"%{pitcher_name.split()[-1]}%" if len(pitcher_name.split()) > 0 else "%"
 
-    query_parameters = [
-        ScalarQueryParameter("batter_name", "STRING", batter_name),
-        ScalarQueryParameter("batter_reversed", "STRING", b_rev),
-        ScalarQueryParameter("batter_part", "STRING", b_part),
-        ScalarQueryParameter("pitcher_name", "STRING", pitcher_name),
-        ScalarQueryParameter("pitcher_reversed", "STRING", p_rev),
-        ScalarQueryParameter("pitcher_part", "STRING", p_part)
-    ]
+#     query_parameters = [
+#         ScalarQueryParameter("batter_name", "STRING", batter_name),
+#         ScalarQueryParameter("batter_reversed", "STRING", b_rev),
+#         ScalarQueryParameter("batter_part", "STRING", b_part),
+#         ScalarQueryParameter("pitcher_name", "STRING", pitcher_name),
+#         ScalarQueryParameter("pitcher_reversed", "STRING", p_rev),
+#         ScalarQueryParameter("pitcher_part", "STRING", p_part)
+#     ]
 
-    job_config = QueryJobConfig(query_parameters=query_parameters)
+#     job_config = QueryJobConfig(query_parameters=query_parameters)
 
-    # Check cache first
-    cache = StatsCache()
-    cached_data = cache.get_player_stats(player_name=batter_name, season=2024, query_type=f"matchup_{pitcher_name}")
-    if cached_data:
-        logger.info("Cache HIT")
-        return cached_data
+#     # Check cache first
+#     cache = StatsCache()
+#     cached_data = cache.get_player_stats(player_name=batter_name, season=2024, query_type=f"matchup_{pitcher_name}")
+#     if cached_data:
+#         logger.info("Cache HIT")
+#         return cached_data
     
-    try:
-        df = client.query(query, job_config=job_config).to_dataframe()
-        logger.info(f"✅ Matchup history found", row_count=len(df), batter_name=batter_name, pitcher_name=pitcher_name)
-        result = df.to_dict(orient='records')
-        # Save to Redis
-        cache.set_player_stats(player_name=batter_name, season=2024, query_type=f"matchup_{pitcher_name}", data=result)
-        return result
-    except Exception as e:
-        raise DataFetchError("対戦履歴の取得に失敗しました", original_error=e) from e
+#     try:
+#         df = client.query(query, job_config=job_config).to_dataframe()
+#         logger.info(f"✅ Matchup history found", row_count=len(df), batter_name=batter_name, pitcher_name=pitcher_name)
+#         result = df.to_dict(orient='records')
+#         # Save to Redis
+#         cache.set_player_stats(player_name=batter_name, season=2024, query_type=f"matchup_{pitcher_name}", data=result)
+#         return result
+#     except Exception as e:
+#         raise DataFetchError("対戦履歴の取得に失敗しました", original_error=e) from e
 
 
-@tool
-def mlb_matchup_analytics_tool(batter_name: str, pitcher_name: str):
-    """
-    特定の打者と投手の『球種別の対戦相性サマリー』を取得する分析ツール。
-    打率、OPSなどの結果だけでなく、空振り率、球速、平均回転数などの球のクオリティも取得できます。
-    batter_name: 打者のフルネーム（例: 'Shohei Ohtani'）
-    pitcher_name: 投手のフルネーム（例: 'Yu Darvish'）
-    """
-    query = f"""
-    SELECT *
-    FROM `tksm-dash-test-25.mlb_analytics_dash_25.view_matchup_pitch_analytics`
-    WHERE (
-        (UPPER(batter_name) = UPPER(@batter_name)) OR
-        (UPPER(batter_name) = UPPER(@batter_reversed)) OR
-        (UPPER(batter_name) LIKE UPPER(@batter_part))
-    ) AND (
-        (UPPER(pitcher_name) = UPPER(@pitcher_name)) OR
-        (UPPER(pitcher_name) = UPPER(@pitcher_reversed)) OR
-        (UPPER(pitcher_name) LIKE UPPER(@pitcher_part))
-    )
-    ORDER BY pitch_count DESC
-    """
+# @tool
+# def mlb_matchup_analytics_tool(batter_name: str, pitcher_name: str):
+#     """
+#     特定の打者と投手の『球種別の対戦相性サマリー』を取得する分析ツール。
+#     打率、OPSなどの結果だけでなく、空振り率、球速、平均回転数などの球のクオリティも取得できます。
+#     batter_name: 打者のフルネーム（例: 'Shohei Ohtani'）
+#     pitcher_name: 投手のフルネーム（例: 'Yu Darvish'）
+#     """
+#     query = f"""
+#     SELECT *
+#     FROM `tksm-dash-test-25.mlb_analytics_dash_25.view_matchup_pitch_analytics`
+#     WHERE (
+#         (UPPER(batter_name) = UPPER(@batter_name)) OR
+#         (UPPER(batter_name) = UPPER(@batter_reversed)) OR
+#         (UPPER(batter_name) LIKE UPPER(@batter_part))
+#     ) AND (
+#         (UPPER(pitcher_name) = UPPER(@pitcher_name)) OR
+#         (UPPER(pitcher_name) = UPPER(@pitcher_reversed)) OR
+#         (UPPER(pitcher_name) LIKE UPPER(@pitcher_part))
+#     )
+#     ORDER BY pitch_count DESC
+#     """
     
-    def reverse_name(name):
-        parts = name.split()
-        return f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) > 1 else name
+#     def reverse_name(name):
+#         parts = name.split()
+#         return f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) > 1 else name
     
-    b_rev = reverse_name(batter_name)
-    p_rev = reverse_name(pitcher_name)
-    b_part = f"%{batter_name.split()[-1]}%" if len(batter_name.split()) > 0 else "%"
-    p_part = f"%{pitcher_name.split()[-1]}%" if len(pitcher_name.split()) > 0 else "%"
+#     b_rev = reverse_name(batter_name)
+#     p_rev = reverse_name(pitcher_name)
+#     b_part = f"%{batter_name.split()[-1]}%" if len(batter_name.split()) > 0 else "%"
+#     p_part = f"%{pitcher_name.split()[-1]}%" if len(pitcher_name.split()) > 0 else "%"
 
-    query_parameters = [
-        ScalarQueryParameter("batter_name", "STRING", batter_name),
-        ScalarQueryParameter("batter_reversed", "STRING", b_rev),
-        ScalarQueryParameter("batter_part", "STRING", b_part),
-        ScalarQueryParameter("pitcher_name", "STRING", pitcher_name),
-        ScalarQueryParameter("pitcher_reversed", "STRING", p_rev),
-        ScalarQueryParameter("pitcher_part", "STRING", p_part)
-    ]
+#     query_parameters = [
+#         ScalarQueryParameter("batter_name", "STRING", batter_name),
+#         ScalarQueryParameter("batter_reversed", "STRING", b_rev),
+#         ScalarQueryParameter("batter_part", "STRING", b_part),
+#         ScalarQueryParameter("pitcher_name", "STRING", pitcher_name),
+#         ScalarQueryParameter("pitcher_reversed", "STRING", p_rev),
+#         ScalarQueryParameter("pitcher_part", "STRING", p_part)
+#     ]
 
-    job_config = QueryJobConfig(query_parameters=query_parameters)
+#     job_config = QueryJobConfig(query_parameters=query_parameters)
 
-    try:
-        df = client.query(query, job_config=job_config).to_dataframe()
-        return df.to_dict(orient='records')
-    except Exception as e:
-        logger.error(f"Error in mlb_matchup_analytics_tool: {e}")
-        return []
+#     try:
+#         df = client.query(query, job_config=job_config).to_dataframe()
+#         return df.to_dict(orient='records')
+#     except Exception as e:
+#         logger.error(f"Error in mlb_matchup_analytics_tool: {e}")
+#         return []
 
 
 # Semantic Layer のメトリクス名 → UI 表示用ラベル（野球の慣用表記）

--- a/backend/app/services/analytics/base_engine.py
+++ b/backend/app/services/analytics/base_engine.py
@@ -269,7 +269,7 @@ class BaseEngine:
 
         # 13. output_formatの検証
         if params.get("output_format"):
-            if params["output_format"] not in ["sentence", "table"]:
+            if params["output_format"] not in ["sentence", "table", "data"]:
                 logger.warning(f"⚠️ Invalid output_format: {params['output_format']}")
                 return False
 

--- a/backend/app/services/analytics/batter_services.py
+++ b/backend/app/services/analytics/batter_services.py
@@ -11,6 +11,8 @@ from dotenv import load_dotenv
 from datetime import datetime
 from ..bigquery_service import client
 from ..llm_gateway_service import call_gemini
+from backend.app.config.prompt_registry import get_prompt_version
+from backend.app.middleware.request_context import add_bq_latency_ms
 import logging
 from ..conversation_service import get_conversation_service
 from .base_engine import BaseEngine
@@ -84,10 +86,19 @@ def _load_prompt_template(template_name: str) -> str:
         raise
 
 
-def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[str, Any]]:
+def _parse_query_with_llm(
+    query: str,
+    season: Optional[int],
+    original_query: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
     """
-    [ステップ1] LLMを使い、質問からパラメータを抽出します。この関数はLLMの役割を果たします。ユーザーの質問を解析し、「意図」を汲み取り、
-    データベースで検索するためのパラメータをJSON形式で抽出します。
+    [ステップ1] LLMを使い、質問からパラメータを抽出します。
+
+    Args:
+        query: 会話コンテキスト解決後のクエリ (LLM に投げる本文)
+        season: 補助のシーズンヒント
+        original_query: ユーザーが実際に入力したオリジナル文 (BQ ログ用)。
+                        指定なければ query をそのまま使う。
     """
     if not GEMINI_API_KEY:
         logger.error("GEMINI_API_KEY_V2 is not set.")
@@ -108,12 +119,33 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
         prev_year=current_year - 1
     )
 
+    # LLM の JSON 応答から parsed_* フィールドを log entry に転記するフック。
+    # call_gemini 内で text 受信後・log 書き込み前に呼ばれる。
+    def _hook(text: str, entry):
+        try:
+            parsed = json.loads(text)
+            entry.parsed_query_type = parsed.get("query_type")
+            metrics = parsed.get("metrics")
+            entry.parsed_metrics = (
+                json.dumps(metrics, ensure_ascii=False) if metrics is not None else None
+            )
+            entry.parsed_player_name = parsed.get("name")
+            parsed_season = parsed.get("season")
+            entry.parsed_season = int(parsed_season) if parsed_season is not None else None
+        except (json.JSONDecodeError, TypeError, ValueError):
+            # ロギング失敗は本処理に影響させない
+            pass
+
     text = call_gemini(
         prompt=prompt,
         model="gemini-2.5-flash",
         response_mime_type="application/json",
         feature="analytics_batter",
-        user_id="",
+        prompt_name="parse_query",
+        prompt_version=get_prompt_version("parse_query"),
+        user_query=original_query or query,
+        resolved_query=query if (original_query and original_query != query) else None,
+        post_response_hook=_hook,
     )
     if not text:
         return None
@@ -134,14 +166,22 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
 
 
 def get_ai_response_for_batter_stats(
-        query: str,
+        query: Optional[str] = None,
         season: Optional[int] = None,
         session_id: Optional[str] = None,
-        output_format: Optional[str] = None  # 呼び出し元から明示的に指定された場合にLLM解析結果を上書き
+        output_format: Optional[str] = None,  # 呼び出し元から明示的に指定された場合にLLM解析結果を上書き
+        structured_params: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
     """
     【打撃リーダーボード特化版】
     ユーザーの"打撃リーダーボード"に関する質問を処理します。
+
+    2 つのモード:
+      A) structured_params が渡された場合 (推奨/新方式):
+         ChatOrchestrator の外側 LLM が既に NLU を済ませている前提。
+         ツール内 NLU をスキップして直接 SQL を組み立てる。
+      B) query (自然文) が渡された場合 (後方互換):
+         ツール内で _parse_query_with_llm を呼んで NLU を実行する旧フロー。
     """
 
     # Step 0: Resolve conversation context (会話コンテキストの解決 == 直前の履歴から情報を補完)
@@ -149,7 +189,7 @@ def get_ai_response_for_batter_stats(
     resolved_query = query
     context_used = False
 
-    if session_id:
+    if session_id and query:
         logger.info(f"Resolving conversation context for session_id: {session_id}")
         context_result = conv_service.resolve_context(query, session_id)
         resolved_query = context_result["resolved_query"]
@@ -159,28 +199,40 @@ def get_ai_response_for_batter_stats(
         if not season and context_result.get("season"):
             season = int(context_result["season"])
             logger.info(f"Season {season} inferred from conversation context")
-        
+
         if context_used:
             logger.info(f"Query resolved: '{query}' → '{resolved_query}'")
-        
+
         # ユーザーメッセージを会話履歴に保存。次の質問で「さっきの質問をもう一度」などの文脈が使えるようにする。
         conv_service.add_message(session_id, "user", query)
 
-    # Step 1: LLMで質問を解析（解決後のクエリを使用）
-    query_params = _parse_query_with_llm(resolved_query, season)
-    if not query_params:
-        logger.warning("Could not extract parameters from the query.")
-        error_response = {
-            "answer": "質問を理解できませんでした。打撃成績のランキングについて質問してください。（例：2024年のホームラン王は誰？）",
-            "isTable": False
-        }
+    # Step 1: query_params を決定 (structured_params 優先、なければ NLU)
+    if structured_params and (
+        structured_params.get("query_type")
+        or structured_params.get("name")
+        or structured_params.get("metrics")
+    ):
+        # モード A: 外側 LLM が解析済み → NLU をスキップ
+        logger.info(f"Skipping NLU; using structured_params: {structured_params}")
+        query_params = {k: v for k, v in structured_params.items() if v is not None}
+    else:
+        # モード B: 自然文を NLU
+        if not query:
+            return {
+                "answer": "クエリ引数が不足しています (query または structured_params のいずれかが必須)。",
+                "isTable": False,
+            }
+        query_params = _parse_query_with_llm(resolved_query, season, original_query=query)
+        if not query_params:
+            logger.warning("Could not extract parameters from the query.")
+            error_response = {
+                "answer": "質問を理解できませんでした。打撃成績のランキングについて質問してください。（例：2024年のホームラン王は誰？）",
+                "isTable": False,
+            }
+            if session_id:
+                conv_service.add_message(session_id, "assistant", error_response["answer"])
+            return error_response
 
-        # エラーレスポンスも会話履歴に保存
-        if session_id:
-            conv_service.add_message(session_id, "assistant", error_response["answer"])
-        
-        return error_response
-    
     logger.info(f"Parsed query parameters: {query_params}")
 
     # 呼び出し元から output_format が明示指定されていれば LLM 解析結果を上書き
@@ -260,6 +312,8 @@ def get_ai_response_for_batter_stats(
         query_start = datetime.now()
         results_df = client.query(sql_query, job_config=job_config).to_dataframe()
         query_duration = (datetime.now() - query_start).total_seconds()
+        # BQ 累計時間を ContextVar に加算 (エンドポイントが最後に log_entry に書く)
+        add_bq_latency_ms(query_duration * 1000)
 
         logger.info(f"Query completed in {query_duration:.2f}s, fetched {len(results_df)} rows")
 
@@ -290,7 +344,23 @@ def get_ai_response_for_batter_stats(
     # Step 4: Format response
     total_duration = (datetime.now() - query_start).total_seconds()
     logger.info(f"Total request processing time: {total_duration:.2f}s")
-    
+
+    # output_format='data': 生データを返し、ツール内の最終 LLM 生成をスキップする。
+    # ChatOrchestrator の外側 LLM がこのデータを受け取って応答合成する想定。
+    if query_params.get("output_format") == "data":
+        logger.info(f"output_format=data: returning raw rows ({len(results_df)} rows), skipping LLM narrative")
+        rows = results_df.to_dict("records")
+        return {
+            "isTable": False,
+            "isChart": False,
+            "data": rows,
+            "row_count": len(rows),
+            "columns": list(results_df.columns),
+            "parameters": query_params,
+            # ContextVar 経由ではなく戻り値で BQ 時間を伝搬 (StreamingResponse 配下で ContextVar が伝わらない問題回避)
+            "bigquery_latency_ms": query_duration * 1000,
+        }
+
     # if output format is table
     if query_params.get("output_format") == "table":
         # Debug logging

--- a/backend/app/services/analytics/pitcher_services.py
+++ b/backend/app/services/analytics/pitcher_services.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 from datetime import datetime
 from ..bigquery_service import client
 from ..llm_gateway_service import call_gemini
+from backend.app.middleware.request_context import add_bq_latency_ms
 import logging
 from ..conversation_service import get_conversation_service
 from .base_engine import BaseEngine
@@ -58,10 +59,19 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY_V2")
 SERVICE_ACCOUNT_KEY_PATH = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 
-def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[str, Any]]:
+def _parse_query_with_llm(
+    query: str,
+    season: Optional[int],
+    original_query: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
     """
-    [ステップ1] LLMを使い、質問からパラメータを抽出します。この関数はLLMの役割を果たします。ユーザーの質問を解析し、「意図」を汲み取り、
-    データベースで検索するためのパラメータをJSON形式で抽出します。
+    [ステップ1] LLMを使い、質問からパラメータを抽出します。
+
+    Args:
+        query: 会話コンテキスト解決後のクエリ (LLM に投げる本文)
+        season: 補助のシーズンヒント
+        original_query: ユーザーが実際に入力したオリジナル文 (BQ ログ用)。
+                        指定なければ query をそのまま使う。
     """
     if not GEMINI_API_KEY:
         logger.error("GEMINI_API_KEY_V2 is not set.")
@@ -125,12 +135,33 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
     JSON:
     """
 
+    # LLM の JSON 応答から parsed_* フィールドを log entry に転記するフック。
+    def _hook(text: str, entry):
+        try:
+            parsed = json.loads(text)
+            entry.parsed_query_type = parsed.get("query_type")
+            metrics = parsed.get("metrics")
+            entry.parsed_metrics = (
+                json.dumps(metrics, ensure_ascii=False) if metrics is not None else None
+            )
+            entry.parsed_player_name = parsed.get("name")
+            parsed_season = parsed.get("season")
+            entry.parsed_season = int(parsed_season) if parsed_season is not None else None
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+
+    # NOTE: pitcher の parse prompt は code 内インライン定義で prompt_registry に未登録。
+    # 本来 prompts/pitcher_parse_query_v1.txt に切り出して registry 化すべき (別 issue)。
+    # それまでは prompt_name のみ記録、prompt_version は NULL (正直に記録)。
     text = call_gemini(
         prompt=prompt,
         model="gemini-2.5-flash",
         response_mime_type="application/json",
         feature="analytics_pitcher",
-        user_id="",
+        prompt_name="pitcher_parse_query_inline",
+        user_query=original_query or query,
+        resolved_query=query if (original_query and original_query != query) else None,
+        post_response_hook=_hook,
     )
     if not text:
         return None
@@ -146,13 +177,18 @@ def _parse_query_with_llm(query: str, season: Optional[int]) -> Optional[Dict[st
 
 
 def get_ai_response_for_pitcher_stats(
-        query: str, 
+        query: Optional[str] = None,
         season: Optional[int] = None,
-        session_id: Optional[str] = None # Id from frontend to track user session
+        session_id: Optional[str] = None,  # Id from frontend to track user session
+        output_format: Optional[str] = None,
+        structured_params: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
     """
     【投手成績特化版】
-    ユーザーの投手成績（防御率、奪三振、WHIP等）に関する質問を処理します。
+
+    2 つのモード:
+      A) structured_params 渡された場合: NLU をスキップ (推奨/新方式)
+      B) query (NL) のみ: 後方互換、tool 内 NLU 実行
     """
 
     # Step 0: Resolve conversation context (会話コンテキストの解決 == 直前の履歴から情報を補完)
@@ -160,7 +196,7 @@ def get_ai_response_for_pitcher_stats(
     resolved_query = query
     context_used = False
 
-    if session_id:
+    if session_id and query:
         logger.info(f"Resolving conversation context for session_id: {session_id}")
         context_result = conv_service.resolve_context(query, session_id)
         resolved_query = context_result["resolved_query"]
@@ -170,29 +206,43 @@ def get_ai_response_for_pitcher_stats(
         if not season and context_result.get("season"):
             season = int(context_result["season"])
             logger.info(f"Season {season} inferred from conversation context")
-        
+
         if context_used:
             logger.info(f"Query resolved: '{query}' → '{resolved_query}'")
-        
+
         # ユーザーメッセージを会話履歴に保存。次の質問で「さっきの質問をもう一度」などの文脈が使えるようにする。
         conv_service.add_message(session_id, "user", query)
 
-    # Step 1: LLMで質問を解析（解決後のクエリを使用）
-    query_params = _parse_query_with_llm(resolved_query, season)
-    if not query_params:
-        logger.warning("Could not extract parameters from the query.")
-        error_response = {
-            "answer": "質問を理解できませんでした。打撃成績のランキングについて質問してください。（例：2024年のホームラン王は誰？）",
-            "isTable": False
-        }
+    # Step 1: query_params を決定 (structured_params 優先、なければ NLU)
+    if structured_params and (
+        structured_params.get("query_type")
+        or structured_params.get("name")
+        or structured_params.get("metrics")
+    ):
+        logger.info(f"Skipping NLU; using structured_params: {structured_params}")
+        query_params = {k: v for k, v in structured_params.items() if v is not None}
+    else:
+        if not query:
+            return {
+                "answer": "クエリ引数が不足しています (query または structured_params のいずれかが必須)。",
+                "isTable": False,
+            }
+        query_params = _parse_query_with_llm(resolved_query, season, original_query=query)
+        if not query_params:
+            logger.warning("Could not extract parameters from the query.")
+            error_response = {
+                "answer": "質問を理解できませんでした。投手成績のランキングについて質問してください。",
+                "isTable": False,
+            }
+            if session_id:
+                conv_service.add_message(session_id, "assistant", error_response["answer"])
+            return error_response
 
-        # エラーレスポンスも会話履歴に保存
-        if session_id:
-            conv_service.add_message(session_id, "assistant", error_response["answer"])
-        
-        return error_response
-    
     logger.info(f"Parsed query parameters: {query_params}")
+
+    # 呼び出し元から output_format が明示指定されていれば LLM 解析結果を上書き
+    if output_format:
+        query_params["output_format"] = output_format
 
     # Step 1.5: セキュリティ検証（SQLインジェクション対策）
     if not BaseEngine.validate_query_params(query_params):
@@ -267,6 +317,8 @@ def get_ai_response_for_pitcher_stats(
         query_start = datetime.now()
         results_df = client.query(sql_query, job_config=job_config).to_dataframe()
         query_duration = (datetime.now() - query_start).total_seconds()
+        # BQ 累計時間を ContextVar に加算 (エンドポイントが最後に log_entry に書く)
+        add_bq_latency_ms(query_duration * 1000)
 
         logger.info(f"Query completed in {query_duration:.2f}s, fetched {len(results_df)} rows")
 
@@ -297,7 +349,23 @@ def get_ai_response_for_pitcher_stats(
     # Step 4: Format response
     total_duration = (datetime.now() - query_start).total_seconds()
     logger.info(f"Total request processing time: {total_duration:.2f}s")
-    
+
+    # output_format='data': 生データを返し、ツール内の最終 LLM 生成をスキップする。
+    # ChatOrchestrator の外側 LLM がこのデータを受け取って応答合成する想定。
+    if query_params.get("output_format") == "data":
+        logger.info(f"output_format=data: returning raw rows ({len(results_df)} rows), skipping LLM narrative")
+        rows = results_df.to_dict("records")
+        return {
+            "isTable": False,
+            "isChart": False,
+            "data": rows,
+            "row_count": len(rows),
+            "columns": list(results_df.columns),
+            "parameters": query_params,
+            # ContextVar 経由ではなく戻り値で BQ 時間を伝搬 (StreamingResponse 配下で ContextVar が伝わらない問題回避)
+            "bigquery_latency_ms": query_duration * 1000,
+        }
+
     # if output format is table
     if query_params.get("output_format") == "table":
         # Debug logging

--- a/backend/app/services/chat_orchestrator.py
+++ b/backend/app/services/chat_orchestrator.py
@@ -1,0 +1,661 @@
+"""
+ChatOrchestrator: チャット機能の唯一の入口。
+素の google-genai SDK + tool_use ループで、共通ツール (tools/) を順次呼び出す。
+
+設計原則:
+- LangGraph には依存しない（StrategyAgent との結合を切る）
+- ストリーミング (SSE) はエンドポイント側で SSE 化するため、ここでは
+  辞書イベントの AsyncGenerator を返す（既存 run_mlb_agent_stream と同じ契約）
+- tool 関数の戻り値構造（{"isTable", "tableData", ...}）はそのまま LLM に渡し、
+  最終的に UI 層に構造化データを返す責務は final_answer 構築側が持つ
+
+依存:
+- backend/app/services/tools/  共通ツール
+- backend/app/services/security_guardrail  Prompt Injection 防御
+"""
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+from google import genai
+from google.genai import types
+
+from backend.app.config.prompt_registry import get_prompt_version
+from backend.app.config.settings import get_settings
+from backend.app.core.exceptions import PromptInjectionError
+from backend.app.services.llm_gateway_service import _calc_cost_usd
+from backend.app.services.llm_logger_service import LLMLogEntry, get_llm_logger
+from backend.app.services.security_guardrail import get_security_guardrail
+from backend.app.services.token_budget_service import get_token_budget_service
+from backend.app.services.tools import (
+    CHAT_TOOL_DECLARATIONS,
+    CHAT_TOOL_DECLARATIONS_SEMANTIC,
+    CHAT_TOOL_REGISTRY,
+    _get_semantic_tool_registry,
+)
+from backend.app.utils.structured_logger import get_logger
+
+logger = get_logger("chat-orchestrator")
+
+DEFAULT_MODEL = "gemini-2.5-flash"
+MAX_TOOL_ITERATIONS = 6
+
+
+def _get_valid_metric_keys() -> List[str]:
+    """METRIC_MAP の正規キー名一覧を取得する。
+    LLM の system prompt に注入し、'rbi' のような短縮形ではなく
+    'runs_batted_in' のような正規名のみ使うよう制約する。
+    """
+    try:
+        from backend.app.config.query_maps import METRIC_MAP
+        return sorted(METRIC_MAP.keys())
+    except Exception:
+        return []
+
+
+def _get_semantic_metrics_and_dimensions() -> tuple:
+    """Semantic Layer 登録済みメトリクス・次元の語彙を取得する。
+    warmup 失敗時は空タプルを返し、prompt は fail-open でその旨を明示する。
+    """
+    try:
+        from backend.app.services.semantic_layer_client import get_metric_metadata
+        meta = get_metric_metadata()
+        return (
+            sorted(meta.get("metrics", [])),
+            sorted(meta.get("dimensions", [])),
+        )
+    except Exception:
+        return ([], [])
+
+
+def _build_system_prompt_legacy() -> str:
+    """legacy 経路 (USE_SEMANTIC_LAYER=false) 用の system prompt。
+    get_batter_stats_tool / get_pitcher_stats_tool の構造化引数を LLM に指示。
+    """
+    current_year = datetime.now().year
+    metric_keys = _get_valid_metric_keys()
+    metric_vocab_line = (
+        ", ".join(metric_keys) if metric_keys else "(METRIC_MAP 読み込み失敗)"
+    )
+    return f"""あなたはMLBデータ分析の専門アシスタントです。
+ユーザーの質問を解析し、提供されたツールを呼び出して必要なデータを取得し、
+プロのアナリスト視点で簡潔かつ的確な日本語回答を返してください。
+
+【現在の日付に関する絶対ルール】
+- **現在は {current_year} 年です。** {current_year - 1} 年以前のシーズンは **過去の実績** (確定値) です。
+- 過去シーズンの成績を「予測」「推定」「見込み」などの表現で記述することは禁止です。事実として記述してください。
+- データベースには 2015 年〜 {current_year} 年の全シーズンの実績データが格納されています。
+- 「データがない」「予測です」と早合点せず、ツールが返した数値はそのまま事実として扱ってください。
+
+【ツール呼び出しの絶対ルール】
+- ユーザー質問の自然文解析 (NLU) は **あなた自身の責務** です。
+- get_batter_stats_tool / get_pitcher_stats_tool を呼ぶ際は、必ず **構造化引数** を直接渡してください:
+    * name: 選手名を英語フルネームに正規化 (例: 「大谷さん」→ "Shohei Ohtani", 「鈴木誠也」→ "Seiya Suzuki")
+    * season: 年指定があれば整数で (例: {current_year - 1})。「キャリア」「通算」なら省略。「今年」「今シーズン」は {current_year}。
+    * query_type: 状況なし年指定 → 'season_batting' / 状況あり → 'batting_splits' / 通算 → 'career_batting'
+    * metrics: **必ず以下の正規キー名のみ** をリストで指定してください (短縮形・別名は禁止、validation エラーになります):
+        {metric_vocab_line}
+        または特殊キーワード 'main_stats' (主要スタッツ一括取得) のいずれか。
+        例: 「打点」→ ['runs_batted_in'] (NOT 'rbi') / 「本塁打」→ ['homerun'] (NOT 'hr') / 「打率」→ ['batting_average'] (NOT 'avg')
+    * split_type / inning / strikes / balls / game_score / pitcher_throws / pitch_type: 該当時のみ
+    * output_format: デフォルト 'data' (生データ取得)。ユーザーが「表で」と言ったら 'table'。
+- 旧式の `query` (自然文) 引数は **使わないでください**。ツール内で NLU が再実行されて遅くなります。
+
+【データ分析の絶対ルール】
+- 自分の知識だけで回答することは禁止です。必ずツールを呼び出して最新データを取得してください。
+- 打者対投手の対戦質問では、必ず mlb_matchup_analytics_tool と mlb_matchup_history_tool の両方を使ってください。
+- ツールが空結果やエラーを返した場合、引数を見直して 1〜2 回まで再試行してください。
+
+【応答合成のルール】
+- ツールから返ってきた 'data' (生データ) を読んで、**あなたが** 最終応答を組み立ててください。
+- 数値は **そのまま事実として記述** (「〇〇は××本塁打を記録しました」)。推測表現禁止。
+- Markdown 見出しと箇条書きを使い、主語から始まる完全な文章で回答を生成してください。
+"""
+
+
+def _build_system_prompt_semantic() -> str:
+    """Semantic Layer 経路 (USE_SEMANTIC_LAYER=true) 用の system prompt。
+    query_semantic_metrics_tool に構造化引数を渡すよう LLM に指示。
+    prompts/oracle_semantic_v1.txt の仕様を踏襲し、有名選手の mlbid 8 人を hardcode。
+    """
+    current_year = datetime.now().year
+    metrics, dimensions = _get_semantic_metrics_and_dimensions()
+    metrics_line = ", ".join(metrics) if metrics else "(Semantic Layer warmup 失敗、MetricFlow に直接問い合わせ)"
+    dimensions_line = ", ".join(dimensions) if dimensions else "(取得不可)"
+    return f"""あなたはMLBデータ分析の専門アシスタントです。
+ユーザーの質問を解析し、`query_semantic_metrics_tool` を呼び出してデータを取得し、
+プロのアナリスト視点で簡潔かつ的確な日本語回答を返してください。
+
+【現在の日付に関する絶対ルール】
+- **現在は {current_year} 年です。** {current_year - 1} 年以前のシーズンは **過去の実績** (確定値) です。
+- 過去シーズンの成績を「予測」「推定」「見込み」などの表現で記述することは禁止です。事実として記述してください。
+- 「今年」「今シーズン」「最新」は **season={current_year}**。「去年」は **season={current_year - 1}**。
+
+【ツール呼び出しの絶対ルール】
+- ユーザー質問の NLU は **あなた自身の責務** です。`query_semantic_metrics_tool` に構造化引数を直接渡してください。
+- **`metrics` 引数には以下の正規メトリクス名のみ使用可** (短縮形・別名は禁止):
+    {metrics_line}
+
+【選手名 → mlbid の解決】
+
+以下の有名選手は mlbid を直接使ってください:
+- 大谷翔平 / Shohei Ohtani → 660271
+- ムーキー・ベッツ / Mookie Betts → 605141
+- フレディ・フリーマン / Freddie Freeman → 518692
+- アーロン・ジャッジ / Aaron Judge → 592450
+- フアン・ソト / Juan Soto → 665742
+- ヨシノブ・ヤマモト / Yoshinobu Yamamoto → 808967
+- ロナルド・アクーニャJr / Ronald Acuna Jr → 660670
+- ホセ・ラミレス / Jose Ramirez → 608070
+
+リストにない選手は **mlbid を指定せず**、`where=["player__player_name = 'フルネーム'"]` で名前絞り込みしてください。
+
+【利用可能な次元】
+{dimensions_line}
+
+【その他】
+- 打者は entity_type='player'、投手は entity_type='pitcher'。
+- 打者対投手の対戦質問では mlb_matchup_analytics_tool と mlb_matchup_history_tool を使用 (Semantic Layer 未対応のため)。
+
+【応答合成のルール】
+- ツール戻り値を読んで **あなたが** 最終応答を組み立ててください。
+- 数値はそのまま事実として記述 (「〇〇は××本塁打を記録しました」)。推測表現禁止。
+- Markdown 見出しと箇条書きを使い、主語から始まる完全な文章で回答してください。
+"""
+
+
+def _build_system_prompt(use_semantic: bool = False) -> str:
+    """システムプロンプト構築。フラグで legacy / semantic 経路を切替。"""
+    return _build_system_prompt_semantic() if use_semantic else _build_system_prompt_legacy()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sanitize_tool_result(obj: Any) -> Any:
+    """Gemini API は NaN/Infinity を拒否するため None に置換する。
+    旧 executor_node から踏襲。"""
+    if isinstance(obj, list):
+        return [_sanitize_tool_result(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _sanitize_tool_result(v) for k, v in obj.items()}
+    if isinstance(obj, float):
+        if obj != obj:  # NaN
+            return None
+        if obj in (float("inf"), float("-inf")):
+            return None
+    return obj
+
+
+def _extract_structured_payload(tool_results: List[Any]) -> Dict[str, Any]:
+    """ツール戻り値から UI 用構造化フィールドを抽出する。
+    旧 synthesizer_node の構造化抽出ロジックを移植。
+    """
+    payload: Dict[str, Any] = {
+        "isTable": False,
+        "isChart": False,
+        "isMatchupCard": False,
+        "tableData": None,
+        "columns": None,
+        "isTransposed": False,
+        "chartType": "",
+        "chartData": None,
+        "chartConfig": None,
+        "matchupData": {},
+    }
+    # Table / Chart は最後の構造化結果を優先
+    for res in reversed(tool_results):
+        if not isinstance(res, dict):
+            continue
+        if res.get("isTable") is True:
+            payload.update({
+                "isTable": True,
+                "tableData": res.get("tableData"),
+                "columns": res.get("columns"),
+                "isTransposed": res.get("isTransposed", False),
+            })
+            break
+        if res.get("isChart") is True:
+            payload.update({
+                "isChart": True,
+                "chartType": res.get("chartType", ""),
+                "chartData": res.get("chartData"),
+                "chartConfig": res.get("chartConfig"),
+            })
+            break
+
+    # MatchupCard は list 形式の戻り値から構築
+    matchup_history: List[Dict[str, Any]] = []
+    matchup_stats: List[Dict[str, Any]] = []
+    for res in tool_results:
+        if isinstance(res, list) and res:
+            first = res[0]
+            if isinstance(first, dict):
+                if "pitch_name" in first and ("batting_average" in first or "avg" in first):
+                    for item in res:
+                        if "avg" in item and "batting_average" not in item:
+                            item["batting_average"] = item["avg"]
+                    matchup_stats = res
+                    payload["isMatchupCard"] = True
+                elif "game_date" in first:
+                    matchup_history = res
+                    payload["isMatchupCard"] = True
+    if payload["isMatchupCard"]:
+        seed = matchup_stats or matchup_history or [{}]
+        payload["matchupData"] = {
+            "stats": matchup_stats,
+            "history": matchup_history[:50],
+            "summary": {
+                "batter": seed[0].get("batter_name", "Batter"),
+                "pitcher": seed[0].get("pitcher_name", "Pitcher"),
+            },
+        }
+    return payload
+
+
+def _format_rows_as_markdown(tool_results: List[Any]) -> str:
+    """tool 戻り値を LLM 不使用で Markdown 文字列に整形する。
+    synthesize_response=False (デフォルト) で UI 表示テキストとして使う。
+
+    対応する tool 戻り値形式:
+      1. {"data": [rows], "parameters": {...}}  — legacy batter/pitcher services
+      2. {"answer": "...", "isTable": bool, "tableData": [...], "columns": [...]}  — Semantic Layer
+      3. {"answer": "..."} — Semantic Layer sentence モード
+    """
+    parts: List[str] = []
+    for res in tool_results:
+        if not isinstance(res, dict):
+            continue
+
+        # 形式 1: legacy batter/pitcher の生データ
+        rows = res.get("data")
+        if rows and isinstance(rows, list):
+            params = res.get("parameters") or {}
+            player = params.get("name") or (rows[0].get("name") if rows else None)
+            season = params.get("season")
+            header_bits = [b for b in [player, f"{season}年" if season else None] if b]
+            if header_bits:
+                parts.append(f"### {' / '.join(header_bits)}")
+            for row in rows:
+                for col, val in row.items():
+                    if val is None:
+                        continue
+                    parts.append(f"- {col}: {val}")
+            continue
+
+        # 形式 2: Semantic Layer の table 構造化応答
+        if res.get("isTable") and res.get("tableData"):
+            table_data = res["tableData"]
+            cols = res.get("columns") or []
+            col_keys = [c.get("key") if isinstance(c, dict) else c for c in cols]
+            if not col_keys and table_data:
+                col_keys = list(table_data[0].keys())
+            for row in table_data:
+                for k in col_keys:
+                    v = row.get(k)
+                    if v is None:
+                        continue
+                    parts.append(f"- {k}: {v}")
+            continue
+
+        # 形式 3: answer フィールドのみ (Semantic Layer sentence モード等)
+        answer = res.get("answer")
+        if answer and isinstance(answer, str):
+            parts.append(answer)
+
+    return "\n".join(parts) or "データが取得できませんでした。"
+
+
+class ChatOrchestrator:
+    """素の Gemini SDK + tool_use ループで動くチャットエンジン。
+
+    tool 実行後の挙動を 2 モードで切替:
+      - synthesize_response=False (デフォルト): tool が返した生データをそのまま返す。LLM #2 を呼ばない。
+      - synthesize_response=True: tool データを LLM に渡して自然言語応答を合成する。
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        api_key: Optional[str] = None,
+        synthesize_response: bool = False,
+        use_semantic_layer: Optional[bool] = None,
+    ):
+        self.model = model
+        self.synthesize_response = synthesize_response
+        # use_semantic_layer 未指定なら settings から取得 (env: USE_SEMANTIC_LAYER)
+        if use_semantic_layer is None:
+            use_semantic_layer = bool(get_settings().use_semantic_layer)
+        self.use_semantic_layer = use_semantic_layer
+
+        key = api_key or os.getenv("GEMINI_API_KEY_V2")
+        if not key:
+            raise RuntimeError("GEMINI_API_KEY_V2 is not configured for ChatOrchestrator")
+        self._client = genai.Client(api_key=key)
+
+        # フラグでツール宣言と registry を切り替え
+        if self.use_semantic_layer:
+            self._tools_config = types.Tool(function_declarations=CHAT_TOOL_DECLARATIONS_SEMANTIC)
+            self._tool_registry = _get_semantic_tool_registry()
+            logger.info("ChatOrchestrator initialized with Semantic Layer tools")
+        else:
+            self._tools_config = types.Tool(function_declarations=CHAT_TOOL_DECLARATIONS)
+            self._tool_registry = CHAT_TOOL_REGISTRY
+            logger.info("ChatOrchestrator initialized with legacy METRIC_MAP tools")
+
+        self._gen_config = types.GenerateContentConfig(
+            tools=[self._tools_config],
+            system_instruction=_build_system_prompt(use_semantic=self.use_semantic_layer),
+            temperature=0,
+        )
+
+    def _execute_tool(self, name: str, args: Dict[str, Any]) -> Any:
+        """tool_use の dispatch。@tool 関数は .invoke(args) で呼べる。"""
+        tool_fn = self._tool_registry.get(name)
+        if tool_fn is None:
+            logger.warning(f"Unknown tool requested by LLM: {name}")
+            return {"error": f"Tool {name} not found"}
+        try:
+            return tool_fn.invoke(args)
+        except Exception as e:
+            logger.error(f"Tool execution failed: {name}", error=str(e), exc_info=True)
+            return {"error": f"Tool {name} failed: {e}"}
+    
+
+    async def run(self, user_query: str) -> Dict[str, Any]:
+        """非ストリーム実行。テスト・バッチ用途。"""
+        guardrail = get_security_guardrail()
+        is_safe, reason = guardrail.validate_and_log(user_query)
+        if not is_safe:
+            raise PromptInjectionError(
+                message="申し訳ございませんが、このリクエストにはお応えできません。MLB統計に関する質問をお願いいたします。",
+                detected_pattern=reason,
+            )
+
+        contents: List[types.Content] = [
+            types.Content(role="user", parts=[types.Part(text=user_query)])
+        ]
+        tool_results_seen: List[Any] = []
+
+        for iteration in range(MAX_TOOL_ITERATIONS):
+            response = self._client.models.generate_content(
+                model=self.model,
+                contents=contents,
+                config=self._gen_config,
+            )
+            cand = (response.candidates or [None])[0]
+            if cand is None:
+                break
+
+            function_calls = []
+            text_parts = []
+            for part in (cand.content.parts or []):
+                if part.function_call:
+                    function_calls.append(part.function_call)
+                elif part.text:
+                    text_parts.append(part.text)
+
+            if not function_calls:
+                final_text = "".join(text_parts).strip()
+                payload = _extract_structured_payload(tool_results_seen)
+                return {"final_answer": final_text, **payload}
+
+            # tool_use を contents に積む
+            contents.append(types.Content(
+                role="model",
+                parts=[types.Part(function_call=fc) for fc in function_calls],
+            ))
+            for fc in function_calls:
+                args = dict(fc.args or {})
+                result = self._execute_tool(fc.name, args)
+                tool_results_seen.append(result)
+                sanitized = _sanitize_tool_result(result)
+                contents.append(types.Content(
+                    role="user",
+                    parts=[types.Part(function_response=types.FunctionResponse(
+                        name=fc.name,
+                        response={"result": sanitized},
+                    ))],
+                ))
+
+            # synthesize_response=False (デフォルト): LLM #2 を呼ばず即 return
+            if not self.synthesize_response:
+                payload = _extract_structured_payload(tool_results_seen)
+                return {"final_answer": "", **payload}
+
+        logger.warning("ChatOrchestrator hit MAX_TOOL_ITERATIONS")
+        return {
+            "final_answer": "ツール呼び出しが上限に達しました。質問を簡潔にして再度お試しください。",
+            **_extract_structured_payload(tool_results_seen),
+        }
+
+
+    async def run_stream(
+        self,
+        user_query: str,
+        request_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """ストリーミング実行。SSE イベント辞書を yield する。
+        旧 run_mlb_agent_stream と同じイベント契約を維持。
+        """
+        guardrail = get_security_guardrail()
+        is_safe, reason = guardrail.validate_and_log(user_query)
+        if not is_safe:
+            yield {
+                "type": "error",
+                "error_type": "blocked",
+                "message": "申し訳ございませんが、このリクエストにはお応えできません。MLB統計に関する質問をお願いいたします。",
+                "detected_pattern": reason,
+            }
+            return
+
+        # フロント互換のため routing イベントを 1 回だけ送る
+        yield {
+            "type": "routing",
+            "agent_type": "chat",
+            "message": "ChatOrchestrator で処理します",
+        }
+
+        contents: List[types.Content] = [
+            types.Content(role="user", parts=[types.Part(text=user_query)])
+        ]
+        tool_results_seen: List[Any] = []
+        accumulated_answer = ""
+        accumulated_llm_ms = 0.0
+
+        for iteration in range(MAX_TOOL_ITERATIONS):
+            yield {
+                "type": "state_update",
+                "node": "oracle",
+                "status": "started",
+                "message": "質問を分析しています",
+                "node_details": "ユーザーの質問を理解し、必要なツールを選択",
+                "timestamp": _now_iso(),
+                "step_type": "node_start",
+            }
+
+            # LLM 呼び出しを LLMLogEntry でラップして BQ に記録する。
+            # 1 iteration = 1 LLM 呼び出し = 1 ログ行 (model/tokens/cost/parsed_*)
+            entry = LLMLogEntry()
+            entry.model = self.model
+            entry.feature = f"chat_orchestrator_iter_{iteration}"
+            entry.prompt_name = "chat_orchestrator_system"
+            entry.prompt_version = get_prompt_version("chat_orchestrator_system")
+            entry.user_query = (user_query or "")[:500]
+
+            llm_t0 = time.time()
+            function_calls: List[Any] = []
+            iter_text_parts: List[str] = []
+            last_usage = None
+            try:
+                stream = self._client.models.generate_content_stream(
+                    model=self.model,
+                    contents=contents,
+                    config=self._gen_config,
+                )
+
+                for chunk in stream:
+                    # 各 chunk に usage_metadata が累積で乗ってくる。最後のものを採用。
+                    if getattr(chunk, "usage_metadata", None):
+                        last_usage = chunk.usage_metadata
+                    for cand in (chunk.candidates or []):
+                        for part in (cand.content.parts or []):
+                            if part.function_call:
+                                function_calls.append(part.function_call)
+                            elif part.text:
+                                accumulated_answer += part.text
+                                iter_text_parts.append(part.text)
+                                yield {
+                                    "type": "token",
+                                    "content": part.text,
+                                    "node": "synthesizer",
+                                }
+                entry.success = True
+                entry.response_answer = "".join(iter_text_parts) or None
+
+                # function_call の引数を parsed_* カラムに記録 (Orchestrator が解析した結果)
+                for fc in function_calls:
+                    fc_args = dict(fc.args or {})
+                    if fc_args.get("name"):
+                        entry.parsed_player_name = fc_args.get("name")
+                    if fc_args.get("query_type"):
+                        entry.parsed_query_type = fc_args.get("query_type")
+                    metrics = fc_args.get("metrics")
+                    if metrics:
+                        entry.parsed_metrics = json.dumps(metrics, ensure_ascii=False)
+                    if fc_args.get("season") is not None:
+                        try:
+                            entry.parsed_season = int(fc_args["season"])
+                        except (TypeError, ValueError):
+                            pass
+
+                # usage_metadata からトークン数・コスト算出
+                if last_usage:
+                    entry.input_tokens = getattr(last_usage, "prompt_token_count", None) or 0
+                    entry.output_tokens = getattr(last_usage, "candidates_token_count", None) or 0
+                    entry.cached_tokens = getattr(last_usage, "cached_content_token_count", None)
+                    entry.estimated_cost_usd = _calc_cost_usd(
+                        model=self.model,
+                        input_tokens=entry.input_tokens or 0,
+                        output_tokens=entry.output_tokens or 0,
+                        cached_tokens=entry.cached_tokens or 0,
+                    )
+                    # Phase 3-A: chat プールに使用量を計上
+                    try:
+                        total_tokens = (entry.input_tokens or 0) + (entry.output_tokens or 0)
+                        if total_tokens > 0:
+                            get_token_budget_service().record_usage(total_tokens, pool="chat")
+                    except Exception as e:
+                        logger.warning(f"token budget record failed (suppressed): {e}")
+            except Exception as e:
+                entry.success = False
+                entry.error_type = type(e).__name__
+                entry.error_message = str(e)[:500]
+                logger.error(f"ChatOrchestrator LLM call failed: {e}", exc_info=True)
+                raise
+            finally:
+                entry.llm_latency_ms = (time.time() - llm_t0) * 1000.0
+                try:
+                    get_llm_logger().log(entry)
+                except Exception as e:
+                    # ロギング失敗は本処理に影響させない
+                    logger.warning(f"LLM log write failed (suppressed): {e}")
+                accumulated_llm_ms += entry.llm_latency_ms
+
+            yield {
+                "type": "state_update",
+                "node": "oracle",
+                "status": "completed",
+                "message": "oracle 完了",
+                "timestamp": _now_iso(),
+                "step_type": "node_end",
+            }
+
+            if not function_calls:
+                payload = _extract_structured_payload(tool_results_seen)
+                yield {
+                    "type": "final_answer",
+                    "answer": accumulated_answer.strip(),
+                    **payload,
+                    "isStrategyReport": False,
+                    "strategyData": None,
+                    "llm_latency_ms": accumulated_llm_ms,
+                }
+                return
+
+            # tool_use を contents に積む + 各 tool を実行
+            contents.append(types.Content(
+                role="model",
+                parts=[types.Part(function_call=fc) for fc in function_calls],
+            ))
+            for fc in function_calls:
+                yield {
+                    "type": "tool_start",
+                    "tool_name": fc.name,
+                    "message": f"🔧 {fc.name} を実行中...",
+                    "timestamp": _now_iso(),
+                    "step_type": "tool_call",
+                }
+                args = dict(fc.args or {})
+                result = self._execute_tool(fc.name, args)
+                tool_results_seen.append(result)
+                output_summary = ""
+                if isinstance(result, list):
+                    output_summary = f"{len(result)}件のデータを取得"
+                yield {
+                    "type": "tool_end",
+                    "tool_name": fc.name,
+                    "message": f"✅ {fc.name} 完了",
+                    "output_summary": output_summary,
+                    "timestamp": _now_iso(),
+                    "step_type": "tool_result",
+                }
+                sanitized = _sanitize_tool_result(result)
+                contents.append(types.Content(
+                    role="user",
+                    parts=[types.Part(function_response=types.FunctionResponse(
+                        name=fc.name,
+                        response={"result": sanitized},
+                    ))],
+                ))
+
+            # ===== 分岐: tool 実行後の応答生成モード =====
+            # synthesize_response=False (デフォルト): LLM #2 を呼ばず、tool 生データを Markdown に整形して返す。
+            # synthesize_response=True: ループを続け、次の iteration で LLM が応答合成する。
+            if not self.synthesize_response:
+                payload = _extract_structured_payload(tool_results_seen)
+                # 生データを LLM 不使用で Markdown 整形
+                formatted_answer = _format_rows_as_markdown(tool_results_seen)
+                # tool 戻り値から BQ 累計時間を集計 (ContextVar 非経由)
+                bq_latency_ms = sum(
+                    res.get("bigquery_latency_ms", 0) or 0
+                    for res in tool_results_seen
+                    if isinstance(res, dict)
+                )
+                yield {
+                    "type": "final_answer",
+                    "answer": formatted_answer,
+                    **payload,
+                    "isStrategyReport": False,
+                    "strategyData": None,
+                    "llm_latency_ms": accumulated_llm_ms,
+                    "bigquery_latency_ms": bq_latency_ms or None,
+                }
+                return
+
+        logger.warning("ChatOrchestrator stream hit MAX_TOOL_ITERATIONS")
+        yield {
+            "type": "final_answer",
+            "answer": accumulated_answer.strip() or "ツール呼び出しが上限に達しました。質問を簡潔にして再度お試しください。",
+            **_extract_structured_payload(tool_results_seen),
+            "isStrategyReport": False,
+            "strategyData": None,
+            "llm_latency_ms": accumulated_llm_ms,
+        }
+
+

--- a/backend/app/services/llm_gateway_service.py
+++ b/backend/app/services/llm_gateway_service.py
@@ -14,7 +14,7 @@ import os
 import time
 import logging
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Callable, Dict, Optional
 
 from dotenv import load_dotenv
 from google import genai
@@ -96,7 +96,11 @@ def call_gemini(
     user_id: str = "",
     endpoint: Optional[str] = None,
     request_id: Optional[str] = None,
+    prompt_name: Optional[str] = None,
     prompt_version: Optional[str] = None,
+    user_query: Optional[str] = None,
+    resolved_query: Optional[str] = None,
+    post_response_hook: Optional[Callable[[str, LLMLogEntry], None]] = None,
 ) -> Optional[str]:
     """
     Gemini テキスト生成の単一窓口。
@@ -106,22 +110,36 @@ def call_gemini(
         model: gemini-2.5-flash / gemini-2.0-flash 等
         response_mime_type: "text/plain" or "application/json"
         feature: ダッシュボード集計用タグ (例 "ai_summary", "routing_judge")
-        user_id: Firebase UID 等 (集計用に caller から伝搬)
-        endpoint: 呼び出し元 API パス (任意)
-        request_id: HTTP リクエスト ID (任意)
+        user_id: Firebase UID 等 (省略時は ContextVar から auto-populate)
+        endpoint: 呼び出し元 API パス (省略時は ContextVar から auto-populate)
+        request_id: HTTP リクエスト ID (省略時は ContextVar から auto-populate)
+        prompt_name: prompt registry のキー名 (任意)
         prompt_version: prompt registry から取得した version (任意)
+        user_query: BQ ログの user_query カラムに記録する真のユーザー入力文。
+                    省略時は空文字を記録する (プロンプト本文は記録しない)。
+        resolved_query: 会話履歴コンテキスト解決後のクエリ (任意)
+        post_response_hook: LLM 応答受信後、ログ書き込み前に呼ばれるフック。
+                            caller が parsed_query_type / parsed_metrics 等の
+                            派生フィールドを log entry に詰めるために使う。
+                            シグネチャ: (response_text: str, entry: LLMLogEntry) -> None
 
     Returns:
         生成テキスト、または失敗時 None (既存 _make_request と互換)
     """
     entry = LLMLogEntry()
-    entry.user_id = user_id
+    # 明示引数は ContextVar auto-populate を上書きする (auto は __init__ 内)
+    if user_id:
+        entry.user_id = user_id
+    if endpoint is not None:
+        entry.endpoint = endpoint
+    if request_id is not None:
+        entry.request_id = request_id
     entry.model = model
-    entry.endpoint = endpoint
-    entry.request_id = request_id
     entry.feature = feature
+    entry.prompt_name = prompt_name
     entry.prompt_version = prompt_version
-    entry.user_query = prompt[:500]  # プロンプト先頭500文字（全文は冗長）
+    entry.user_query = (user_query or "")[:500]
+    entry.resolved_query = resolved_query
 
     text: Optional[str] = None
     t0 = time.time()
@@ -159,6 +177,14 @@ def call_gemini(
             logger.warning("Gemini SDK returned no text")
         else:
             entry.success = True
+            entry.response_answer = text
+            # caller が derived field (parsed_*) を log entry に書き込めるフック。
+            # フック内例外は本処理に伝播させない (ロギングは best-effort)。
+            if post_response_hook is not None:
+                try:
+                    post_response_hook(text, entry)
+                except Exception as e:
+                    logger.warning(f"post_response_hook failed (suppressed): {e}")
 
     except Exception as e:
         entry.success = False
@@ -207,12 +233,19 @@ class LangchainUsageCallback(BaseCallbackHandler):
         model: str,
         user_id: str = "",
         endpoint: Optional[str] = None,
+        pool: str = "chat",
     ):
+        """
+        Args:
+            pool: Phase 3-A 用。"chat" または "report"。
+                  StrategyAgent / strategy-report 系は "report" を指定すること。
+        """
         super().__init__() if _LANGCHAIN_AVAILABLE else None
         self.feature = feature
         self.model = model
         self.user_id = user_id
         self.endpoint = endpoint
+        self.pool = pool
         self._start_time: Optional[float] = None
 
     # LangChain は chat-style では on_chat_model_start を呼ぶ
@@ -273,6 +306,15 @@ class LangchainUsageCallback(BaseCallbackHandler):
             get_llm_logger().log(entry)
         except Exception as e:
             logger.error(f"LangchainUsageCallback: log failed: {e}")
+
+        # Phase 3-A: プール別に使用量を計上
+        try:
+            from backend.app.services.token_budget_service import get_token_budget_service
+            total_tokens = (entry.input_tokens or 0) + (entry.output_tokens or 0)
+            if total_tokens > 0 and self.pool in ("chat", "report"):
+                get_token_budget_service().record_usage(total_tokens, pool=self.pool)
+        except Exception as e:
+            logger.warning(f"LangchainUsageCallback: budget record failed (suppressed): {e}")
 
     def on_llm_error(self, error, **kwargs):
         entry = LLMLogEntry()

--- a/backend/app/services/llm_logger_service.py
+++ b/backend/app/services/llm_logger_service.py
@@ -13,7 +13,13 @@ from google.cloud import bigquery
 import json
 import logging
 
-from backend.app.middleware.request_context import get_trace_id
+from backend.app.middleware.request_context import (
+    get_endpoint,
+    get_request_id,
+    get_session_id,
+    get_trace_id,
+    get_user_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,12 +34,14 @@ class LLMLogEntry:
 
     def __init__(self):
         self.log_id = str(uuid.uuid4())
-        self.user_id: str = ""
+        # ContextVar からの auto-populate（caller が明示セットすれば上書きされる）
+        # request middleware / firebase_auth / endpoint で set 済みの値を流用し、
+        # 全 LLM 呼び出しログに横断的なトレース情報を埋める。
+        self.user_id: str = get_user_id() or ""
         self.timestamp = datetime.now(timezone.utc).isoformat()
-        self.request_id: Optional[str] = None
-        # Snowflake-style 横断的 trace id（ContextVar から自動取得、明示セットで上書き可）
+        self.request_id: Optional[str] = get_request_id() or None
         self.trace_id: Optional[str] = get_trace_id() or None
-        self.session_id: Optional[str] = None
+        self.session_id: Optional[str] = get_session_id() or None
         self.user_query: str = ""
         self.resolved_query: Optional[str] = None
         self.prompt_name: Optional[str] = None
@@ -52,7 +60,7 @@ class LLMLogEntry:
         self.llm_latency_ms: Optional[float] = None
         self.total_latency_ms: Optional[float] = None
         self.bigquery_latency_ms: Optional[float] = None
-        self.endpoint: Optional[str] = None
+        self.endpoint: Optional[str] = get_endpoint() or None
         self.user_rating: Optional[str] = None
         self.feedback_category: Optional[str] = None
         self.feedback_reason: Optional[str] = None

--- a/backend/app/services/token_budget_service.py
+++ b/backend/app/services/token_budget_service.py
@@ -1,56 +1,93 @@
 """
 Daily LLM Token Budget Tracking (In-Memory)
-インメモリで日次トークン使用量を記録し、予算超過を検出する。
-Redis不要。Cloud Runコンテナ再起動時にリセットされるが、
-コスト防御目的には十分機能する。
+インメモリで日次トークン使用量をプール別に記録し、予算超過を検出する。
+Redis不要。Cloud Runコンテナ再起動時にリセットされるが、コスト防御目的には十分機能する。
+
+Phase 3-A: プール分離
+  - "chat":   ChatOrchestrator 経由 (チャット機能)
+  - "report": StrategyAgent / strategy-report エンドポイント経由 (レポート機能)
+  - "shared": 上記合算の hard cap (旧 llm_daily_token_budget 互換)
 """
 import threading
 from datetime import datetime, timezone
+from typing import Dict, Literal
+
 from backend.app.config.settings import get_settings
 from backend.app.utils.structured_logger import get_logger
 
 logger = get_logger("token-budget")
+
+Pool = Literal["chat", "report", "shared"]
 
 
 class TokenBudgetService:
 
     def __init__(self):
         settings = get_settings()
-        self.daily_budget = settings.llm_daily_token_budget
-        self._usage: int = 0
+        # プール別予算
+        self.daily_budget: Dict[str, int] = {
+            "chat": settings.llm_daily_token_budget_chat,
+            "report": settings.llm_daily_token_budget_report,
+            "shared": settings.llm_daily_token_budget,  # 合算 hard cap
+        }
+        # プール別使用量
+        self._usage: Dict[str, int] = {"chat": 0, "report": 0}
         self._current_date: str = ""
         self._lock = threading.Lock()
 
     def _today(self) -> str:
-        """今日の日付文字列（UTC基準）"""
         return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     def _reset_if_new_day(self) -> None:
-        """日付が変わっていたらカウンターをリセット"""
         today = self._today()
         if self._current_date != today:
-            self._usage = 0
+            self._usage = {"chat": 0, "report": 0}
             self._current_date = today
 
-    def record_usage(self, tokens_used: int) -> None:
-        """トークン使用量を記録"""
+    def record_usage(self, tokens_used: int, pool: Pool = "chat") -> None:
+        """指定プールにトークン使用量を記録する。
+
+        Args:
+            tokens_used: 加算するトークン数
+            pool: "chat" または "report"。"shared" は記録不可 (合算は派生値)
+        """
+        if pool == "shared":
+            raise ValueError(
+                "'shared' プールには直接記録できません。chat か report を指定してください"
+            )
         with self._lock:
             self._reset_if_new_day()
-            self._usage += tokens_used
+            self._usage[pool] += tokens_used
+            logger.info(
+                "token_budget_recorded",
+                pool=pool,
+                tokens=tokens_used,
+                pool_usage=self._usage[pool],
+                pool_remaining=max(0, self.daily_budget[pool] - self._usage[pool]),
+            )
 
-    def get_usage(self) -> int:
-        """本日のトークン使用量を取得"""
+    def get_usage(self, pool: Pool = "chat") -> int:
+        """指定プールの本日の使用量を取得。"""
         with self._lock:
             self._reset_if_new_day()
-            return self._usage
+            if pool == "shared":
+                return self._usage["chat"] + self._usage["report"]
+            return self._usage[pool]
 
-    def is_budget_exceeded(self) -> bool:
-        """予算超過かどうかを判定"""
-        return self.get_usage() >= self.daily_budget
+    def is_budget_exceeded(self, pool: Pool = "chat") -> bool:
+        """指定プールが予算超過かどうかを判定。
+        プール別上限 OR 合算 hard cap のいずれか超過なら True。
+        """
+        if pool == "shared":
+            return self.get_usage("shared") >= self.daily_budget["shared"]
+        return (
+            self.get_usage(pool) >= self.daily_budget[pool]
+            or self.get_usage("shared") >= self.daily_budget["shared"]
+        )
 
-    def get_remaining(self) -> int:
-        """残りトークン数"""
-        return max(0, self.daily_budget - self.get_usage())
+    def get_remaining(self, pool: Pool = "chat") -> int:
+        """指定プールの残りトークン数"""
+        return max(0, self.daily_budget[pool] - self.get_usage(pool))
 
 
 _instance = None

--- a/backend/app/services/tools/__init__.py
+++ b/backend/app/services/tools/__init__.py
@@ -1,0 +1,68 @@
+"""
+共通ツールモジュール。
+ChatOrchestrator (Phase 2 で導入) と StrategyAgent の両方から import される。
+
+依存ルール:
+  - 他の services/*.py に依存してよいのは bigquery_service / cache_service / analytics/ のみ
+  - LangGraph / LangChain agent ロジックには依存しない（双方向依存を避けるため）
+"""
+from .batter_stats_tool import get_batter_stats_tool
+from .pitcher_stats_tool import get_pitcher_stats_tool
+from .matchup_history_tool import mlb_matchup_history_tool
+from .matchup_analytics_tool import mlb_matchup_analytics_tool
+
+__all__ = [
+    "get_batter_stats_tool",
+    "get_pitcher_stats_tool",
+    "mlb_matchup_history_tool",
+    "mlb_matchup_analytics_tool",
+]
+
+
+from ._genai_schemas import (
+    CHAT_TOOL_DECLARATIONS,
+    CHAT_TOOL_DECLARATIONS_SEMANTIC,
+    GET_BATTER_STATS_DECL,
+    GET_PITCHER_STATS_DECL,
+    MATCHUP_HISTORY_DECL,
+    MATCHUP_ANALYTICS_DECL,
+    QUERY_SEMANTIC_METRICS_DECL,
+)
+
+# ツール名 → 実体関数のマップ（ChatOrchestrator の dispatch 用）
+# USE_SEMANTIC_LAYER=false 用 (legacy METRIC_MAP 経路)
+CHAT_TOOL_REGISTRY = {
+    "get_batter_stats_tool": get_batter_stats_tool,
+    "get_pitcher_stats_tool": get_pitcher_stats_tool,
+    "mlb_matchup_history_tool": mlb_matchup_history_tool,
+    "mlb_matchup_analytics_tool": mlb_matchup_analytics_tool,
+}
+
+
+def _get_semantic_tool_registry() -> dict:
+    """USE_SEMANTIC_LAYER=true 用の registry を遅延構築する。
+    query_semantic_metrics_tool が ai_agent_service にあるため、
+    モジュール読み込み時に import すると循環依存が発生する。
+    呼び出し時 (ChatOrchestrator.__init__) に解決する。
+
+    matchup 系は Semantic Layer 化未着手のため legacy のまま維持。
+    """
+    from backend.app.services.ai_agent_service import query_semantic_metrics_tool
+    return {
+        "query_semantic_metrics_tool": query_semantic_metrics_tool,
+        "mlb_matchup_history_tool": mlb_matchup_history_tool,
+        "mlb_matchup_analytics_tool": mlb_matchup_analytics_tool,
+    }
+
+
+__all__ += [
+    "CHAT_TOOL_DECLARATIONS",
+    "CHAT_TOOL_DECLARATIONS_SEMANTIC",
+    "CHAT_TOOL_REGISTRY",
+    "_get_semantic_tool_registry",
+    "GET_BATTER_STATS_DECL",
+    "GET_PITCHER_STATS_DECL",
+    "MATCHUP_HISTORY_DECL",
+    "MATCHUP_ANALYTICS_DECL",
+    "QUERY_SEMANTIC_METRICS_DECL",
+]

--- a/backend/app/services/tools/_genai_schemas.py
+++ b/backend/app/services/tools/_genai_schemas.py
@@ -1,0 +1,248 @@
+"""
+google-genai SDK 用の FunctionDeclaration スキーマ定義。
+@tool デコレータ付きの本体関数はそのまま使い回し、SDK 渡し用のスキーマのみここで管理する。
+
+設計判断:
+- LangChain @tool は Pydantic 由来の docstring/型ヒントから自動でスキーマを作るが、
+  google-genai は明示的な FunctionDeclaration が必要。
+- 自動変換ライブラリ (langchain → genai) を入れると依存が増えるため、Phase 2 では手書きで割り切る。
+- ツール本体の引数を変更したら、ここも同期で更新する責任を負う（Phase 3 で自動化検討）。
+"""
+from google.genai import types
+
+
+GET_BATTER_STATS_DECL = types.FunctionDeclaration(
+    name="get_batter_stats_tool",
+    description=(
+        "打撃成績を BigQuery から取得する。"
+        "**呼び出し元の LLM (ChatOrchestrator) がユーザー質問を解析し、ここに構造化引数を直接渡すこと**。"
+        "ツール内では NLU をスキップし、与えられた引数で動的 SQL を組み立てて結果を返す。"
+        "output_format='data' (デフォルト) は生データを返す。応答文の生成は呼び出し元 LLM が行う。"
+    ),
+    parameters={
+        "type": "OBJECT",
+        "properties": {
+            "query_type": {
+                "type": "STRING",
+                "enum": ["season_batting", "batting_splits", "career_batting"],
+                "description": "年指定+状況なし→season_batting / 年指定+状況あり→batting_splits / 通算→career_batting",
+            },
+            "metrics": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "取得指標 (例: ['homerun'], ['batting_average'], ['main_stats'])",
+            },
+            "name": {
+                "type": "STRING",
+                "description": "選手名 (英語フルネーム、例: 'Shohei Ohtani')",
+            },
+            "season": {
+                "type": "INTEGER",
+                "description": "対象シーズン (例: 2026)。通算/全シーズンの場合は省略。",
+            },
+            "split_type": {
+                "type": "STRING",
+                "enum": [
+                    "risp", "bases_loaded", "runner_on_1b", "inning",
+                    "pitcher_throws", "pitch_type", "game_score_situation", "monthly",
+                ],
+                "description": "状況別カット (query_type='batting_splits' 時に指定)",
+            },
+            "inning": {
+                "type": "ARRAY",
+                "items": {"type": "INTEGER"},
+                "description": "split_type='inning' 用 (例: [1], [7,8,9])",
+            },
+            "strikes": {"type": "INTEGER"},
+            "balls": {"type": "INTEGER"},
+            "game_score": {
+                "type": "STRING",
+                "description": "例: 'one_run_lead', 'one_run_trail', 'four_plus_run_lead'",
+            },
+            "pitcher_throws": {
+                "type": "STRING",
+                "enum": ["LHP", "RHP"],
+            },
+            "pitch_type": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+            },
+            "order_by": {"type": "STRING"},
+            "limit": {"type": "INTEGER"},
+            "output_format": {
+                "type": "STRING",
+                "enum": ["data", "sentence", "table"],
+                "description": "'data' (デフォルト): 生データ。'table': UI 表形式。'sentence': ツール内 LLM 文章化 (非推奨)",
+            },
+            "query": {
+                "type": "STRING",
+                "description": "[後方互換] 構造化引数を渡せない時のみ。指定すると tool 内で NLU LLM が走る (旧挙動)。",
+            },
+        },
+    },
+)
+
+GET_PITCHER_STATS_DECL = types.FunctionDeclaration(
+    name="get_pitcher_stats_tool",
+    description=(
+        "投球成績を BigQuery から取得する。"
+        "**呼び出し元の LLM がユーザー質問を解析し、ここに構造化引数を直接渡すこと**。"
+        "ツール内では NLU をスキップする。"
+    ),
+    parameters={
+        "type": "OBJECT",
+        "properties": {
+            "query_type": {
+                "type": "STRING",
+                "enum": ["season_pitching", "pitching_splits", "career_pitching"],
+            },
+            "metrics": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "取得指標 (例: ['era'], ['strikeouts'], ['main_stats'])",
+            },
+            "name": {"type": "STRING", "description": "投手名 (英語フルネーム)"},
+            "season": {"type": "INTEGER"},
+            "split_type": {
+                "type": "STRING",
+                "enum": [
+                    "risp", "bases_loaded", "runner_on_1b", "inning",
+                    "game_score_situation", "monthly",
+                ],
+            },
+            "inning": {"type": "ARRAY", "items": {"type": "INTEGER"}},
+            "strikes": {"type": "INTEGER"},
+            "balls": {"type": "INTEGER"},
+            "game_score": {"type": "STRING"},
+            "pitch_type": {"type": "ARRAY", "items": {"type": "STRING"}},
+            "order_by": {"type": "STRING"},
+            "limit": {"type": "INTEGER"},
+            "output_format": {
+                "type": "STRING",
+                "enum": ["data", "sentence", "table"],
+                "description": "'data' (デフォルト) / 'table' / 'sentence' (非推奨)",
+            },
+            "query": {
+                "type": "STRING",
+                "description": "[後方互換] 自然言語クエリ。指定すると tool 内で NLU LLM が走る。",
+            },
+        },
+    },
+)
+
+MATCHUP_HISTORY_DECL = types.FunctionDeclaration(
+    name="mlb_matchup_history_tool",
+    description="特定の打者と投手の過去の全対決履歴を取得する。打席ごとの配球の流れ、結果、コース等を取得できる。",
+    parameters={
+        "type": "OBJECT",
+        "properties": {
+            "batter_name": {"type": "STRING", "description": "打者のフルネーム（例: 'Shohei Ohtani'）"},
+            "pitcher_name": {"type": "STRING", "description": "投手のフルネーム（例: 'Yu Darvish'）"},
+        },
+        "required": ["batter_name", "pitcher_name"],
+    },
+)
+
+MATCHUP_ANALYTICS_DECL = types.FunctionDeclaration(
+    name="mlb_matchup_analytics_tool",
+    description="特定の打者と投手の球種別対戦相性サマリー（打率・OPS・空振り率・球速等）を取得する。",
+    parameters={
+        "type": "OBJECT",
+        "properties": {
+            "batter_name": {"type": "STRING", "description": "打者のフルネーム"},
+            "pitcher_name": {"type": "STRING", "description": "投手のフルネーム"},
+        },
+        "required": ["batter_name", "pitcher_name"],
+    },
+)
+
+QUERY_SEMANTIC_METRICS_DECL = types.FunctionDeclaration(
+    name="query_semantic_metrics_tool",
+    description=(
+        "dbt Semantic Layer (MetricFlow) から打撃・投手メトリクスを取得する。"
+        "**USE_SEMANTIC_LAYER=true** 時の唯一のデータ取得経路。"
+        "**呼び出し元の LLM が ユーザー質問を解析し、ここに構造化引数を直接渡すこと**。"
+        "metrics 名は Semantic Layer 登録済みの正規名のみ使用可。"
+        "選手フィルタは mlbid (整数) または where=[\"player__player_name = 'フルネーム'\"] のいずれか。"
+    ),
+    parameters={
+        "type": "OBJECT",
+        "properties": {
+            "metrics": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": (
+                    "取得するメトリクス名のリスト (Semantic Layer 登録済み正規名)。"
+                    "例: ['batting_average', 'ops_metric', 'home_runs_total']。"
+                    "短縮形 (avg, ops, hr) は禁止。"
+                ),
+            },
+            "entity_type": {
+                "type": "STRING",
+                "enum": ["player", "pitcher"],
+                "description": "'player' (打者用 batter_season) または 'pitcher' (投手用 pitcher_season)",
+            },
+            "mlbid": {
+                "type": "INTEGER",
+                "description": (
+                    "MLB ID (例: 大谷=660271, ジャッジ=592450, ベッツ=605141, "
+                    "フリーマン=518692, ソト=665742, 山本=808967, アクーニャ=660670, ラミレス=608070)。"
+                    "リストにない選手は省略し、where 句で player__player_name で絞り込む。"
+                ),
+            },
+            "season": {
+                "type": "INTEGER",
+                "description": "対象シーズン (例: 2026)。「今年」「今シーズン」は現在年、省略時もデフォルト現在年。",
+            },
+            "team": {
+                "type": "STRING",
+                "description": "チーム略称 (例: 'LAD', 'NYY')",
+            },
+            "group_by": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "集計次元 (任意)",
+            },
+            "where": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": (
+                    "追加 WHERE 句 (MetricFlow Jinja 構文)。"
+                    "選手名で絞り込む場合: [\"player__player_name = 'Shohei Ohtani'\"]"
+                ),
+            },
+            "order_by": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "ソート対象メトリクス名",
+            },
+            "limit": {
+                "type": "INTEGER",
+                "description": "取得行数上限 (デフォルト 20)",
+            },
+            "output_format": {
+                "type": "STRING",
+                "enum": ["sentence", "table"],
+                "description": "'sentence' (文章) または 'table' (UI 表形式)",
+            },
+        },
+        "required": ["metrics"],
+    },
+)
+
+
+# USE_SEMANTIC_LAYER=false 時の標準ツール (legacy METRIC_MAP 経路)
+CHAT_TOOL_DECLARATIONS = [
+    GET_BATTER_STATS_DECL,
+    GET_PITCHER_STATS_DECL,
+    MATCHUP_HISTORY_DECL,
+    MATCHUP_ANALYTICS_DECL,
+]
+
+# USE_SEMANTIC_LAYER=true 時のツール (Semantic Layer 経路)
+# matchup 系は Semantic Layer 化未着手のため legacy のまま維持
+CHAT_TOOL_DECLARATIONS_SEMANTIC = [
+    QUERY_SEMANTIC_METRICS_DECL,
+    MATCHUP_HISTORY_DECL,
+    MATCHUP_ANALYTICS_DECL,
+]

--- a/backend/app/services/tools/batter_stats_tool.py
+++ b/backend/app/services/tools/batter_stats_tool.py
@@ -1,0 +1,50 @@
+from typing import List, Optional
+
+from langchain_core.tools import tool
+
+
+@tool
+def get_batter_stats_tool(
+    query_type: Optional[str] = None,
+    metrics: Optional[List[str]] = None,
+    name: Optional[str] = None,
+    season: Optional[int] = None,
+    split_type: Optional[str] = None,
+    inning: Optional[List[int]] = None,
+    strikes: Optional[int] = None,
+    balls: Optional[int] = None,
+    game_score: Optional[str] = None,
+    pitcher_throws: Optional[str] = None,
+    pitch_type: Optional[List[str]] = None,
+    order_by: Optional[str] = None,
+    limit: Optional[int] = None,
+    output_format: str = "data",
+    query: Optional[str] = None,
+):
+    """打撃成績を取得する。呼び出し元 LLM が構造化引数を渡すこと。
+    query (NL) を渡した場合は後方互換として tool 内で NLU が走る (非推奨)。
+    """
+    from ..analytics.batter_services import get_ai_response_for_batter_stats
+
+    structured = {
+        "query_type": query_type,
+        "metrics": metrics,
+        "name": name,
+        "season": season,
+        "split_type": split_type,
+        "inning": inning,
+        "strikes": strikes,
+        "balls": balls,
+        "game_score": game_score,
+        "pitcher_throws": pitcher_throws,
+        "pitch_type": pitch_type,
+        "order_by": order_by,
+        "limit": limit,
+        "output_format": output_format,
+    }
+    return get_ai_response_for_batter_stats(
+        query=query,
+        season=season,
+        output_format=output_format,
+        structured_params=structured,
+    )

--- a/backend/app/services/tools/matchup_analytics_tool.py
+++ b/backend/app/services/tools/matchup_analytics_tool.py
@@ -1,0 +1,58 @@
+from langchain_core.tools import tool
+from google.cloud.bigquery import QueryJobConfig, ScalarQueryParameter
+
+from backend.app.utils.structured_logger import get_logger
+from ..bigquery_service import client
+
+logger = get_logger("tools.matchup_analytics")
+
+
+@tool
+def mlb_matchup_analytics_tool(batter_name: str, pitcher_name: str):
+    """
+    特定の打者と投手の『球種別の対戦相性サマリー』を取得する分析ツール。
+    打率、OPSなどの結果だけでなく、空振り率、球速、平均回転数などの球のクオリティも取得できます。
+    batter_name: 打者のフルネーム（例: 'Shohei Ohtani'）
+    pitcher_name: 投手のフルネーム（例: 'Yu Darvish'）
+    """
+    query = f"""
+    SELECT *
+    FROM `tksm-dash-test-25.mlb_analytics_dash_25.view_matchup_pitch_analytics`
+    WHERE (
+        (UPPER(batter_name) = UPPER(@batter_name)) OR
+        (UPPER(batter_name) = UPPER(@batter_reversed)) OR
+        (UPPER(batter_name) LIKE UPPER(@batter_part))
+    ) AND (
+        (UPPER(pitcher_name) = UPPER(@pitcher_name)) OR
+        (UPPER(pitcher_name) = UPPER(@pitcher_reversed)) OR
+        (UPPER(pitcher_name) LIKE UPPER(@pitcher_part))
+    )
+    ORDER BY pitch_count DESC
+    """
+    
+    def reverse_name(name):
+        parts = name.split()
+        return f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) > 1 else name
+    
+    b_rev = reverse_name(batter_name)
+    p_rev = reverse_name(pitcher_name)
+    b_part = f"%{batter_name.split()[-1]}%" if len(batter_name.split()) > 0 else "%"
+    p_part = f"%{pitcher_name.split()[-1]}%" if len(pitcher_name.split()) > 0 else "%"
+
+    query_parameters = [
+        ScalarQueryParameter("batter_name", "STRING", batter_name),
+        ScalarQueryParameter("batter_reversed", "STRING", b_rev),
+        ScalarQueryParameter("batter_part", "STRING", b_part),
+        ScalarQueryParameter("pitcher_name", "STRING", pitcher_name),
+        ScalarQueryParameter("pitcher_reversed", "STRING", p_rev),
+        ScalarQueryParameter("pitcher_part", "STRING", p_part)
+    ]
+
+    job_config = QueryJobConfig(query_parameters=query_parameters)
+
+    try:
+        df = client.query(query, job_config=job_config).to_dataframe()
+        return df.to_dict(orient='records')
+    except Exception as e:
+        logger.error(f"Error in mlb_matchup_analytics_tool: {e}")
+        return []

--- a/backend/app/services/tools/matchup_history_tool.py
+++ b/backend/app/services/tools/matchup_history_tool.py
@@ -1,0 +1,75 @@
+from langchain_core.tools import tool
+from google.cloud.bigquery import QueryJobConfig, ScalarQueryParameter
+
+from backend.app.core.exceptions import DataFetchError
+from backend.app.utils.structured_logger import get_logger
+from ..bigquery_service import client
+from ..cache_service import StatsCache
+
+logger = get_logger("tools.matchup_history")
+
+
+@tool
+def mlb_matchup_history_tool(batter_name: str, pitcher_name: str):
+    """
+    特定の打者と投手の『過去の全対決履歴』を取得するツール。
+    打席ごとの配球（球種の流れ）や、結果、コースなどの詳細なプロセスを取得できます。
+    batter_name: 打者のフルネーム（例: 'Shohei Ohtani'）
+    pitcher_name: 投手のフルネーム（例: 'Yu Darvish'）
+    """
+    logger.info(f"🔍 DEBUG: mlb_matchup_history_tool called with batter='{batter_name}', pitcher='{pitcher_name}'")
+    batter_name = batter_name.strip()
+    pitcher_name = pitcher_name.strip()
+
+    query = f"""
+    SELECT *
+    FROM `tksm-dash-test-25.mlb_analytics_dash_25.view_matchup_specific_history`
+    WHERE (
+        (UPPER(batter_name) = UPPER(@batter_name)) OR
+        (UPPER(batter_name) = UPPER(@batter_reversed)) OR
+        (UPPER(batter_name) LIKE UPPER(@batter_part))
+    ) AND (
+        (UPPER(pitcher_name) = UPPER(@pitcher_name)) OR
+        (UPPER(pitcher_name) = UPPER(@pitcher_reversed)) OR
+        (UPPER(pitcher_name) LIKE UPPER(@pitcher_part))
+    )
+    ORDER BY game_date DESC, at_bat_number DESC
+    LIMIT 30
+    """
+
+    def reverse_name(name):
+        parts = name.split()
+        return f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) > 1 else name
+
+    b_rev = reverse_name(batter_name)
+    p_rev = reverse_name(pitcher_name)
+    b_part = f"%{batter_name.split()[-1]}%" if len(batter_name.split()) > 0 else "%"
+    p_part = f"%{pitcher_name.split()[-1]}%" if len(pitcher_name.split()) > 0 else "%"
+
+    query_parameters = [
+        ScalarQueryParameter("batter_name", "STRING", batter_name),
+        ScalarQueryParameter("batter_reversed", "STRING", b_rev),
+        ScalarQueryParameter("batter_part", "STRING", b_part),
+        ScalarQueryParameter("pitcher_name", "STRING", pitcher_name),
+        ScalarQueryParameter("pitcher_reversed", "STRING", p_rev),
+        ScalarQueryParameter("pitcher_part", "STRING", p_part)
+    ]
+
+    job_config = QueryJobConfig(query_parameters=query_parameters)
+
+    # Check cache first
+    cache = StatsCache()
+    cached_data = cache.get_player_stats(player_name=batter_name, season=2024, query_type=f"matchup_{pitcher_name}")
+    if cached_data:
+        logger.info("Cache HIT")
+        return cached_data
+    
+    try:
+        df = client.query(query, job_config=job_config).to_dataframe()
+        logger.info(f"✅ Matchup history found", row_count=len(df), batter_name=batter_name, pitcher_name=pitcher_name)
+        result = df.to_dict(orient='records')
+        # Save to Redis
+        cache.set_player_stats(player_name=batter_name, season=2024, query_type=f"matchup_{pitcher_name}", data=result)
+        return result
+    except Exception as e:
+        raise DataFetchError("対戦履歴の取得に失敗しました", original_error=e) from e

--- a/backend/app/services/tools/pitcher_stats_tool.py
+++ b/backend/app/services/tools/pitcher_stats_tool.py
@@ -1,0 +1,48 @@
+from typing import List, Optional
+
+from langchain_core.tools import tool
+
+
+@tool
+def get_pitcher_stats_tool(
+    query_type: Optional[str] = None,
+    metrics: Optional[List[str]] = None,
+    name: Optional[str] = None,
+    season: Optional[int] = None,
+    split_type: Optional[str] = None,
+    inning: Optional[List[int]] = None,
+    strikes: Optional[int] = None,
+    balls: Optional[int] = None,
+    game_score: Optional[str] = None,
+    pitch_type: Optional[List[str]] = None,
+    order_by: Optional[str] = None,
+    limit: Optional[int] = None,
+    output_format: str = "data",
+    query: Optional[str] = None,
+):
+    """投球成績を取得する。呼び出し元 LLM が構造化引数を渡すこと。
+    query (NL) を渡した場合は後方互換として tool 内で NLU が走る (非推奨)。
+    """
+    from ..analytics.pitcher_services import get_ai_response_for_pitcher_stats
+
+    structured = {
+        "query_type": query_type,
+        "metrics": metrics,
+        "name": name,
+        "season": season,
+        "split_type": split_type,
+        "inning": inning,
+        "strikes": strikes,
+        "balls": balls,
+        "game_score": game_score,
+        "pitch_type": pitch_type,
+        "order_by": order_by,
+        "limit": limit,
+        "output_format": output_format,
+    }
+    return get_ai_response_for_pitcher_stats(
+        query=query,
+        season=season,
+        output_format=output_format,
+        structured_params=structured,
+    )

--- a/backend/scripts/poc/poc_genai_tool_stream.py
+++ b/backend/scripts/poc/poc_genai_tool_stream.py
@@ -1,0 +1,93 @@
+"""
+POC: google-genai SDK の tool_use + streaming 動作確認。
+ChatOrchestrator 実装前に SDK の挙動（特に stream 中の function_call 検出方法）を把握する。
+"""
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+
+# プロジェクトルート直下の .env を明示的に読み込む（既存サービスと同じパターン）
+# scripts/poc/poc_genai_tool_stream.py → 3 階層上がプロジェクトルート
+_env_path = Path(__file__).parent.parent.parent.parent / ".env"
+load_dotenv(dotenv_path=_env_path)
+
+
+def main():
+    api_key = os.getenv("GEMINI_API_KEY_V2")
+    if not api_key:
+        raise RuntimeError(
+            f"GEMINI_API_KEY_V2 が見つかりません。.env (探索パス: {_env_path}) を確認してください。"
+        )
+    client = genai.Client(api_key=api_key)
+
+    # 最小限のダミー tool（実 BQ には触らない）
+    add_tool = types.FunctionDeclaration(
+        name="add_two_numbers",
+        description="2 つの整数の和を返す",
+        parameters={
+            "type": "OBJECT",
+            "properties": {
+                "a": {"type": "INTEGER"},
+                "b": {"type": "INTEGER"},
+            },
+            "required": ["a", "b"],
+        },
+    )
+
+    config = types.GenerateContentConfig(
+        tools=[types.Tool(function_declarations=[add_tool])],
+        system_instruction="あなたは計算アシスタント。必ず add_two_numbers ツールを使って答えること。",
+        temperature=0,
+    )
+
+    contents = [
+        types.Content(role="user", parts=[types.Part(text="3 と 5 を足すといくつ？")]),
+    ]
+
+    for iteration in range(3):
+        print(f"\n===== iteration {iteration} =====")
+        stream = client.models.generate_content_stream(
+            model="gemini-2.5-flash",
+            contents=contents,
+            config=config,
+        )
+
+        function_calls = []
+        full_text = ""
+        for chunk_idx, chunk in enumerate(stream):
+            for cand in (chunk.candidates or []):
+                for part in (cand.content.parts or []):
+                    if part.function_call:
+                        print(f"[chunk={chunk_idx}] function_call: name={part.function_call.name}, args={dict(part.function_call.args or {})}")
+                        function_calls.append(part.function_call)
+                    elif part.text:
+                        print(f"[chunk={chunk_idx}] text: {part.text!r}")
+                        full_text += part.text
+
+        if not function_calls:
+            print(f"\n--- DONE (final text: {full_text}) ---")
+            break
+
+        # assistant の function_call を contents に追加
+        contents.append(types.Content(
+            role="model",
+            parts=[types.Part(function_call=fc) for fc in function_calls],
+        ))
+        # tool_response を追加
+        for fc in function_calls:
+            args = dict(fc.args or {})
+            result = args["a"] + args["b"]
+            contents.append(types.Content(
+                role="user",
+                parts=[types.Part(function_response=types.FunctionResponse(
+                    name=fc.name,
+                    response={"result": result},
+                ))],
+            ))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_reflection_loop.py
+++ b/backend/tests/test_reflection_loop.py
@@ -204,7 +204,7 @@ def test_executor_empty_result_detection_list():
     }
 
     # Mock tool result (empty list)
-    with patch("backend.app.services.ai_agent_service.get_batter_stats_tool") as mock_tool:
+    with patch("backend.app.services.tools.batter_stats_tool.get_batter_stats_tool") as mock_tool:
         mock_tool.invoke.return_value = []
 
         result = agent.executor_node(state)
@@ -238,7 +238,7 @@ def test_executor_empty_result_detection_dict():
     }
 
     # Mock tool result (dict with "データが見つかりませんでした" message)
-    with patch("backend.app.services.ai_agent_service.get_pitcher_stats_tool") as mock_tool:
+    with patch("backend.app.services.tools.pitcher_stats_tool.get_pitcher_stats_tool") as mock_tool:
         mock_tool.invoke.return_value = {
             "answer": "指定された条件に一致するデータが見つかりませんでした。",
             "isTable": False
@@ -336,7 +336,7 @@ def test_integration_reflection_triggered_on_empty_result():
     agent.raw_model.invoke.return_value = mock_synthesizer_response
 
     # Mock tool results
-    with patch("backend.app.services.ai_agent_service.get_batter_stats_tool") as mock_tool:
+    with patch("backend.app.services.tools.batter_stats_tool.get_batter_stats_tool") as mock_tool:
         mock_tool.invoke.side_effect = [
             {"answer": "データが見つかりませんでした"},  # Empty result (triggers reflection)
             [{"player": "Test Player", "hr": 30}]       # Success after reflection


### PR DESCRIPTION


Phase 1 — Common tools module
- Move 4 shared tools (batter/pitcher stats, matchup history/analytics) to backend/app/services/tools/
- Keep StrategyAgent and tests pointing at the new import paths

Phase 2 — ChatOrchestrator (raw google-genai SDK + tool_use loop)
- Add backend/app/services/chat_orchestrator.py
- Replace SupervisorAgent + 4 LangGraph sub-agents (Batter/Pitcher/Matchup/Stats) at request time when USE_LEGACY_CHAT_AGENT=false
- Gemini SDK FunctionDeclarations in tools/_genai_schemas.py with structured args
- Add USE_SEMANTIC_LAYER branch: ChatOrchestrator can register query_semantic_metrics_tool when true (Cloud Run only — local lacks SA auth for MetricFlow)
- SSE event contract preserved (routing, state_update, tool_start/end, token, final_answer)

Phase 2.5 — Tool slim-down (4 LLM calls -> 1)
- Tools accept structured args directly; tool-internal _parse_query_with_llm is skipped when structured_params provided
- New output_format='data' returns raw rows and skips the tool's final LLM narration
- ChatOrchestrator's synthesize_response=False (default) returns Markdown-formatted tool data without a second LLM call
- system prompt dynamically injects current year + METRIC_MAP keys / Semantic Layer metrics vocabulary

Phase 3-A — Token Budget pool separation
- TokenBudgetService refactored: chat / report / shared pools with per-pool record_usage / is_budget_exceeded
- ChatOrchestrator records to pool='chat'; LangchainUsageCallback accepts pool kwarg; strategy_report endpoints pass pool='report'

BQ logging fixes
- LLMLogEntry auto-populates request_id / user_id / endpoint / session_id from ContextVar
- firebase_auth middleware now calls set_user_id() for ContextVar wiring
- request_id middleware sets endpoint ContextVar
- ai_analytics endpoints call set_session_id() / reset_bq_latency_ms()
- call_gemini gains user_query / resolved_query / prompt_name / post_response_hook parameters; response_answer column is now populated
- batter_services / pitcher_services hooks populate parsed_query_type / parsed_metrics / parsed_player_name / parsed_season; ChatOrchestrator does the same from function_call args
- bigquery_latency_ms flows back via tool return value (ContextVar fails under StreamingResponse) — endpoint reads it from the final_answer event
- prompt_version pulled from prompt_registry.get_prompt_version (no hardcoding)

Documentation
- README.md / README_JP.md / README_architecture.md / README_ai_architecture.md updated for new architecture, tool slim-down, and pool separation