### PR TITLE
feat: Gemini Context Caching for parse_query / oracle_semantic — ~1/10 input cost reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ An AI-powered analytics interface for exploring Major League Baseball statistics
 
 **Capabilities**:
 - **📝 Prompt Versioning**: Externalized LLM prompts as versioned text files (`parse_query_v1.txt`, `routing_v1.txt`) managed via `prompt_registry.py`, enabling version-controlled prompt iteration without code changes
+- **💾 Context Caching (Gemini)**: Long fixed prompt prefixes (`parse_query_v1`, `oracle_semantic_v1`) registered via `client.caches.create()` and referenced per-request through `cached_content`. Reduces input token billing from ~$0.30/M to ~$0.03/M tokens (~1/10). Per-instance in-memory registry with 1-hour TTL and fail-open fallback ([`prompt_cache_service.py`](backend/app/services/prompt_cache_service.py))
 - **📊 LLM I/O Logging**: Async logging of all LLM interactions (queries, parsed results, latency, errors) to BigQuery via `llm_logger_service.py` for observability and drift detection
 - **🚦 LLM Evaluation Gate**: CI/CD quality gate that runs LLM against a golden dataset (`golden_dataset.json`) and blocks deployment if accuracy drops below 80%
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -105,6 +105,7 @@
 
 **機能**:
 - **📝 プロンプトバージョニング**: LLMプロンプトをバージョン付きテキストファイル（`parse_query_v1.txt`, `routing_v1.txt`）として外部化し、`prompt_registry.py`で管理。コード変更なしでプロンプト改善が可能
+- **💾 Context Caching (Gemini)**: 長い固定プレフィックス（`parse_query_v1`, `oracle_semantic_v1`）を `client.caches.create()` で登録し、リクエストでは `cached_content` 参照のみ送信。input トークン課金を ~$0.30/M → ~$0.03/M (~1/10) に削減。インスタンス毎の in-memory registry、1 時間 TTL、失敗時は自動フォールバック ([`prompt_cache_service.py`](backend/app/services/prompt_cache_service.py))
 - **📊 LLM I/Oロギング**: 全LLMインタラクション（クエリ、パース結果、レイテンシ、エラー）を`llm_logger_service.py`経由でBigQueryに非同期ロギング。可観測性とドリフト検出に活用
 - **🚦 LLM評価ゲート**: ゴールデンデータセット（`golden_dataset.json`）に対してLLMを実行し、精度が80%を下回った場合にデプロイを停止するCI/CD品質ゲート
 

--- a/README_ai_architecture.md
+++ b/README_ai_architecture.md
@@ -11,6 +11,7 @@
 |---|---|
 | [1. 全体像](#1-全体像) | AI コアと harness 層の俯瞰図 |
 | [2. LLM Gateway](#2-llm-gateway-層) | 全 LLM 呼び出しの単一窓口 |
+| [2.5. Context Caching](#25-context-caching) | Gemini Context Caching で input トークン課金を ~1/10 に削減 |
 | [3. Logging & Cost Tracking](#3-logging--cost-tracking-層) | BigQuery への観測ログ |
 | [4. Prompt Registry](#4-prompt-registry-層) | プロンプト版管理（active / shadow） |
 | [5. Judge Layer](#5-judge-layer-llm-as-a-judge) | 5 種の LLM Judge |
@@ -137,6 +138,59 @@ flowchart LR
 ```
 
 LangChain は SDK ラッパー越しに呼ぶため `call_gemini()` を経由いたしません。同等の観測性を保つため `LangchainUsageCallback` を別途用意し、`on_llm_end` で `usage_metadata` を抽出いたします。
+
+---
+
+## 2.5. Context Caching
+
+ファイル: [backend/app/services/prompt_cache_service.py](backend/app/services/prompt_cache_service.py)
+
+### 役割
+
+Gemini Context Caching (`client.caches.create()`) を用いて、**長い固定プレフィックスをサーバ側に保持**し、リクエストでは動的サフィックスのみ送信する。`cached_per_1m_usd = $0.03` を活用し、input トークン課金を **~$0.30/M → ~$0.03/M (約 1/10)** に削減。
+
+### 設計
+
+| 機能 | 実装 |
+|---|---|
+| Cache 取得 | `get_or_create_cache(prompt_name, prompt_version, prefix_text, as_system_instruction=...)` |
+| 一意キー | `(prompt_name, version, model, mode_tag, sha256(prefix_text)[:16])` |
+| 二重作成防止 | `threading.Lock` で同時初回作成を直列化 |
+| TTL 管理 | デフォルト 3600 秒。残り 5 分を切ったら自動再作成 |
+| Fail-open | 作成失敗時は `None` を返し、caller は非キャッシュ経路にフォールバック |
+| 登録モード 2 系統 | `as_system_instruction=False` (user contents) / `True` (system instruction) |
+
+### 適用箇所
+
+| 経路 | プロンプト | 登録モード | トークン数 | 削減効果 |
+|---|---|---|---:|---|
+| `_parse_query_with_llm` ([batter_services.py](backend/app/services/analytics/batter_services.py)) | `parse_query_v1.txt` の `# 本番` マーカー前 (instructions + examples) | user contents | ~2,250 tok | input ~97% がキャッシュヒット |
+| `oracle_node` (Semantic Layer 経路、[batter_agents.py](backend/app/services/agents/batter_agents.py) / [pitcher_agents.py](backend/app/services/agents/pitcher_agents.py)) | `oracle_semantic_v1.txt` に metric/dimension vocab を baked in | system instruction | ~1,100-2,000 tok | 同上 (LangChain `.bind(cached_content=...)` 経由) |
+
+### プロンプト分割パターン
+
+```
+parse_query_v1.txt:
+  ┌──────────────────────────────┐
+  │ instructions + JSON schema + │ ← cacheable prefix (>1,024 token)
+  │ examples (10 個)              │   {current_year} は year 単位で baked in
+  ├──────────────────────────────┤ ← `# 本番` マーカー (split 位置)
+  │ # 本番                        │ ← dynamic suffix
+  │ 質問: 「{query}」             │   毎リクエスト送信
+  │ JSON:                         │
+  └──────────────────────────────┘
+```
+
+### 制約
+
+- **最小トークン数**: Gemini 2.5 Flash で 1,024 token、Pro で 2,048 token を下回ると `caches.create()` が拒否される
+- **キャッシュストレージ料金**: $1.00/M token/hour (例: 2,250 tok × $1/M/hr ≈ $0.054/day)
+- **In-memory dict**: Cloud Run の各インスタンスが個別にキャッシュを作成 (インスタンス間で共有しない)
+- **`USE_SEMANTIC_LAYER=true`** 時のみ oracle 経路のキャッシュが発火 (= Cloud Run 本番)
+
+### 計測
+
+`llm_interaction_logs.cached_tokens` カラムに記録 (`call_gemini` 経路は `usage_metadata.cached_content_token_count` から、LangChain 経路は `LangchainUsageCallback._extract_usage` の `input_token_details.cache_read` から抽出)。
 
 ---
 

--- a/README_architecture.md
+++ b/README_architecture.md
@@ -482,8 +482,9 @@ sequenceDiagram
 |----------|-------|
 | **Prompt Versioning** | Externalized prompts as versioned text files (`parse_query_v1.txt`, `routing_v1.txt`) |
 | **Prompt Registry** | `prompt_registry.py` manages prompt loading and version switching |
+| **Context Caching** | `prompt_cache_service.py` registers long fixed prefixes (`parse_query_v1`, `oracle_semantic_v1`) via `client.caches.create()`; reduces Gemini input billing from ~$0.30/M to ~$0.03/M tokens (~1/10). Per-instance in-memory registry with 1-hour TTL and fail-open fallback |
 | **LLM I/O Logging** | `llm_logger_service.py` logs all LLM interactions to BigQuery asynchronously |
-| **Logged Fields** | User query, parsed result, prompt version, latency, errors, routing result, user feedback, reflection loop metadata (is_retry, retry_count, retry_reason) |
+| **Logged Fields** | User query, parsed result, prompt version, latency, errors, routing result, user feedback, reflection loop metadata (is_retry, retry_count, retry_reason), cached_tokens (Context Caching hit ratio) |
 | **Evaluation Gate** | `evaluate_llm_accuracy.py` runs LLM against golden dataset in CI/CD |
 | **Golden Dataset** | `golden_dataset.json` with test cases covering batting, pitching, splits, career (expandable via HITL) |
 | **Pass Threshold** | 80% accuracy required to proceed with deployment |

--- a/backend/app/services/agents/batter_agents.py
+++ b/backend/app/services/agents/batter_agents.py
@@ -137,7 +137,7 @@ class BatterAgent:
 
     def oracle_node(self, state):
         if self.use_semantic:
-            from backend.app.config.prompt_registry import get_prompt
+            from backend.app.config.prompt_registry import get_prompt, get_prompt_version
             available_metrics = ", ".join(self._metric_metadata.get("metrics", [])) or "(取得不可)"
             available_dimensions = ", ".join(self._metric_metadata.get("dimensions", [])) or "(取得不可)"
             system_prompt = get_prompt(
@@ -145,6 +145,28 @@ class BatterAgent:
                 available_metrics=available_metrics,
                 available_dimensions=available_dimensions,
             )
+
+            # Context Caching: system prompt は metric/dimension vocab を含むが
+            # vocab 変更頻度が低いため cache 効率が高い。LangChain `.bind()` 経由で
+            # cached_content を per-invoke 注入し、失敗時は非キャッシュ経路に倒す。
+            cache_name = None
+            try:
+                from backend.app.services.prompt_cache_service import get_or_create_cache
+                cache_name = get_or_create_cache(
+                    prompt_name="oracle_semantic",
+                    prompt_version=get_prompt_version("oracle_semantic"),
+                    prefix_text=system_prompt,
+                    as_system_instruction=True,
+                )
+            except Exception as e:
+                logger.warning(f"oracle_semantic cache lookup failed: {e}")
+
+            if cache_name:
+                try:
+                    cached_model = self.raw_model.bind(cached_content=cache_name).bind_tools(self.tools)
+                    return {"messages": [cached_model.invoke(state["messages"])]}
+                except Exception as e:
+                    logger.warning(f"cached invoke failed, fallback to non-cached: {e}")
         else:
             system_prompt = """あなたはMLB打撃データの司令塔です。
 

--- a/backend/app/services/agents/pitcher_agents.py
+++ b/backend/app/services/agents/pitcher_agents.py
@@ -135,7 +135,7 @@ class PitcherAgent:
 
     def oracle_node(self, state):
         if self.use_semantic:
-            from backend.app.config.prompt_registry import get_prompt
+            from backend.app.config.prompt_registry import get_prompt, get_prompt_version
             available_metrics = ", ".join(self._metric_metadata.get("metrics", [])) or "(取得不可)"
             available_dimensions = ", ".join(self._metric_metadata.get("dimensions", [])) or "(取得不可)"
             system_prompt = get_prompt(
@@ -143,6 +143,28 @@ class PitcherAgent:
                 available_metrics=available_metrics,
                 available_dimensions=available_dimensions,
             )
+
+            # Context Caching: system prompt は metric/dimension vocab を含むが
+            # vocab 変更頻度が低いため cache 効率が高い。LangChain `.bind()` 経由で
+            # cached_content を per-invoke 注入し、失敗時は非キャッシュ経路に倒す。
+            cache_name = None
+            try:
+                from backend.app.services.prompt_cache_service import get_or_create_cache
+                cache_name = get_or_create_cache(
+                    prompt_name="oracle_semantic",
+                    prompt_version=get_prompt_version("oracle_semantic"),
+                    prefix_text=system_prompt,
+                    as_system_instruction=True,
+                )
+            except Exception as e:
+                logger.warning(f"oracle_semantic cache lookup failed: {e}")
+
+            if cache_name:
+                try:
+                    cached_model = self.raw_model.bind(cached_content=cache_name).bind_tools(self.tools)
+                    return {"messages": [cached_model.invoke(state["messages"])]}
+                except Exception as e:
+                    logger.warning(f"cached invoke failed, fallback to non-cached: {e}")
         else:
             system_prompt = """あなたはMLB投球データの専門家です。
 

--- a/backend/app/services/analytics/batter_services.py
+++ b/backend/app/services/analytics/batter_services.py
@@ -86,6 +86,11 @@ def _load_prompt_template(template_name: str) -> str:
         raise
 
 
+# parse_query_v1.txt の split 位置。これより前 (instructions + examples) を
+# Gemini Context Cache に登録し、これ以降 (本番マーカー + 質問本文) を毎回送信する。
+_PARSE_QUERY_SPLIT_MARKER = "# 本番"
+
+
 def _parse_query_with_llm(
     query: str,
     season: Optional[int],
@@ -93,6 +98,10 @@ def _parse_query_with_llm(
 ) -> Optional[Dict[str, Any]]:
     """
     [ステップ1] LLMを使い、質問からパラメータを抽出します。
+
+    Context Caching 対応: 固定プレフィックスを caches.create() でサーバ側に登録し、
+    リクエストでは動的サフィックスのみ送信する。input トークン課金を ~1/10 に削減。
+    cache 取得失敗時は無音で従来 (全文送信) 動作にフォールバックする。
 
     Args:
         query: 会話コンテキスト解決後のクエリ (LLM に投げる本文)
@@ -104,23 +113,52 @@ def _parse_query_with_llm(
         logger.error("GEMINI_API_KEY_V2 is not set.")
         return None
 
-    # プロンプトテンプレートを読み込み
     prompt_template = _load_prompt_template("parse_query_v1")
-
-    # seasonパラメータがある場合、ヒントとして追加
-    season_hint = f"\n    - **コンテキスト情報**: 会話履歴から、対象シーズンは {season} 年と推測されます。質問に年の記載がない場合でも、このシーズンを使用してください。" if season else ""
-
-    # プレースホルダーを置換
     current_year = datetime.now().year
-    prompt = prompt_template.format(
-        season_hint=season_hint,
-        query=query,
+    prev_year = current_year - 1
+
+    # cacheable prefix と dynamic suffix に分割
+    if _PARSE_QUERY_SPLIT_MARKER in prompt_template:
+        prefix_raw, suffix_after = prompt_template.split(_PARSE_QUERY_SPLIT_MARKER, 1)
+        suffix_raw = _PARSE_QUERY_SPLIT_MARKER + suffix_after
+    else:
+        prefix_raw, suffix_raw = "", prompt_template
+
+    # プレフィックスは年単位で安定 (TTL 切れで再作成すれば足りる)。
+    # {season_hint} はキャッシュ内では空にし、実 hint は suffix 先頭に prepend する。
+    prefix_text = prefix_raw.format(
+        season_hint="",
         current_year=current_year,
-        prev_year=current_year - 1
+        prev_year=prev_year,
+    ) if prefix_raw else ""
+
+    season_hint_text = (
+        f"\n# 補足: 会話履歴から、対象シーズンは {season} 年と推測されます。"
+        f"質問に年の記載がない場合でも、このシーズンを使用してください。\n"
+        if season else ""
+    )
+    suffix_text = season_hint_text + suffix_raw.format(
+        season_hint="",
+        current_year=current_year,
+        prev_year=prev_year,
+        query=query,
     )
 
-    # LLM の JSON 応答から parsed_* フィールドを log entry に転記するフック。
-    # call_gemini 内で text 受信後・log 書き込み前に呼ばれる。
+    cache_name: Optional[str] = None
+    if prefix_text:
+        try:
+            from backend.app.services.prompt_cache_service import get_or_create_cache
+            cache_name = get_or_create_cache(
+                prompt_name="parse_query",
+                prompt_version=get_prompt_version("parse_query"),
+                prefix_text=prefix_text,
+            )
+        except Exception as e:
+            logger.warning(f"prompt cache lookup failed: {e}")
+
+    # キャッシュあり: suffix のみ送信 / なし: 従来通り全文送信
+    final_prompt = suffix_text if cache_name else (prefix_text + suffix_text)
+
     def _hook(text: str, entry):
         try:
             parsed = json.loads(text)
@@ -133,11 +171,10 @@ def _parse_query_with_llm(
             parsed_season = parsed.get("season")
             entry.parsed_season = int(parsed_season) if parsed_season is not None else None
         except (json.JSONDecodeError, TypeError, ValueError):
-            # ロギング失敗は本処理に影響させない
             pass
 
     text = call_gemini(
-        prompt=prompt,
+        prompt=final_prompt,
         model="gemini-2.5-flash",
         response_mime_type="application/json",
         feature="analytics_batter",
@@ -146,6 +183,7 @@ def _parse_query_with_llm(
         user_query=original_query or query,
         resolved_query=query if (original_query and original_query != query) else None,
         post_response_hook=_hook,
+        cached_content_name=cache_name,
     )
     if not text:
         return None

--- a/backend/app/services/llm_gateway_service.py
+++ b/backend/app/services/llm_gateway_service.py
@@ -84,6 +84,13 @@ def _get_genai_client() -> genai.Client:
     return _genai_client
 
 
+def get_genai_client() -> genai.Client:
+    """Public accessor for the shared genai client.
+    prompt_cache_service 等、gateway 外から caches.create() を呼ぶ用途で利用する。
+    """
+    return _get_genai_client()
+
+
 # ==================================
 # Gateway 本体
 # ==================================
@@ -101,6 +108,7 @@ def call_gemini(
     user_query: Optional[str] = None,
     resolved_query: Optional[str] = None,
     post_response_hook: Optional[Callable[[str, LLMLogEntry], None]] = None,
+    cached_content_name: Optional[str] = None,
 ) -> Optional[str]:
     """
     Gemini テキスト生成の単一窓口。
@@ -145,7 +153,10 @@ def call_gemini(
     t0 = time.time()
     try:
         client = _get_genai_client()
-        config = types.GenerateContentConfig(response_mime_type=response_mime_type)
+        config_kwargs = {"response_mime_type": response_mime_type}
+        if cached_content_name:
+            config_kwargs["cached_content"] = cached_content_name
+        config = types.GenerateContentConfig(**config_kwargs)
 
         response = client.models.generate_content(
             model=model,
@@ -256,14 +267,19 @@ class LangchainUsageCallback(BaseCallbackHandler):
         self._start_time = time.time()
 
     def _extract_usage(self, response) -> Dict[str, int]:
-        """LangChain LLMResult から (input, output) トークン数を抽出。複数 path に対応。"""
-        in_t, out_t = 0, 0
+        """LangChain LLMResult から (input, output, cached) トークン数を抽出。複数 path に対応。"""
+        in_t, out_t, cached_t = 0, 0, 0
         try:
             # Path 1: response.llm_output["token_usage"] (OpenAI 互換 path)
             if getattr(response, "llm_output", None):
                 tu = (response.llm_output or {}).get("token_usage") or {}
                 in_t = tu.get("prompt_token_count") or tu.get("input_tokens") or in_t
                 out_t = tu.get("candidates_token_count") or tu.get("output_tokens") or out_t
+                cached_t = (
+                    tu.get("cached_content_token_count")
+                    or tu.get("cache_read_input_tokens")
+                    or cached_t
+                )
 
             # Path 2: response.generations[0][0].message.usage_metadata (Gemini 経路の主流)
             gens = getattr(response, "generations", None) or []
@@ -274,14 +290,22 @@ class LangchainUsageCallback(BaseCallbackHandler):
                 if um:
                     in_t = in_t or um.get("input_tokens") or 0
                     out_t = out_t or um.get("output_tokens") or 0
+                    # LangChain usage_metadata は input_token_details に cache_read を入れる
+                    details = um.get("input_token_details") or {}
+                    cached_t = cached_t or details.get("cache_read") or 0
                 # Path 3: generation_info
                 gi = getattr(first, "generation_info", None) or {}
                 um2 = gi.get("usage_metadata") or {}
                 in_t = in_t or um2.get("prompt_token_count") or 0
                 out_t = out_t or um2.get("candidates_token_count") or 0
+                cached_t = cached_t or um2.get("cached_content_token_count") or 0
         except Exception as e:
             logger.warning(f"LangchainUsageCallback: failed to extract usage: {e}")
-        return {"input_tokens": int(in_t or 0), "output_tokens": int(out_t or 0)}
+        return {
+            "input_tokens": int(in_t or 0),
+            "output_tokens": int(out_t or 0),
+            "cached_tokens": int(cached_t or 0),
+        }
 
     def on_llm_end(self, response, **kwargs):
         entry = LLMLogEntry()
@@ -293,10 +317,12 @@ class LangchainUsageCallback(BaseCallbackHandler):
         usage = self._extract_usage(response)
         entry.input_tokens = usage["input_tokens"]
         entry.output_tokens = usage["output_tokens"]
+        entry.cached_tokens = usage["cached_tokens"] or None
         entry.estimated_cost_usd = _calc_cost_usd(
             model=self.model,
             input_tokens=entry.input_tokens or 0,
             output_tokens=entry.output_tokens or 0,
+            cached_tokens=entry.cached_tokens or 0,
         )
         if self._start_time:
             entry.llm_latency_ms = (time.time() - self._start_time) * 1000.0

--- a/backend/app/services/prompt_cache_service.py
+++ b/backend/app/services/prompt_cache_service.py
@@ -1,0 +1,102 @@
+"""
+Prompt Cache Service
+Gemini Context Caching の lifecycle 管理。
+固定プレフィックスを `client.caches.create()` で登録し、
+generate_content 時に `cached_content` として参照することで、
+input トークンの再計算課金を ~1/10 に削減する。
+
+設計:
+- in-memory dict (prompt_name, version, content_hash) → cache name
+- TTL 切れ近接時は再作成
+- 失敗時 None を返し caller が非キャッシュ経路にフォールバック
+"""
+import hashlib
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from google.genai import types
+
+from backend.app.services.llm_gateway_service import get_genai_client
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 3600
+MIN_REMAINING_SECONDS = 300  # 残り 5 分を切ったら再作成
+
+
+@dataclass
+class _CacheEntry:
+    name: str
+    created_at: float
+    ttl_seconds: int
+
+
+_registry: Dict[str, _CacheEntry] = {}
+_lock = threading.Lock()
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def get_or_create_cache(
+    *,
+    prompt_name: str,
+    prompt_version: Optional[str],
+    prefix_text: str,
+    model: str = "gemini-2.5-flash",
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    as_system_instruction: bool = False,
+) -> Optional[str]:
+    """プレフィックスに対応する CachedContent name を返す。失敗時 None。
+
+    Args:
+        as_system_instruction: True なら system_instruction として登録 (oracle_semantic 等の
+                               system prompt 用途)。False (デフォルト) なら user contents として登録
+                               (parse_query 等のインライン prompt 用途)。
+    """
+    mode_tag = "sys" if as_system_instruction else "usr"
+    key = f"{prompt_name}|{prompt_version or 'none'}|{model}|{mode_tag}|{_hash(prefix_text)}"
+
+    with _lock:
+        entry = _registry.get(key)
+        if entry is not None:
+            elapsed = time.time() - entry.created_at
+            if elapsed < entry.ttl_seconds - MIN_REMAINING_SECONDS:
+                return entry.name
+
+        try:
+            client = get_genai_client()
+            config_kwargs = {
+                "display_name": f"{prompt_name}_{prompt_version or 'unknown'}",
+                "ttl": f"{ttl_seconds}s",
+            }
+            if as_system_instruction:
+                config_kwargs["system_instruction"] = prefix_text
+            else:
+                config_kwargs["contents"] = [types.Content(
+                    role="user",
+                    parts=[types.Part(text=prefix_text)],
+                )]
+            cache = client.caches.create(
+                model=model,
+                config=types.CreateCachedContentConfig(**config_kwargs),
+            )
+            _registry[key] = _CacheEntry(
+                name=cache.name,
+                created_at=time.time(),
+                ttl_seconds=ttl_seconds,
+            )
+            logger.info(
+                f"Created cache {cache.name} for {prompt_name}_{prompt_version} (mode={mode_tag})"
+            )
+            return cache.name
+        except Exception as e:
+            logger.warning(
+                f"Cache creation failed for {prompt_name}_{prompt_version}: {e}. "
+                f"Will fall back to non-cached path."
+            )
+            return None

--- a/backend/scripts/measure_prompt_tokens.py
+++ b/backend/scripts/measure_prompt_tokens.py
@@ -1,0 +1,41 @@
+"""
+Step 1-1: 候補プロンプトのトークン数を計測し、Context Caching 適用可否を判定する。
+Run: python -m backend.scripts.measure_prompt_tokens
+"""
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from google import genai
+
+# .env ロード（他スクリプトと同じパターン）
+_env_path = Path(__file__).parent.parent.parent / ".env"
+load_dotenv(dotenv_path=_env_path)
+
+client = genai.Client(api_key=os.getenv("GEMINI_API_KEY_V2"))
+MODEL = "gemini-2.5-flash"
+MIN_CACHE_TOKENS = 1024  # Gemini 2.5 Flash の最小要件
+
+# 候補 1: ChatOrchestrator のインライン system prompt
+from backend.app.services.chat_orchestrator import (
+    _build_system_prompt_legacy,
+    _build_system_prompt_semantic,
+)
+
+candidates = {
+    "chat_orchestrator_system_legacy": _build_system_prompt_legacy(),
+    "chat_orchestrator_system_semantic": _build_system_prompt_semantic(),
+}
+
+# 候補 2: prompts/ 配下のファイル
+prompts_dir = Path(__file__).parent.parent / "app" / "prompts"
+for txt_path in sorted(prompts_dir.glob("*.txt")):
+    candidates[txt_path.stem] = txt_path.read_text(encoding="utf-8")
+
+# 計測
+print(f"{'prompt_name':<45} {'tokens':>8}  cacheable?")
+print("-" * 72)
+for name, content in candidates.items():
+    resp = client.models.count_tokens(model=MODEL, contents=content)
+    n = resp.total_tokens
+    flag = "✅ YES" if n >= MIN_CACHE_TOKENS else f"❌ NO (< {MIN_CACHE_TOKENS})"
+    print(f"{name:<45} {n:>8}  {flag}")


### PR DESCRIPTION
## Summary
- Add `backend/app/services/prompt_cache_service.py` — Gemini Context Caching lifecycle service (in-memory registry, TTL refresh, fail-open fallback, dual mode for system_instruction / user contents)
- Extend `backend/app/services/llm_gateway_service.py` — add `cached_content_name` parameter to `call_gemini`; extend `LangchainUsageCallback._extract_usage` to pull `cached_tokens` from `input_token_details.cache_read` and recalculate cost
- Refactor `backend/app/services/analytics/batter_services.py:_parse_query_with_llm` — split `parse_query_v1.txt` at the `# 本番` marker, cache the prefix (~2,250 tokens), send only the dynamic suffix per request
- Refactor `backend/app/services/agents/batter_agents.py` and `pitcher_agents.py` `oracle_node` — register `oracle_semantic_v1.txt` as `system_instruction` and inject via LangChain `.bind(cached_content=...)` per invoke
- Add `backend/scripts/measure_prompt_tokens.py` — utility to count tokens of candidate prompts and check against the 1,024-token minimum for Gemini 2.5 Flash caching
- Update `README.md`, `README_JP.md`, `README_architecture.md`, `README_ai_architecture.md` — add Context Caching section documenting cost reduction (~$0.30/M → ~$0.03/M tokens)

## Background
Gemini's `cached_per_1m_usd` is roughly 1/10 of the standard input price ($0.03 vs $0.30 per 1M tokens for Flash), but this repository had no call site for `client.caches.create()`. Pricing table, BigQuery `cached_tokens` column, and cost calculation logic were already in place, leaving the system in a half-wired state where `cached_tokens` was almost always NULL and long fixed prefixes (~2,250 tokens for `parse_query`, ~1,100–2,000 tokens for `oracle_semantic`) were re-billed on every request.

This PR wires up Gemini Context Caching for both prompts. Fixed prefixes are registered on the Gemini side, and each request sends only the dynamic suffix (user question or LangGraph `state["messages"]`). For the Flash model this collapses prompt-prefix billing by roughly an order of magnitude and removes the dominant input-cost line item for the day-to-day LLM traffic.

## Key Design Decisions
- **Template-file untouched + marker-based split**: `parse_query_v1.txt` itself is not modified; the Python caller splits at the existing `# 本番` marker. No prompt version bump needed; future versions stay cache-friendly as long as the marker is preserved.
- **Dual registration mode (`as_system_instruction` flag)**: `parse_query` is cached as user contents (inline-prompt semantics); `oracle_semantic` is cached as `system_instruction` (system-prompt semantics). This aligns with Gemini's API semantics and lets LangChain `.bind(cached_content=...)` work naturally.
- **Fail-open behavior**: If `caches.create()` fails (below minimum token count, quota exhaustion, SDK error, etc.), the service returns `None` and callers silently fall back to the original full-prompt path. No outages on cache misconfiguration.
- **1-hour TTL with 5-minute refresh threshold**: Trade-off between cache storage cost ($1/M tok/hour) and re-create overhead. Requests within 5 minutes of expiry trigger a refresh to avoid TTL-expiry failures on `generate_content`.
- **Per-instance in-memory registry**: No external KV store (Redis, etc.). A `threading.Lock` serializes only first-time creation. Storage cost scales as `(Cloud Run instance count) × ~$0.054/day/prompt`.
- **Content hash in cache key**: Keyed by `(prompt_name, version, model, mode_tag, sha256(prefix_text)[:16])`. Any single-character change to the prompt produces a new key, automatically generating a fresh cache while the old one expires via TTL.
- **`LangchainUsageCallback` cached_tokens extraction**: Covers both LangChain's `input_token_details.cache_read` path and the raw Gemini SDK's `cached_content_token_count` path, unifying BigQuery observability across the two LLM call routes.

## Test Plan
- [ ] Verify `python -c "from backend.app.services.analytics.batter_services import _parse_query_with_llm; _parse_query_with_llm('大谷の2024年のHR数は？', None)"` emits a `Created cache cachedContents/...` log entry
- [ ] Verify two consecutive invocations in the same process produce the `Created cache` log only on the first call (in-memory dict hit on the second)
- [ ] Verify rows in BigQuery `llm_interaction_logs` with `prompt_name='parse_query'` show `cached_tokens ≈ 2,250` and `cached_tokens / input_tokens ≥ 0.95`
- [ ] Verify on Cloud Run with `USE_SEMANTIC_LAYER=true` that `oracle_semantic` invocations populate non-NULL `cached_tokens` in BigQuery
- [ ] Verify cache creation failure path: temporarily pass a prefix below 1,024 tokens and confirm `Cache creation failed ...` is logged and the request still succeeds via the non-cached fallback
- [ ] Verify the previously failing rows (`generate_response_v1.txt` 0 bytes, `chat_orchestrator_system_*` below threshold) remain on the non-cached path with no behavior change
